### PR TITLE
[BO - Structure tiers déclarant] Reprendre l'info dans la fiche BO

### DIFF
--- a/templates/back/signalement/view/information/information-tiers.html.twig
+++ b/templates/back/signalement/view/information/information-tiers.html.twig
@@ -36,12 +36,6 @@
             <div class="fr-col-12">
                 <strong>Type de bailleur :</strong> {{ signalement.typeProprio ? signalement.typeProprio.label}}
             </div>
-            {% if signalement.typeProprio and signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
-            <div class="fr-col-12">
-                <strong>Nom de la structure :</strong> {{ signalement.structureDeclarant }}
-            </div>
-            {% endif %}
-            
         {% elseif signalement.lienDeclarantOccupant %}
             <div class="fr-col-12 fr-col-md-6">
                 <strong>Lien :</strong>
@@ -59,9 +53,14 @@
             <strong>Prénom :</strong> {{ signalement.prenomDeclarant }}
         </div>
         {% if signalement.matriculeDeclarant %}
-        <div class="fr-col-12 fr-col-md-6">
-            <strong>Matricule :</strong> {{ signalement.matriculeDeclarant }}
-        </div>
+            <div class="fr-col-12 fr-col-md-6">
+                <strong>Matricule :</strong> {{ signalement.matriculeDeclarant }}
+            </div>
+        {% endif %}
+        {% if signalement.structureDeclarant %}
+            <div class="fr-col-12 fr-col-md-6">
+                <strong>Nom de la structure :</strong> {{ signalement.structureDeclarant }}
+            </div>
         {% endif %}
         <div class="fr-col-12">
             <strong>Courriel :</strong>


### PR DESCRIPTION
## Ticket

#5699

## Description
Dans les fiche de signalement BO, onglet "foyer", section "Coordonnées du tiers déclarant" : affichage de la données "structure déclarant" dés qu'elle est disponible.
<img width="951" height="221" alt="Screenshot 2026-04-10 at 15-41-51 #2022-1 Signalement - Signal-Logement" src="https://github.com/user-attachments/assets/a6372b58-064a-4e6f-9ea5-e91a3926a551" />
