### PR TITLE
[BO - SCHS dans Santé Habitat] Synchroniser avec le WS Santé Habitat

### DIFF
--- a/src/Command/Cron/SynchronizeEsaboraSISHCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSISHCommand.php
@@ -2,7 +2,7 @@
 
 namespace App\Command\Cron;
 
-use App\Entity\Enum\PartnerType;
+use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Repository\AffectationRepository;
 use App\Service\Interconnection\Esabora\EsaboraManager;
 use App\Service\Interconnection\Esabora\EsaboraSISHService;
@@ -50,7 +50,7 @@ class SynchronizeEsaboraSISHCommand extends AbstractSynchronizeEsaboraCommand
             $input,
             $output,
             $this->esaboraService,
-            PartnerType::ARS,
+            DossierMessageSISH::CAN_SYNC_SISH_ESABORA,
         );
 
         return Command::SUCCESS;

--- a/src/Command/Cron/SynchronizeInterventionSISHCommand.php
+++ b/src/Command/Cron/SynchronizeInterventionSISHCommand.php
@@ -2,8 +2,8 @@
 
 namespace App\Command\Cron;
 
-use App\Entity\Enum\PartnerType;
 use App\Manager\JobEventManager;
+use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Repository\AffectationRepository;
 use App\Repository\JobEventRepository;
 use App\Service\Interconnection\Esabora\AbstractEsaboraService;
@@ -70,7 +70,7 @@ class SynchronizeInterventionSISHCommand extends AbstractSynchronizeEsaboraComma
         $io = new SymfonyStyle($input, $output);
         $uuidSignalement = $input->getArgument('uuid_signalement') ?? null;
         $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-            partnerType: PartnerType::ARS,
+            partnerType: DossierMessageSISH::CAN_SYNC_SISH_ESABORA,
             uuidSignalement: $uuidSignalement
         );
         $count = 0;

--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -2,9 +2,9 @@
 
 namespace App\Command;
 
-use App\Entity\Enum\PartnerType;
 use App\Messenger\InterconnectionBus;
 use App\Messenger\Message\Esabora\DossierMessageSCHS;
+use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Repository\AffectationRepository;
 use App\Repository\TerritoryRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 
 #[AsCommand(
     name: 'app:push-esabora-dossier',
@@ -43,6 +44,9 @@ class PushEsaboraDossierCommand extends Command
             ->addOption('uuid', null, InputOption::VALUE_OPTIONAL, 'Signalement Uuid');
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
@@ -59,7 +63,9 @@ class PushEsaboraDossierCommand extends Command
         $affectations = null;
         if ($uuid) {
             $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-                partnerType: 'sish' === $serviceType ? PartnerType::ARS : DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
+                partnerType: 'sish' === $serviceType
+                    ? DossierMessageSISH::CAN_SYNC_SISH_ESABORA
+                    : DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
                 isSynchronized: false,
                 uuidSignalement: $uuid
             );
@@ -76,7 +82,9 @@ class PushEsaboraDossierCommand extends Command
             }
 
             $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-                partnerType: 'sish' === $serviceType ? PartnerType::ARS : PartnerType::COMMUNE_SCHS,
+                partnerType: 'sish' === $serviceType
+                    ? DossierMessageSISH::CAN_SYNC_SISH_ESABORA
+                    : DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
                 isSynchronized: false,
                 territory: $territory
             );

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -11,6 +11,8 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\JobEvent;
 use App\Entity\Signalement;
 use App\Entity\Territory;
+use App\Service\Interconnection\Esabora\EsaboraSCHSService;
+use App\Service\Interconnection\Esabora\EsaboraSISHService;
 use App\Service\ListFilters\SearchAffectationWithoutSubscription;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -72,8 +74,10 @@ class AffectationRepository extends ServiceEntityRepository
             ->setParameter('signalement_status_list', SignalementStatus::excludedStatuses());
 
         if (is_array($partnerType)) {
+            $serviceType = in_array(PartnerType::ARS, $partnerType) ? EsaboraSISHService::SERVICE_TYPE : EsaboraSCHSService::SERVICE_TYPE;
             $qb->andWhere('p.type IN (:partner_types)')->setParameter('partner_types', $partnerType);
         } else {
+            $serviceType = PartnerType::ARS === $partnerType ? EsaboraSISHService::SERVICE_TYPE : EsaboraSCHSService::SERVICE_TYPE;
             $qb->andWhere('p.type = :partner_type')->setParameter('partner_type', $partnerType);
         }
 
@@ -89,6 +93,19 @@ class AffectationRepository extends ServiceEntityRepository
 
         if (null !== $territory) {
             $qb->andWhere('a.territory = :territory')->setParameter('territory', $territory);
+        }
+
+        $esaboraCondition = $qb->expr()->orX(
+            'p.esaboraUrl LIKE :esabora_url', 'p.esaboraUrl LIKE :esabora_url_local'
+        );
+        $qb
+            ->setParameter('esabora_url', '%sante-habitat%')
+            ->setParameter('esabora_url_local', '%ARS%');
+
+        if (EsaboraSISHService::SERVICE_TYPE === $serviceType) {
+            $qb->andWhere($esaboraCondition);
+        } else {
+            $qb->andWhere($qb->expr()->not($esaboraCondition));
         }
 
         return $qb->getQuery()->getResult();

--- a/src/Service/Interconnection/Esabora/EsaboraSCHSService.php
+++ b/src/Service/Interconnection/Esabora/EsaboraSCHSService.php
@@ -18,6 +18,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class EsaboraSCHSService extends AbstractEsaboraService
 {
+    public const string SERVICE_TYPE = 'schs';
     public const string ACTION_SYNC_EVENTS = 'sync_events';
     public const string ACTION_SYNC_EVENTFILES = 'sync_eventfiles';
 

--- a/src/Service/Interconnection/Esabora/EsaboraSISHService.php
+++ b/src/Service/Interconnection/Esabora/EsaboraSISHService.php
@@ -20,6 +20,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class EsaboraSISHService extends AbstractEsaboraService
 {
+    public const string SERVICE_TYPE = 'sish';
     public const string NAME_SI = 'SI-Santé Habitat (SI-SH)';
 
     public function __construct(

--- a/tests/Unit/Command/PushEsaboraDossierCommandTest.php
+++ b/tests/Unit/Command/PushEsaboraDossierCommandTest.php
@@ -6,6 +6,7 @@ use App\Command\PushEsaboraDossierCommand;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Territory;
 use App\Messenger\InterconnectionBus;
+use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Repository\AffectationRepository;
 use App\Repository\TerritoryRepository;
 use App\Tests\FixturesHelper;
@@ -16,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 class PushEsaboraDossierCommandTest extends TestCase
 {
     use FixturesHelper;
-    private const ENV = 'dev';
+    private const string ENV = 'dev';
 
     private MockObject&AffectationRepository $affectationRepository;
     private MockObject&TerritoryRepository $territoryRepository;
@@ -54,7 +55,7 @@ class PushEsaboraDossierCommandTest extends TestCase
             ->expects($this->once())
             ->method('findAffectationSubscribedToEsabora')
             ->with(
-                $this->equalTo(PartnerType::ARS),
+                $this->equalTo(DossierMessageSISH::CAN_SYNC_SISH_ESABORA),
                 null,
                 null,
                 (new Territory())->setZip('01')->setIsActive(true)->setName('Ain')
@@ -91,7 +92,7 @@ class PushEsaboraDossierCommandTest extends TestCase
             ->expects($this->once())
             ->method('findAffectationSubscribedToEsabora')
             ->with(
-                $this->equalTo(PartnerType::ARS),
+                $this->equalTo(DossierMessageSISH::CAN_SYNC_SISH_ESABORA),
                 $this->equalTo(false),
                 $this->equalTo('00000000-0000-0000-2023-000000000010')
             )


### PR DESCRIPTION
## Ticket

#5684    

## Description
Aucun changement sur la synchronisation : comportement standard conservé (ARS => WS Santé Habitat, SCHS =>  WS SCHS), d’où l'absence de mise à jour.

## Changements apportés
* Élargir la requête aux SCHS et se baser sur l'url

## Pré-requis
- Activer` FEATURE_SCHS_DISPATCH_SISH_ENABLE=1`
- Exécuter `make mock-restart && make worker-stop && make worker-start`
- Affecter le partenaire `Partenaire SCHS via Santé Habitat` sur un dossier du 13 (par exemple http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000020)

## Tests
- [ ] Exécuter `make console app="sync-esabora-schs"` et vérifier dans l'output que le dossier ne remonte pas que ce soit des feedback d'erreur ou de succès

- [ ] Exécuter `make console app="sync-esabora-sish"` et vérifier dans l'output que le dossier remonte (ici en erreur car absence de mock de succès)
<img width="1096" height="306" alt="image" src="https://github.com/user-attachments/assets/f7efbfdf-bba7-41f7-9f5d-f42b0f7dfb04" />

- [ ] Exécuter `make console app="sync-esabora-sish-intervention"` et vérifier dans l'output que le dossier remonte (ici en erreur car absence de mock de succès)
<img width="1159" height="351" alt="image" src="https://github.com/user-attachments/assets/76e761b9-28f6-4c0f-be12-aaf8779a4bb5" />

