### PR TITLE
[Date des photos] Préserver les données exif

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -27,10 +27,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         # Install Redis
         && pecl install redis \
         && docker-php-ext-enable redis \
+        # Install Imagick
+        && pecl install imagick \
+        && docker-php-ext-enable imagick \
         # PHP GD
         && docker-php-ext-configure gd --with-freetype --with-jpeg \
         # Install others
-        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl gd sockets\
+        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl gd sockets exif \
         && docker-php-ext-enable opcache \
         && rm /usr/src/php/ext/*.tgz \
         && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer  \

--- a/.docker/php-worker/Dockerfile
+++ b/.docker/php-worker/Dockerfile
@@ -28,10 +28,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         # Install Redis
         && pecl install redis \
         && docker-php-ext-enable redis \
+        # Install Imagick
+        && pecl install imagick \
+        && docker-php-ext-enable imagick \
         # PHP GD
         && docker-php-ext-configure gd --with-freetype --with-jpeg \
         # Install others
-        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl gd sockets\
+        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl gd sockets exif \
         && docker-php-ext-enable opcache \
         && rm /usr/src/php/ext/*.tgz \
         && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer  \

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": "~8.4",
         "ext-sodium": "*",
+        "ext-imagick": "*",
         "beberlei/doctrineextensions": "^1.3",
         "codercat/jwk-to-pem": "^1.1",
         "composer/package-versions-deprecated": "1.11.99.4",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -146,7 +146,7 @@ services:
                 - '@App\Serializer\SignalementDraftRequestNormalizer'
     Intervention\Image\ImageManager:
         arguments:
-            $driver: 'Intervention\Image\Drivers\Gd\Driver'
+            $driver: 'Intervention\Image\Drivers\Imagick\Driver'
 
     App\Service\Signalement\DesordreTraitement\DesordreTraitementNuisibles:
         tags:

--- a/migrations/Version20260410082704.php
+++ b/migrations/Version20260410082704.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260410082704 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout du champ datePriseDeVue dans l\'entité File';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD date_prise_de_vue DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file DROP date_prise_de_vue');
+    }
+}

--- a/src/DataFixtures/Loader/LoadInterventionData.php
+++ b/src/DataFixtures/Loader/LoadInterventionData.php
@@ -84,7 +84,8 @@ class LoadInterventionData extends Fixture implements OrderedFixtureInterface
                     partner: $user->getPartnerInTerritoryOrFirstOne($intervention->getSignalement()->getTerritory()),
                     user: $user,
                     intervention: $intervention,
-                    documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE
+                    documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE,
+                    setDatePriseDeVueFromExifData: false,
                 );
                 $manager->persist($file);
             }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -293,7 +293,8 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 signalement: $signalement,
                 partner: $partner,
                 user: $user,
-                documentType: DocumentType::AUTRE
+                documentType: DocumentType::AUTRE,
+                setDatePriseDeVueFromExifData: false,
             );
             if (\in_array($document['mimeType'], File::RESIZABLE_MIME_TYPES)) {
                 $file->setIsVariantsGenerated(true);
@@ -312,7 +313,8 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                     signalement: $signalement,
                     partner: $user?->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                     user: $user,
-                    documentType: DocumentType::AUTRE
+                    documentType: DocumentType::AUTRE,
+                    setDatePriseDeVueFromExifData: false,
                 );
                 $manager->persist($file);
                 ++$countMorePhoto;
@@ -504,7 +506,8 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                     signalement: $signalement,
                     // user: $user,
                     documentType: DocumentType::tryFrom($document['document_type']) ?? DocumentType::PHOTO_SITUATION,
-                    desordreSlug: $document['slug'] ?? null
+                    desordreSlug: $document['slug'] ?? null,
+                    setDatePriseDeVueFromExifData: false
                 );
                 $manager->persist($file);
             }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -133,6 +133,9 @@ class File implements EntityHistoryInterface
     #[Assert\Length(max: 255, maxMessage: 'La description ne doit pas dépasser {{ limit }} caractères')]
     private ?string $description = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $datePriseDeVue = null;
+
     #[ORM\Column]
     private ?bool $isWaitingSuivi = null;
 
@@ -367,6 +370,18 @@ class File implements EntityHistoryInterface
     {
         $description = null !== $description ? trim($description) : null;
         $this->description = $description ?: null;
+
+        return $this;
+    }
+
+    public function getDatePriseDeVue(): ?\DateTimeImmutable
+    {
+        return $this->datePriseDeVue;
+    }
+
+    public function setDatePriseDeVue(?\DateTimeImmutable $datePriseDeVue): static
+    {
+        $this->datePriseDeVue = $datePriseDeVue;
 
         return $this;
     }

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -11,17 +11,13 @@ use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
 use App\Entity\User;
-use App\Service\Files\ImageVariantProvider;
+use App\Service\Files\FileReaderExif;
 use App\Service\Signalement\SignalementDocumentTypeMapper;
-use Intervention\Image\ImageManager;
-use Psr\Log\LoggerInterface;
 
 class FileFactory
 {
     public function __construct(
-        private readonly ImageManager $imageManager,
-        private readonly ImageVariantProvider $imageVariantProvider,
-        private readonly LoggerInterface $logger,
+        private readonly FileReaderExif $fileReaderExif,
     ) {
     }
 
@@ -48,6 +44,7 @@ class FileFactory
         ?Territory $territory = null,
         ?array $partnerCompetence = null,
         ?array $partnerType = null,
+        ?bool $setDatePriseDeVueFromExifData = true,
     ): ?File {
         $extension = strtolower(pathinfo($filename, \PATHINFO_EXTENSION));
         $title = basename($title);
@@ -58,20 +55,8 @@ class FileFactory
             ->setIsWaitingSuivi($isWaitingSuivi)
             ->setIsTemp($isTemp);
 
-        if (in_array($file->getExtension(), File::RESIZABLE_EXTENSION)) {
-            try {
-                $image = $this->imageManager->decode($this->imageVariantProvider->getFileVariant($file->getFilename()));
-            } catch (\Exception $e) {
-                $this->logger->error('Impossible de décoder l\'image pour le fichier : '.$file->getFilename().'. Erreur : '.$e->getMessage());
-            }
-            $datePriseDeVue = isset($image) ? $image->exif('EXIF.DateTimeOriginal') : null;
-            if ($datePriseDeVue) {
-                try {
-                    $file->setDatePriseDeVue(new \DateTimeImmutable($datePriseDeVue));
-                } catch (\Exception $e) {
-                    $this->logger->error('Impossible de convertir la donnée EXIF DateTimeOriginal ("'.$datePriseDeVue.'") en DateTimeImmutable pour le fichier : '.$file->getFilename());
-                }
-            }
+        if ($setDatePriseDeVueFromExifData && in_array($file->getExtension(), File::RESIZABLE_EXTENSION)) {
+            $this->fileReaderExif->setDatePriseDeVueFromExifData($file);
         }
         if (null !== $documentType) {
             $file->setDocumentType($documentType);

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -11,10 +11,20 @@ use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
 use App\Entity\User;
+use App\Service\Files\ImageVariantProvider;
 use App\Service\Signalement\SignalementDocumentTypeMapper;
+use Intervention\Image\ImageManager;
+use Psr\Log\LoggerInterface;
 
 class FileFactory
 {
+    public function __construct(
+        private readonly ImageManager $imageManager,
+        private readonly ImageVariantProvider $imageVariantProvider,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
     /**
      * @param Qualification[] $partnerCompetence
      * @param PartnerType[]   $partnerType
@@ -48,6 +58,21 @@ class FileFactory
             ->setIsWaitingSuivi($isWaitingSuivi)
             ->setIsTemp($isTemp);
 
+        if (in_array($file->getExtension(), File::RESIZABLE_EXTENSION)) {
+            try {
+                $image = $this->imageManager->decode($this->imageVariantProvider->getFileVariant($file->getFilename()));
+            } catch (\Exception $e) {
+                $this->logger->error('Impossible de décoder l\'image pour le fichier : '.$file->getFilename().'. Erreur : '.$e->getMessage());
+            }
+            $datePriseDeVue = isset($image) ? $image->exif('EXIF.DateTimeOriginal') : null;
+            if ($datePriseDeVue) {
+                try {
+                    $file->setDatePriseDeVue(new \DateTimeImmutable($datePriseDeVue));
+                } catch (\Exception $e) {
+                    $this->logger->error('Impossible de convertir la donnée EXIF DateTimeOriginal ("'.$datePriseDeVue.'") en DateTimeImmutable pour le fichier : '.$file->getFilename());
+                }
+            }
+        }
         if (null !== $documentType) {
             $file->setDocumentType($documentType);
         } else {

--- a/src/Service/Files/FileReaderExif.php
+++ b/src/Service/Files/FileReaderExif.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Service\Files;
+
+use App\Entity\File;
+use Intervention\Image\ImageManager;
+use Psr\Log\LoggerInterface;
+
+class FileReaderExif
+{
+    public function __construct(
+        private readonly ImageManager $imageManager,
+        private readonly ImageVariantProvider $imageVariantProvider,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function setDatePriseDeVueFromExifData(File $file): void
+    {
+        try {
+            $image = $this->imageManager->decode($this->imageVariantProvider->getFileVariant($file->getFilename()));
+        } catch (\Exception $e) {
+            $this->logger->error('Impossible de décoder l\'image pour le fichier : '.$file->getFilename().'. Erreur : '.$e->getMessage());
+        }
+        $datePriseDeVue = isset($image) ? $image->exif('EXIF.DateTimeOriginal') : null;
+        if ($datePriseDeVue) {
+            try {
+                $file->setDatePriseDeVue(new \DateTimeImmutable($datePriseDeVue));
+            } catch (\Exception $e) {
+                $this->logger->error('Impossible de convertir la donnée EXIF DateTimeOriginal ("'.$datePriseDeVue.'") en DateTimeImmutable pour le fichier : '.$file->getFilename());
+            }
+        }
+    }
+}

--- a/src/Service/Files/ImageVariantProvider.php
+++ b/src/Service/Files/ImageVariantProvider.php
@@ -8,7 +8,7 @@ use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
-readonly class ImageVariantProvider
+class ImageVariantProvider
 {
     public function __construct(
         private FilesystemOperator $fileStorage,

--- a/src/Service/Files/SignalementFileAttacher.php
+++ b/src/Service/Files/SignalementFileAttacher.php
@@ -29,8 +29,8 @@ class SignalementFileAttacher
         array $fileData,
         ?User $uploadedBy = null,
     ): void {
+        $this->uploadHandlerService->moveFromBucketTempFolder($fileData['file']);
         $file = $this->fileFactory->createFromFileArray(file: $fileData, signalement: $signalement);
-        $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
         $fileSize = $this->uploadHandlerService->getFileSize($file->getFilename());
 
         $file->setSize(null !== $fileSize ? (string) $fileSize : null);

--- a/templates/_partials/_tooltip_photo_template.html.twig
+++ b/templates/_partials/_tooltip_photo_template.html.twig
@@ -1,3 +1,18 @@
-<strong class="fr-ws-nowrap">{{ photo.uploadedBy.nomComplet ?? 'N/R' }}</strong>
-<hr class="fr-pb-1v">
-<span class="fr-ws-nowrap">{{ photo.createdAt is defined ? photo.createdAt|date('d/m/Y') : 'N/R' }}</span>
+<table>
+    <tr>
+        <td class="fr-text--right">Transmis par : </td>
+        <th>{{ photo.uploadedBy.nomComplet ?? 'N/R' }}</th>
+    </tr>
+    {% if photo.createdAt %}
+        <tr>
+            <td class="fr-text--right">Transmis le : </td>
+            <th>{{ photo.createdAt|date('d/m/Y') }}</th>
+        </tr>
+    {% endif %}
+    {% if photo.datePriseDeVue %}
+        <tr>
+            <td class="fr-text--right">Pris le : </td>
+            <th>{{ photo.datePriseDeVue|date('d/m/Y') }}</th>
+        </tr>
+    {% endif %}
+</table>

--- a/templates/_partials/_tooltip_photo_template.html.twig
+++ b/templates/_partials/_tooltip_photo_template.html.twig
@@ -1,18 +1,18 @@
 <table>
     <tr>
-        <td class="fr-text--right">Transmis par : </td>
-        <th>{{ photo.uploadedBy.nomComplet ?? 'N/R' }}</th>
+        <th class="fr-text--right">Transmis par : </th>
+        <td>{{ photo.uploadedBy.nomComplet ?? 'N/R' }}</td>
     </tr>
     {% if photo.createdAt %}
         <tr>
-            <td class="fr-text--right">Transmis le : </td>
-            <th>{{ photo.createdAt|date('d/m/Y') }}</th>
+            <th class="fr-text--right">Transmis le : </th>
+            <td>{{ photo.createdAt|date('d/m/Y') }}</td>
         </tr>
     {% endif %}
     {% if photo.datePriseDeVue %}
         <tr>
-            <td class="fr-text--right">Pris le : </td>
-            <th>{{ photo.datePriseDeVue|date('d/m/Y') }}</th>
+            <th class="fr-text--right">Pris le : </th>
+            <td>{{ photo.datePriseDeVue|date('d/m/Y') }}</td>
         </tr>
     {% endif %}
 </table>

--- a/templates/back/signalement/view/header/_infos-creation.html.twig
+++ b/templates/back/signalement/view/header/_infos-creation.html.twig
@@ -6,7 +6,7 @@
     {% elseif signalement.creationSource is same as enum('App\\Entity\\Enum\\CreationSource').FORM_PRO_BO %}
         par {{ signalement.createdBy.prenom }} {{ signalement.createdBy.nom }}{% if signalement.createdBy.getPartnerInTerritory(signalement.territory) %}, du partenaire {{ signalement.createdBy.getPartnerInTerritory(signalement.territory).nom }}{% endif %} depuis le formulaire pro.
     {% elseif signalement.creationSource is same as enum('App\\Entity\\Enum\\CreationSource').FORM_SERVICE_SECOURS %}
-        depuis le formulaire Service Secours par {{signalement.serviceSecoursRoute.name}}
+        depuis le formulaire Service Secours par {{signalement.serviceSecours.name}}
     {% elseif signalement.creationSource is same as enum('App\\Entity\\Enum\\CreationSource').IMPORT %}
         par import
     {% else %}

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -61,6 +61,12 @@
                     </div>
                     <div class="fr-mt-1w">
                         Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
+                        {% if photo.createdAt %}
+                            le {{ photo.createdAt|date('d/m/Y') }}
+                        {% endif %}
+                        {% if photo.datePriseDeVue %}
+                            / prise le {{ photo.datePriseDeVue|date('d/m/Y') }}
+                        {% endif %}
                     </div>
                     <div class="fr-grid-row fr-mt-2v fr-grid-row--right" id="zoom">
                         <button class="photos-album-btn-zoom-out fr-btn fr-btn--icon-center fr-icon-zoom-out-line fr-mr-4v" data-id="{{ photo.id }}"></button>

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -13,14 +13,14 @@
                     <strong class="fr-ws-nowrap">
                         {{ suivi.createdByNomComplet }}
                     </strong>
-                    <hr class="fr-pb-1v">
+                    <hr>
                     <span class="fr-ws-nowrap">{{ suivi.createdBy.email }}</span>
                     {% if suivi.createdBy.fonction %}
-                        <hr class="fr-pb-1v">
+                        <hr>
                         <span class="fr-ws-nowrap">{{ suivi.createdBy.fonction }}</span>
                     {% endif %}
                     {% if suivi.createdBy.phone %}
-                        <hr class="fr-pb-1v">
+                        <hr>
                         <span class="fr-ws-nowrap">{{ suivi.createdBy.phoneDecoded }}</span>
                     {% endif %}
                 </span>
@@ -31,7 +31,7 @@
                 <span class="fr-tooltip fr-placement" id="tooltip_suivi_{{ suivi.id }}" role="tooltip">
                     <strong class="fr-ws-nowrap">{{ suivi.signalement.displayedNomProprio }}</strong>
                     {% if suivi.signalement.mailProprio %}
-                        <hr class="fr-pb-1v">
+                        <hr>
                         <span class="fr-ws-nowrap">{{ suivi.signalement.mailProprio }}</span>
                     {% endif %}
                 </span>

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -6,8 +6,11 @@ use App\Entity\Enum\DocumentType;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Factory\FileFactory;
+use App\Service\Files\ImageVariantProvider;
 use App\Tests\FixturesHelper;
+use Intervention\Image\ImageManager;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class FileFactoryTest extends TestCase
 {
@@ -15,7 +18,11 @@ class FileFactoryTest extends TestCase
 
     public function testCreateInstance(): void
     {
-        $file = (new FileFactory())->createInstanceFrom(
+        $file = (new FileFactory(
+            $this->createMock(ImageManager::class),
+            $this->createMock(ImageVariantProvider::class),
+            $this->createMock(LoggerInterface::class)
+        ))->createInstanceFrom(
             'sample-123.jpg',
             'sample.jpg',
             $this->getSignalement(),
@@ -43,7 +50,11 @@ class FileFactoryTest extends TestCase
         DocumentType $documentType,
     ): void {
         $signalement = $this->getSignalement();
-        $file = (new FileFactory())->createFromFileArray($dataItem, $signalement);
+        $file = (new FileFactory(
+            $this->createMock(ImageManager::class),
+            $this->createMock(ImageVariantProvider::class),
+            $this->createMock(LoggerInterface::class)
+        ))->createFromFileArray($dataItem, $signalement);
 
         $this->assertEquals($isTypeDocument, $file->isTypeDocument());
         $this->assertEquals($documentType, $file->getDocumentType());

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -6,11 +6,9 @@ use App\Entity\Enum\DocumentType;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Factory\FileFactory;
-use App\Service\Files\ImageVariantProvider;
+use App\Service\Files\FileReaderExif;
 use App\Tests\FixturesHelper;
-use Intervention\Image\ImageManager;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 
 class FileFactoryTest extends TestCase
 {
@@ -18,11 +16,8 @@ class FileFactoryTest extends TestCase
 
     public function testCreateInstance(): void
     {
-        $file = (new FileFactory(
-            $this->createMock(ImageManager::class),
-            $this->createMock(ImageVariantProvider::class),
-            $this->createMock(LoggerInterface::class)
-        ))->createInstanceFrom(
+        $file = (new FileFactory($this->createMock(FileReaderExif::class)))
+        ->createInstanceFrom(
             'sample-123.jpg',
             'sample.jpg',
             $this->getSignalement(),
@@ -50,11 +45,8 @@ class FileFactoryTest extends TestCase
         DocumentType $documentType,
     ): void {
         $signalement = $this->getSignalement();
-        $file = (new FileFactory(
-            $this->createMock(ImageManager::class),
-            $this->createMock(ImageVariantProvider::class),
-            $this->createMock(LoggerInterface::class)
-        ))->createFromFileArray($dataItem, $signalement);
+        $file = (new FileFactory($this->createMock(FileReaderExif::class)))
+        ->createFromFileArray($dataItem, $signalement);
 
         $this->assertEquals($isTypeDocument, $file->isTypeDocument());
         $this->assertEquals($documentType, $file->getDocumentType());

--- a/tests/Unit/Service/Files/SignalementFileAttacherTest.php
+++ b/tests/Unit/Service/Files/SignalementFileAttacherTest.php
@@ -36,7 +36,7 @@ class SignalementFileAttacherTest extends TestCase
             ->willReturn($file);
 
         $file
-            ->expects(self::exactly(3))
+            ->expects(self::exactly(2))
             ->method('getFilename')
             ->willReturn('document.pdf');
 
@@ -116,7 +116,7 @@ class SignalementFileAttacherTest extends TestCase
             ->willReturn($file);
 
         $file
-            ->expects(self::exactly(5))
+            ->expects(self::exactly(4))
             ->method('getFilename')
             ->willReturn('document.pdf');
 
@@ -204,7 +204,7 @@ class SignalementFileAttacherTest extends TestCase
             ->willReturn($file);
 
         $file
-            ->expects(self::exactly(5))
+            ->expects(self::exactly(4))
             ->method('getFilename')
             ->willReturn('infected.pdf');
 
@@ -293,7 +293,7 @@ class SignalementFileAttacherTest extends TestCase
             ->willReturn($file);
 
         $file
-            ->expects(self::exactly(4))
+            ->expects(self::exactly(3))
             ->method('getFilename')
             ->willReturn('photo.jpg');
 


### PR DESCRIPTION
## Ticket

#5697

## Description
Mise en place des changement permettant de préserver les métadonnée des fichier uploadé et d'afficher la date de prise de vue des photos quand elle est disponible.
Utilisation d'`Imagick` en remplacement de `GD` qui permet de meilleurs performance sur les traitement d'image et préserve les métadonnées des fichier par défaut.

## Changements apportés
- Ajout des extension `imagick` et `exif` dans les fichier docker pour le travail en local
- Ajout de `ext-imagick` dans le `composer.json` pour [scalingo](https://doc.scalingo.com/languages/php/extensions)
- Remplacement de l'utilisation de `GD` par `Imagick` par la library `InterventionImage`
- Ajout d'un champ `date_prise_de_vue` sur la table `File`
- Enregistrement de la date de prise de vu a chaque upload d'image (si l'information est disponible)
- Ajout de l'information sur la date de prise de vue (si elle est disponible) su le tooltip au survol des image et à l'agrandissement d'une image
<img width="285" height="338" alt="Capture d&#39;écran 2026-04-10 140258" src="https://github.com/user-attachments/assets/e3a42bec-e617-41a7-b554-d731ead26e2b" />

## Pré-requis
`make build`

## Tests
Pour les test utiliser une photo contenant la date de prise de vu dans es métadonnées (appareil photo/téléphone)
- [ ] Uploader depuis les formulaire (PRO/Service Secours/FO)
- [ ] Uploader des images depuis la fiche BO/FO
- [ ] Voir que pour les photos contenant une date de prise de vue elle est affiché dans le tooltip et la vue gallerie
- [ ] Vérifier un uplod sur la review app https://histologe-staging-pr5702.osc-fr1.scalingo.io/connexion
