### PR TITLE
[BO - Signalement] Améliorations suite a édition BO et message flash ajax

### DIFF
--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -47,9 +47,11 @@ export function jsonResponseProcess(response) {
       const openModalElement = document.querySelector('.fr-modal--opened');
       if (openModalElement) {
         dsfr(openModalElement).modal.conceal();
-        const formElement = openModalElement.querySelector('form');
-        if (formElement) {
-          formElement.reset();
+        if(response.resetForm) {
+          const formElement = openModalElement.querySelector('form');
+          if (formElement) {
+            formElement.reset();
+          }
         }
       }
     }

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -239,7 +239,7 @@ class SignalementActionController extends AbstractController
         $htmlTargetContents = [['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])]];
         $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions, 'resetForm' => true]);
     }
 
     #[Route('/{uuid:signalement}/suivi/delete', name: 'back_signalement_delete_suivi', methods: 'POST')]

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -82,8 +82,10 @@ class SignalementEditController extends AbstractController
             $flashMessages[] = ['type' => 'success', 'title' => 'Abonnement au dossier', 'message' => User::MSG_SUBSCRIPTION_CREATED];
         }
         $htmlTargetContents = $htmlTargetContentsService->getHtmlTargetContentsForSignalementAddress($signalement);
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-coordonnees-tiers', name: 'back_signalement_edit_coordonnees_tiers', methods: 'POST')]
@@ -141,8 +143,10 @@ class SignalementEditController extends AbstractController
                 ]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-invite-tiers', name: 'back_signalement_edit_invite_tiers', methods: 'POST')]
@@ -226,8 +230,10 @@ class SignalementEditController extends AbstractController
                 ]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-coordonnees-foyer', name: 'back_signalement_edit_coordonnees_foyer', methods: 'POST')]
@@ -280,9 +286,19 @@ class SignalementEditController extends AbstractController
                 'target' => '#signalement-information-foyer-container',
                 'content' => $this->renderView('back/signalement/view/information/information-foyer.html.twig', ['signalement' => $signalement]),
             ],
+            [
+                'target' => '#signalement-information-bailleur-container',
+                'content' => $this->renderView('back/signalement/view/information/information-bailleur.html.twig', ['signalement' => $signalement]),
+            ],
+            [
+                'target' => '#signalement-information-agence-container',
+                'content' => $this->renderView('back/signalement/view/information/information-agence.html.twig', ['signalement' => $signalement]),
+            ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-coordonnees-bailleur', name: 'back_signalement_edit_coordonnees_bailleur', methods: 'POST')]
@@ -335,8 +351,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-bailleur.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-coordonnees-agence', name: 'back_signalement_edit_coordonnees_agence', methods: 'POST')]
@@ -390,8 +408,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-agence.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-coordonnees-syndic', name: 'back_signalement_edit_coordonnees_syndic', methods: 'POST')]
@@ -445,8 +465,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-syndic.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-informations-logement', name: 'back_signalement_edit_informations_logement', methods: 'POST')]
@@ -498,8 +520,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-logement.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-composition-logement', name: 'back_signalement_edit_composition_logement', methods: 'POST')]
@@ -551,8 +575,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-composition.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     /**
@@ -604,8 +630,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-situation-foyer.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-procedure-demarches', name: 'back_signalement_edit_procedure_demarches', methods: 'POST')]
@@ -653,8 +681,10 @@ class SignalementEditController extends AbstractController
                 'content' => $this->renderView('back/signalement/view/information/information-procedure.html.twig', ['signalement' => $signalement]),
             ],
         ];
+        $htmlTargetContents[] = ['target' => '#list-suivis', 'content' => $this->renderView('back/signalement/view/suivis.html.twig', ['signalement' => $signalement])];
+        $functions = [['name' => 'applyFilter']];
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/{uuid:signalement}/edit-logement-vacant', name: 'back_signalement_edit_logement_vacant', methods: 'POST')]

--- a/templates/back/signalement/view/information/information-agence.html.twig
+++ b/templates/back/signalement/view/information/information-agence.html.twig
@@ -1,48 +1,51 @@
-<div class="fr-grid-row">
-    <div class="fr-col-12 fr-col-md-8">
-        <h4 class="fr-h6">Informations sur l'agence</h4>
-    </div>
-    <div class="fr-col-12 fr-col-md-4 fr-text--right">
-        {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
-            <button href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-agence" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">
-                Modifier
-            </button>
-        {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-12">
-        <strong>Dénomination :</strong> {{ signalement.denominationAgence }}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Nom :</strong> {{ signalement.nomAgence }}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Prénom :</strong> {{ signalement.prenomAgence }}
-    </div>
-    <div class="fr-col-12">
-        <strong>Courriel :</strong>
-        {% if signalement.mailAgence %}
-            <a href="mailto:{{ signalement.mailAgence }}">{{ signalement.mailAgence }}</a>
-            {% if show_email_alert(signalement.mailAgence) %}
-                <p class="fr-badge fr-badge--error">Format non valide</p>
+{% if signalement|display_signalement_info_agence %}
+    <div class="fr-grid-row">
+        <div class="fr-col-12 fr-col-md-8">
+            <h4 class="fr-h6">Informations sur l'agence</h4>
+        </div>
+        <div class="fr-col-12 fr-col-md-4 fr-text--right">
+            {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
+                <button href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-agence" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">
+                    Modifier
+                </button>
             {% endif %}
-            {% if show_email_usager_alert_brevo('agence', signalement.mailAgence) %}
-                <p class="fr-badge fr-badge--warning">Problème d'e-mail non remis</p>
+        </div>
+        <div class="fr-col-12 fr-col-md-12">
+            <strong>Dénomination :</strong> {{ signalement.denominationAgence }}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Nom :</strong> {{ signalement.nomAgence }}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Prénom :</strong> {{ signalement.prenomAgence }}
+        </div>
+        <div class="fr-col-12">
+            <strong>Courriel :</strong>
+            {% if signalement.mailAgence %}
+                <a href="mailto:{{ signalement.mailAgence }}">{{ signalement.mailAgence }}</a>
+                {% if show_email_alert(signalement.mailAgence) %}
+                    <p class="fr-badge fr-badge--error">Format non valide</p>
+                {% endif %}
+                {% if show_email_usager_alert_brevo('agence', signalement.mailAgence) %}
+                    <p class="fr-badge fr-badge--warning">Problème d'e-mail non remis</p>
+                {% endif %}
             {% endif %}
-        {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Tél. :</strong>
+            {% if signalement.telAgence %}
+                <a href="mailto:{{ signalement.telAgenceDecoded }}">{{ signalement.telAgenceDecoded|phone }}</a>
+            {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Tél. sec. :</strong>
+            {% if signalement.telAgenceSecondaire %}
+                <a href="mailto:{{ signalement.telAgenceSecondaireDecoded }}">{{ signalement.telAgenceSecondaireDecoded|phone }}</a>
+            {% endif %}
+        </div>
+        <div class="fr-col-12">
+            <strong>Adresse :</strong> {{ signalement.adresseAgence ? signalement.adresseAgence ~ ', ' ~ signalement.codePostalAgence ~ ' ' ~ signalement.villeAgence}}
+        </div>
     </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Tél. :</strong>
-        {% if signalement.telAgence %}
-            <a href="mailto:{{ signalement.telAgenceDecoded }}">{{ signalement.telAgenceDecoded|phone }}</a>
-        {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Tél. sec. :</strong>
-        {% if signalement.telAgenceSecondaire %}
-            <a href="mailto:{{ signalement.telAgenceSecondaireDecoded }}">{{ signalement.telAgenceSecondaireDecoded|phone }}</a>
-        {% endif %}
-    </div>
-    <div class="fr-col-12">
-        <strong>Adresse :</strong> {{ signalement.adresseAgence ? signalement.adresseAgence ~ ', ' ~ signalement.codePostalAgence ~ ' ' ~ signalement.villeAgence}}
-    </div>
-</div>
+    <hr class="fr-mt-3w fr-hr">
+{% endif %}

--- a/templates/back/signalement/view/information/information-bailleur.html.twig
+++ b/templates/back/signalement/view/information/information-bailleur.html.twig
@@ -1,95 +1,98 @@
-{% import 'back/signalement/view/_static_picto.html.twig' as picto %}
-<div class="fr-grid-row">
-    <div class="fr-col-12 fr-col-md-8">
-        <h4 class="fr-h6">Informations sur le bailleur</h4>
-    </div>
-    <div class="fr-col-12 fr-col-md-4 fr-text--right">
-        {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
-            <button href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">
-                Modifier
-            </button>
-        {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-12">
-        <strong>Type :</strong>
-        {% if signalement.typeProprio is not same as null %}
-            {{ signalement.typeProprio.label }}
-        {% else %}
-            N/C
-        {% endif %}
-    </div>
-    {% if signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
-    <div class="fr-col-12 fr-col-md-12">
-        <strong>Dénomination :</strong> {{ signalement.denominationProprio }}
-    </div>
-    {% endif %}
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Nom :</strong> {{ signalement.nomProprio }}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Prénom :</strong> {{ signalement.prenomProprio }}
-    </div>
-    <div class="fr-col-12">
-        <strong>Courriel :</strong>
-        {% if signalement.mailProprio %}
-            <a href="mailto:{{ signalement.mailProprio }}">{{ signalement.mailProprio }}</a>
-            {% if show_email_alert(signalement.mailProprio) %}
-                <p class="fr-badge fr-badge--error">Format non valide</p>
+{% if signalement|display_signalement_info_bailleur %}
+    {% import 'back/signalement/view/_static_picto.html.twig' as picto %}
+    <div class="fr-grid-row">
+        <div class="fr-col-12 fr-col-md-8">
+            <h4 class="fr-h6">Informations sur le bailleur</h4>
+        </div>
+        <div class="fr-col-12 fr-col-md-4 fr-text--right">
+            {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
+                <button href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">
+                    Modifier
+                </button>
             {% endif %}
-            {% if show_email_usager_alert_brevo('proprietaire', signalement.mailProprio) %}
-                <p class="fr-badge fr-badge--warning">Problème d'e-mail non remis</p>
-            {% endif %}
-        {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Tél. :</strong>
-        {% if signalement.telProprio %}
-            <a href="mailto:{{ signalement.telProprioDecoded }}">{{ signalement.telProprioDecoded|phone }}</a>
-        {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Tél. sec. :</strong>
-        {% if signalement.telProprioSecondaire %}
-            <a href="mailto:{{ signalement.telProprioSecondaireDecoded }}">{{ signalement.telProprioSecondaireDecoded|phone }}</a>
-        {% endif %}
-    </div>
-    <div class="fr-col-12">
-        <strong>Adresse :</strong> {{ signalement.adresseProprio ? signalement.adresseProprio ~ ', ' ~ signalement.codePostalProprio ~ ' ' ~ signalement.villeProprio}}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Bénéficiaire RSA :</strong>
-        {% if signalement.informationComplementaire %}
-            {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'oui' %}
-                {{ picto.picto_yes() }}
-            {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'non' %}
-                {{ picto.picto_no() }}
+        </div>
+        <div class="fr-col-12 fr-col-md-12">
+            <strong>Type :</strong>
+            {% if signalement.typeProprio is not same as null %}
+                {{ signalement.typeProprio.label }}
             {% else %}
-                {{signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa}}
+                N/C
             {% endif %}
+        </div>
+        {% if signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
+        <div class="fr-col-12 fr-col-md-12">
+            <strong>Dénomination :</strong> {{ signalement.denominationProprio }}
+        </div>
         {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Bénéficiaire FSL :</strong>
-        {% if signalement.informationComplementaire %}
-            {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'oui' %}
-                {{ picto.picto_yes() }}
-            {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'non' %}
-                {{ picto.picto_no() }}
-            {% else %}
-                {{signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl}}
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Nom :</strong> {{ signalement.nomProprio }}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Prénom :</strong> {{ signalement.prenomProprio }}
+        </div>
+        <div class="fr-col-12">
+            <strong>Courriel :</strong>
+            {% if signalement.mailProprio %}
+                <a href="mailto:{{ signalement.mailProprio }}">{{ signalement.mailProprio }}</a>
+                {% if show_email_alert(signalement.mailProprio) %}
+                    <p class="fr-badge fr-badge--error">Format non valide</p>
+                {% endif %}
+                {% if show_email_usager_alert_brevo('proprietaire', signalement.mailProprio) %}
+                    <p class="fr-badge fr-badge--warning">Problème d'e-mail non remis</p>
+                {% endif %}
             {% endif %}
-        {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Tél. :</strong>
+            {% if signalement.telProprio %}
+                <a href="mailto:{{ signalement.telProprioDecoded }}">{{ signalement.telProprioDecoded|phone }}</a>
+            {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Tél. sec. :</strong>
+            {% if signalement.telProprioSecondaire %}
+                <a href="mailto:{{ signalement.telProprioSecondaireDecoded }}">{{ signalement.telProprioSecondaireDecoded|phone }}</a>
+            {% endif %}
+        </div>
+        <div class="fr-col-12">
+            <strong>Adresse :</strong> {{ signalement.adresseProprio ? signalement.adresseProprio ~ ', ' ~ signalement.codePostalProprio ~ ' ' ~ signalement.villeProprio}}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Bénéficiaire RSA :</strong>
+            {% if signalement.informationComplementaire %}
+                {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'oui' %}
+                    {{ picto.picto_yes() }}
+                {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'non' %}
+                    {{ picto.picto_no() }}
+                {% else %}
+                    {{signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa}}
+                {% endif %}
+            {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Bénéficiaire FSL :</strong>
+            {% if signalement.informationComplementaire %}
+                {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'oui' %}
+                    {{ picto.picto_yes() }}
+                {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'non' %}
+                    {{ picto.picto_no() }}
+                {% else %}
+                    {{signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl}}
+                {% endif %}
+            {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Revenu fiscal de référence :</strong>
+            {% if signalement.informationComplementaire %}
+                {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal }} €
+            {% endif %}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Date de naissance :</strong>
+            {% if signalement.informationComplementaire %}
+                {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance}}
+            {% endif %}
+        </div>
     </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Revenu fiscal de référence :</strong>
-        {% if signalement.informationComplementaire %}
-            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal }} €
-        {% endif %}
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        <strong>Date de naissance :</strong>
-        {% if signalement.informationComplementaire %}
-            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance}}
-        {% endif %}
-    </div>
-</div>
+    <hr class="fr-mt-3w fr-hr">
+{% endif %}

--- a/templates/back/signalement/view/tabs/tab-situation.html.twig
+++ b/templates/back/signalement/view/tabs/tab-situation.html.twig
@@ -47,19 +47,13 @@
 
 <hr class="fr-mt-3w fr-hr">
 
-{% if signalement|display_signalement_info_bailleur %}
-    <div id="signalement-information-bailleur-container">
-        {% include 'back/signalement/view/information/information-bailleur.html.twig' %}
-    </div>
-    <hr class="fr-mt-3w fr-hr">
-{% endif %}
+<div id="signalement-information-bailleur-container">
+    {% include 'back/signalement/view/information/information-bailleur.html.twig' %}
+</div>
 
-{% if signalement|display_signalement_info_agence %}
-    <div id="signalement-information-agence-container">
-        {% include 'back/signalement/view/information/information-agence.html.twig' %}
-    </div>
-    <hr class="fr-mt-3w fr-hr">
-{% endif %}
+<div id="signalement-information-agence-container">
+    {% include 'back/signalement/view/information/information-agence.html.twig' %}
+</div>
 
 <div id="signalement-information-syndic-container">
     {% include 'back/signalement/view/information/information-syndic.html.twig' %}


### PR DESCRIPTION
## Ticket

#5546

## Description
- Correction d'une régression suite à la PR #5439 : à chaque fermeture de modale le formulaire contenu était réinitialisé et donc en réouvrant une modale d'édition, les champs que l'on venait de sauvegardé n'était pas repris. La réinitialisation est présent limité à la modale d'ajout de suivi via `'resetForm' => true`.
- Toutes les editions BO génère un suivi indiquant une modification, celui-ci est à présent visible sans rechargement de page.
- Suite à la soumission de la modale d'édition "Coordonnées du foyer" mise a jour des bloc "Informations sur le bailleur" et "Informations sur l'agence" sans rechargement de page (qui peuvent s'afficher ou pas en fonction du "Type d'occupant" mis à jour.

## Pré-requis
`make npm-watch`

## Tests
- [ ] Ajouter deux suivi depuis le BO (sans rechargement de page) et voir que le formulaire est bien vidé entre les deux
- [ ] Utiliser la même modale d'édition BO deux fois d'affilé (sans rechargement de page) et voir que les infos reste bien dans le formulaire de la modale
- [ ] Editer le "Type d'occupant" de la modale "Coordonnées du foyer" et voir que les blocs de l'onglet "Situation" sont mis à jour