### PR TITLE
[BO - Affectation] Raffraichissement modale aprés flash ajax / [BUG - Edition FO] contrainte invariant fiscal / [BUG - service secours] affichage nom

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -264,16 +264,17 @@ const rotatePhotoAlbumImage = (photoId, direction) => {
 
 loadWindowWithLocalStorage('click', '[data-filter-list-signalement]', 'back_link_signalement_view');
 
-document?.querySelectorAll('[data-fr-select-target]')?.forEach((t) => {
-  const source = document?.querySelector('#' + t.getAttribute('data-fr-select-source'));
-  const target = document?.querySelector('#' + t.getAttribute('data-fr-select-target'));
-  t.addEventListeners('click touchdown', () => {
-    [...source.selectedOptions].forEach((s) => {
-      target.append(s);
-    });
-    document?.querySelectorAll('#signalement-affectation-select-affecte option').forEach((o) => {
-      o.selected = true;
-    });
+const signalementAffectationFormRow = document.getElementById('signalement-affectation-form-row');
+signalementAffectationFormRow?.addEventListener('click', (e) => {
+  const t = e.target.closest('[data-fr-select-target]');
+  if (!t) return;
+  const source = document.querySelector('#' + t.getAttribute('data-fr-select-source'));
+  const target = document.querySelector('#' + t.getAttribute('data-fr-select-target'));
+  [...source.selectedOptions].forEach((s) => {
+    target.append(s);
+  });
+  document.querySelectorAll('#signalement-affectation-select-affecte option').forEach((o) => {
+    o.selected = true;
   });
 });
 

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -50,6 +50,9 @@ class AffectationController extends AbstractController
 
     private function getHtmlTargetContentsForAffectationWithActionItems(Signalement $signalement): array
     {
+        $filterInjonctionBailleur = (SignalementStatus::INJONCTION_BAILLEUR === $signalement->getStatut());
+        $affectablePartners = $this->signalementManager->findAffectablePartners($signalement, $filterInjonctionBailleur);
+
         return [
             [
                 'target' => '#affectations-with-action',
@@ -58,6 +61,13 @@ class AffectationController extends AbstractController
                     'partnerEmailAlerts' => $this->emailAlertChecker->buildPartnerEmailAlert($signalement),
                 ]
                 ),
+            ],
+            [
+                'target' => '#signalement-affectation-form-row',
+                'content' => $this->renderView('_partials/_modal_affectation_selects.html.twig', [
+                    'signalement' => $signalement,
+                    'partners' => $affectablePartners,
+                ]),
             ],
         ];
     }
@@ -94,13 +104,10 @@ class AffectationController extends AbstractController
                     $message = sprintf('Impossible d\'affecter simultanément des partenaires interconnectés %s avec les mêmes identifiants.
                     Sélectionnez uniquement le partenaire d\'envoi, puis ajoutez le second après validation.', EsaboraSISHService::NAME_SI);
 
-                    $flashMessage = [
-                        'type' => 'alert',
-                        'title' => 'Erreur',
-                        'message' => $message,
-                    ];
+                    $flashMessage = ['type' => 'alert', 'title' => 'Erreur', 'message' => $message];
+                    $htmlTargetContents = $this->getHtmlTargetContentsForAffectationWithActionItems($signalement);
 
-                    return $this->json(['stayOnPage' => true, 'flashMessages' => [$flashMessage]]);
+                    return $this->json(['stayOnPage' => true, 'flashMessages' => [$flashMessage], 'htmlTargetContents' => $htmlTargetContents]);
                 }
 
                 foreach ($partnersIdToAdd as $partnerIdToAdd) {

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -424,6 +424,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?string $structureReferentSocial = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 12, maxMessage: 'L\'invariant fiscal ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $numeroInvariant = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]

--- a/src/Form/SignalementeEditFO/InformationsGeneralesType.php
+++ b/src/Form/SignalementeEditFO/InformationsGeneralesType.php
@@ -169,9 +169,12 @@ class InformationsGeneralesType extends AbstractType
             ])
             ->add('numeroInvariant', TextType::class, [
                 'label' => 'Invariant fiscal (facultatif)',
-                'help' => 'Format attendu : 255 caractères maximum',
+                'help' => 'Format attendu : 12 caractères maximum',
                 'required' => false,
                 'data' => $signalement->getNumeroInvariant(),
+                'attr' => [
+                    'maxlength' => 12,
+                ],
             ])
             ->add('loyer', NumberType::class, [
                 'label' => 'Montant du loyer (facultatif)',

--- a/templates/_partials/_modal_affectation.html.twig
+++ b/templates/_partials/_modal_affectation.html.twig
@@ -20,61 +20,8 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
-                             id="signalement-affectation-form-row">
-                            <div class="fr-col-5">
-                                <label for="signalement-affectation-select-disponible" class="fr-label fr-text--bold">Partenaires
-                                    disponibles</label>
-                                <select class="fr-select" aria-multiselectable="true"
-                                        id="signalement-affectation-select-disponible"
-                                        size="10" multiple>
-                                    {% for partner in partners['not_affected'] %}
-                                        {% set isDisabled = partner['is_disabled']|default(false) %}
-                                        <option value="{{ partner['id'] }}" {{ isDisabled ? 'disabled' : '' }}>{{ partner['name']|upper }}
-                                            {% if partner.competence|default %}
-                                               ({% for competence in partner.competence %}
-                                                    {{ competence.label }}
-                                                {% endfor %})
-                                            {% endif %}
-                                            </option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div class="fr-col-2 fr-text--center">
-                                <button class="fr-btn fr-btn--secondary fr-fi-arrow-left-s-line-double"
-                                        data-fr-select-source="signalement-affectation-select-affecte"
-                                        data-fr-select-target="signalement-affectation-select-disponible"></button>
-                                <button class="fr-btn fr-fi-arrow-right-s-line-double"
-                                        data-fr-select-source="signalement-affectation-select-disponible"
-                                        data-fr-select-target="signalement-affectation-select-affecte"></button>
-                            </div>
-                            <div class="fr-col-5">
-                                <form method="POST" 
-                                      name="signalement-affectation" 
-                                      id="signalement-affectation-form" 
-                                      action="{{ path('back_signalement_toggle_affectation',{uuid:signalement.uuid}) }}"
-                                      data-submit-type="formData"
-                                      >
-                                    <label for="signalement-affectation-select-affecte" class="fr-label fr-text--bold">Partenaire(s)
-                                        affecté(s)</label>
-                                    <select id="signalement-affectation-select-affecte" multiple
-                                            class="fr-select" aria-multiselectable="true"
-                                            size="10" data-fr-select-count="fr-modal-affectation-count"
-                                            name="signalement-affectation[partners][]">
-                                        {% for partner in partners['affected'] %}
-                                            <option value="{{ partner['id'] }}" selected>{{ partner['name']|upper }}
-                                            {% if partner.competence|default %}
-                                                ({% for competence in partner.competence %}
-                                                    {{ competence.label }}
-                                                {% endfor %})
-                                            {% endif %}
-                                            </option>
-                                        {% endfor %}
-                                    </select>
-                                    <input type="hidden" name="_token"
-                                           value="{{ csrf_token('signalement_affectation_'~signalement.id) }}">
-                                </form>
-                            </div>
+                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle" id="signalement-affectation-form-row">
+                            {% include '_partials/_modal_affectation_selects.html.twig' %}
                         </div>
                     </div>
                     <div class="fr-modal__footer">

--- a/templates/_partials/_modal_affectation_selects.html.twig
+++ b/templates/_partials/_modal_affectation_selects.html.twig
@@ -1,0 +1,48 @@
+<div class="fr-col-5">
+    <label for="signalement-affectation-select-disponible" class="fr-label fr-text--bold">Partenaires disponibles</label>
+    <select class="fr-select" aria-multiselectable="true" id="signalement-affectation-select-disponible" size="10" multiple>
+        {% for partner in partners['not_affected'] %}
+            {% set isDisabled = partner['is_disabled']|default(false) %}
+            <option value="{{ partner['id'] }}" {{ isDisabled ? 'disabled' : '' }}>{{ partner['name']|upper }}
+                {% if partner.competence|default %}
+                    ({% for competence in partner.competence %}
+                        {{ competence.label }}
+                    {% endfor %})
+                {% endif %}
+                </option>
+        {% endfor %}
+    </select>
+</div>
+<div class="fr-col-2 fr-text--center">
+    <button class="fr-btn fr-btn--secondary fr-fi-arrow-left-s-line-double"
+            data-fr-select-source="signalement-affectation-select-affecte"
+            data-fr-select-target="signalement-affectation-select-disponible"></button>
+    <button class="fr-btn fr-fi-arrow-right-s-line-double"
+            data-fr-select-source="signalement-affectation-select-disponible"
+            data-fr-select-target="signalement-affectation-select-affecte"></button>
+</div>
+<div class="fr-col-5">
+    <form method="POST" 
+            name="signalement-affectation" 
+            id="signalement-affectation-form" 
+            action="{{ path('back_signalement_toggle_affectation',{uuid:signalement.uuid}) }}"
+            data-submit-type="formData"
+            >
+        <label for="signalement-affectation-select-affecte" class="fr-label fr-text--bold">Partenaire(s) affecté(s)</label>
+        <select id="signalement-affectation-select-affecte" multiple
+                class="fr-select" aria-multiselectable="true"
+                size="10" data-fr-select-count="fr-modal-affectation-count"
+                name="signalement-affectation[partners][]">
+            {% for partner in partners['affected'] %}
+                <option value="{{ partner['id'] }}" selected>{{ partner['name']|upper }}
+                {% if partner.competence|default %}
+                    ({% for competence in partner.competence %}
+                        {{ competence.label }}
+                    {% endfor %})
+                {% endif %}
+                </option>
+            {% endfor %}
+        </select>
+        <input type="hidden" name="_token" value="{{ csrf_token('signalement_affectation_'~signalement.id) }}">
+    </form>
+</div>

--- a/templates/back/signalement/view/header/_infos-creation.html.twig
+++ b/templates/back/signalement/view/header/_infos-creation.html.twig
@@ -6,7 +6,7 @@
     {% elseif signalement.creationSource is same as enum('App\\Entity\\Enum\\CreationSource').FORM_PRO_BO %}
         par {{ signalement.createdBy.prenom }} {{ signalement.createdBy.nom }}{% if signalement.createdBy.getPartnerInTerritory(signalement.territory) %}, du partenaire {{ signalement.createdBy.getPartnerInTerritory(signalement.territory).nom }}{% endif %} depuis le formulaire pro.
     {% elseif signalement.creationSource is same as enum('App\\Entity\\Enum\\CreationSource').FORM_SERVICE_SECOURS %}
-        depuis le formulaire Service Secours par {{signalement.serviceSecoursRoute.name}}
+        depuis le formulaire Service Secours par {{signalement.serviceSecours.name}}
     {% elseif signalement.creationSource is same as enum('App\\Entity\\Enum\\CreationSource').IMPORT %}
         par import
     {% else %}


### PR DESCRIPTION
## Ticket

#5669
#5689
#5692

## Description
- Rechargement des données de la modale de sélection des affectation à la suite d'un message flash ajax (utilisation de la délégation d'événements pour que le js continue d'être fonctionnel)
- Ajout d'une contrainte sur le champ `numeroInvariant` pour éviter crash lors de l'édition FO ou BO
- Correction de l'affichage du nom du service secours déposant sur la fiche BO 
<img width="686" height="112" alt="Screenshot 2026-04-09 at 12-20-08 #2026-27 Signalement - Signal-Logement" src="https://github.com/user-attachments/assets/969b8bd7-af32-4c01-9918-edf39e995478" />

## Pré-requis
`make npm-watch`
`FEATURE_SCHS_DISPATCH_SISH_ENABLE=1`

## Tests
- [ ] Sur un dossier du 13, affecter les partenaires Partenaire SCHS via Santé Habitat et Partenaire 13-06 ESABORA ARS, vérifier qu'un message d'erreur s'affiche et que les données de la modale sont rechargé. 
- [ ] Tester l'édition FO partie "Informations générales sur le logement" et voir que le champ "Invariant fiscal" et limité a 12 cratères 
