### PR TITLE
[BO - Signalement] Affichage d'un badge indiquant l'EPCI lié à la commune

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -30,6 +30,7 @@ use App\Repository\AffectationRepository;
 use App\Repository\CritereRepository;
 use App\Repository\DesordreCategorieRepository;
 use App\Repository\DesordreCritereRepository;
+use App\Repository\EpciRepository;
 use App\Repository\FileRepository;
 use App\Repository\InterventionRepository;
 use App\Repository\NotificationRepository;
@@ -89,6 +90,7 @@ class SignalementController extends AbstractController
         CritereRepository $critereRepository,
         FileRepository $fileRepository,
         UserRepository $userRepository,
+        EpciRepository $epciRepository,
         SuiviSeenMarker $suiviSeenMarker,
         UserSignalementSubscriptionRepository $signalementSubscriptionRepository,
         SignalementRepository $signalementRepository,
@@ -243,6 +245,8 @@ class SignalementController extends AbstractController
         );
         $subscriptionsInMyPartner = $signalementSubscriptionRepository->findForSignalementAndPartner($signalement, $partner);
 
+        $epciOccupant = $epciRepository->findOneByCommuneInseeAndPostalCode($signalement->getInseeOccupant(), $signalement->getCpOccupant());
+
         $twigParams = [
             'title' => '#'.$signalement->getReference().' Signalement',
             'situations' => $infoDesordres['criticitesArranged'],
@@ -251,6 +255,7 @@ class SignalementController extends AbstractController
             'affectation' => $affectation,
             'isDanger' => $infoDesordres['isDanger'],
             'signalement' => $signalement,
+            'epciOccupant' => $epciOccupant,
             'partner' => $partner,
             'partners' => $partners,
             'clotureForm' => $clotureForm,

--- a/src/Repository/EpciRepository.php
+++ b/src/Repository/EpciRepository.php
@@ -51,4 +51,20 @@ class EpciRepository extends ServiceEntityRepository
 
         return $queryBuilder->getQuery()->getResult();
     }
+
+    public function findOneByCommuneInseeAndPostalCode(string $codeInsee, string $postalCode): ?Epci
+    {
+        if (empty($codeInsee) || empty($postalCode)) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('e')
+            ->innerJoin('e.communes', 'c')
+            ->where('c.codeInsee = :codeInsee')
+            ->andWhere('c.codePostal = :postalCode')
+            ->setParameter('codeInsee', $codeInsee)
+            ->setParameter('postalCode', $postalCode)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/src/Repository/EpciRepository.php
+++ b/src/Repository/EpciRepository.php
@@ -52,7 +52,7 @@ class EpciRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function findOneByCommuneInseeAndPostalCode(string $codeInsee, string $postalCode): ?Epci
+    public function findOneByCommuneInseeAndPostalCode(?string $codeInsee, ?string $postalCode): ?Epci
     {
         if (empty($codeInsee) || empty($postalCode)) {
             return null;

--- a/src/Service/HtmlTargetContentsService.php
+++ b/src/Service/HtmlTargetContentsService.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
+use App\Repository\EpciRepository;
 use App\Repository\SignalementRepository;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
@@ -14,6 +15,7 @@ class HtmlTargetContentsService
         private readonly Environment $twig,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly SignalementRepository $signalementRepository,
+        private readonly EpciRepository $epciRepository,
     ) {
     }
 
@@ -21,11 +23,14 @@ class HtmlTargetContentsService
     {
         $signalementsOnSameAddress = $this->signalementRepository->findOnSameAddress(signalement: $signalement, exclusiveStatus: [], excludedStatus: SignalementStatus::excludedStatuses());
 
+        $epciOccupant = $this->epciRepository->findOneByCommuneInseeAndPostalCode($signalement->getInseeOccupant(), $signalement->getCpOccupant());
+
         return [
             [
                 'target' => '#header-address',
                 'content' => $this->twig->render('back/signalement/view/header/_address.html.twig', [
                     'signalement' => $signalement,
+                    'epciOccupant' => $epciOccupant,
                     'signalementsOnSameAddress' => $signalementsOnSameAddress,
                     'routeForListOfSignalementOnAddress' => $this->urlGenerator->generate('back_signalements_index', [
                         'isImported' => 'oui',

--- a/templates/back/signalement/view/header/_address.html.twig
+++ b/templates/back/signalement/view/header/_address.html.twig
@@ -21,7 +21,7 @@
         {{ epciOccupant.nom }}
     </p>
 {% else %}
-    <p class="fr-badge fr-badge--warning">
+    <p class="fr-badge fr-badge--info fr-badge--no-icon">
         Aucun EPCI trouvé pour ce couple code postal ({{ signalement.cpOccupant }}) - code insee ({{ signalement.inseeOccupant }}).
     </p>
 {% endif %}

--- a/templates/back/signalement/view/header/_address.html.twig
+++ b/templates/back/signalement/view/header/_address.html.twig
@@ -1,4 +1,4 @@
-<span class="fr-h5">
+<div class="fr-h5">
     {{ signalement.adresseOccupant }}
     {% if signalement.complementAdresseOccupant %}- {{signalement.complementAdresseOccupant}}{% endif %},
     {{ signalement.cpOccupant ~' '~ signalement.villeOccupant|capitalize }}
@@ -7,13 +7,25 @@
             Modifier
         </a>
     {% endif %}
-</span>
+</div>
 
 {% if signalement.manualAddressOccupant %}
     <div class="fr-alert fr-alert--info fr-alert--sm fr-mb-3v">
         Cette adresse a été éditée manuellement.
     </div>
 {% endif %}
+
+<div class="fr-mb-3v">
+{% if epciOccupant %}
+    <p class="fr-badge fr-badge--info fr-badge--no-icon">
+        {{ epciOccupant.nom }}
+    </p>
+{% else %}
+    <p class="fr-badge fr-badge--warning">
+        Aucun EPCI trouvé pour ce couple code postal ({{ signalement.cpOccupant }}) - code insee ({{ signalement.inseeOccupant }}).
+    </p>
+{% endif %}
+</div>
 
 <div class="fr-mt-3v">
     <ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left fr-btns-group--sm">

--- a/tests/Functional/Controller/Back/SignalementActionControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementActionControllerTest.php
@@ -383,7 +383,7 @@ class SignalementActionControllerTest extends WebTestCase
     /**
      * @dataProvider provideSignalementToSetRnbId
      */
-    public function testsetRnbId(string $uuid, bool $isGeolocUpdated): void
+    public function testSetRnbId(string $uuid, bool $isGeolocUpdated): void
     {
         $buildingData = json_decode((string) file_get_contents(__DIR__.'/../../../files/betagouv/get_api_rnb_buildings_response.json'), true);
         $building = new RnbBuilding($buildingData['results'][0]);

--- a/tests/Functional/Repository/EpciRepositoryTest.php
+++ b/tests/Functional/Repository/EpciRepositoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\Epci;
+use App\Repository\EpciRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class EpciRepositoryTest extends KernelTestCase
+{
+    private EpciRepository $epciRepository;
+
+    protected function setUp(): void
+    {
+        $this->epciRepository = static::getContainer()->get(EpciRepository::class);
+    }
+
+    /**
+     * @dataProvider provideFindOneByCommuneInseeAndPostalCodeData
+     */
+    public function testFindOneByCommuneInseeAndPostalCode(
+        string $codeInsee,
+        string $postalCode,
+        ?string $expectedCode,
+        ?string $expectedNom,
+    ): void {
+        $epci = $this->epciRepository->findOneByCommuneInseeAndPostalCode($codeInsee, $postalCode);
+
+        if (null === $expectedCode) {
+            $this->assertNull($epci);
+        } else {
+            $this->assertInstanceOf(Epci::class, $epci);
+            $this->assertEquals($expectedCode, $epci->getCode());
+            $this->assertEquals($expectedNom, $epci->getNom());
+        }
+    }
+
+    public static function provideFindOneByCommuneInseeAndPostalCodeData(): \Generator
+    {
+        yield 'valid commune returns epci' => [
+            'codeInsee' => '30007',
+            'postalCode' => '30100',
+            'expectedCode' => '200066918',
+            'expectedNom' => 'CA Alès Agglomération',
+        ];
+
+        yield 'non existent commune returns null' => [
+            'codeInsee' => '99999',
+            'postalCode' => '99999',
+            'expectedCode' => null,
+            'expectedNom' => null,
+        ];
+
+        yield 'empty code insee returns null' => [
+            'codeInsee' => '',
+            'postalCode' => '30100',
+            'expectedCode' => null,
+            'expectedNom' => null,
+        ];
+
+        yield 'empty postal code returns null' => [
+            'codeInsee' => '30007',
+            'postalCode' => '',
+            'expectedCode' => null,
+            'expectedNom' => null,
+        ];
+
+        yield 'both empty returns null' => [
+            'codeInsee' => '',
+            'postalCode' => '',
+            'expectedCode' => null,
+            'expectedNom' => null,
+        ];
+    }
+}


### PR DESCRIPTION
## Ticket

#5675   

## Description
Affichage d'un badge indiquant l'EPCI lié à la commune

## Tests
- [ ] Aller sur un signalement dont le combo code postal / code insee se trouve dans un EPCI existant et voir l'affichage
- [ ] Aller sur un signalement où ce n'est pas le cas et vérifier
