### PR TITLE
[BO - Esabora SCHS] Syncho visite - gestion partenaire par défaut / gestion resynchronisation en cas doublon

### DIFF
--- a/assets/scripts/vanilla/controllers/back_dashboard/pagination_handler.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/pagination_handler.js
@@ -17,7 +17,7 @@ export default function paginationHandler(loadPanelContent) {
       container = link.closest('.fr-tabs__panel')?.querySelector('[data-url]');
     }
     if (!container) {
-      const error = "Pagination: aucun container avec data-url trouvé";
+      const error = 'Pagination: aucun container avec data-url trouvé';
       console.error(error);
       Sentry.captureException(new Error(error));
       return;

--- a/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
@@ -95,8 +95,7 @@ export default function initTabsLoader() {
         }
 
         if (err.message.includes('404')) {
-          loader.innerHTML =
-              '<div class="fr-text--error">Chargement de données impossible.</div>';
+          loader.innerHTML = '<div class="fr-text--error">Chargement de données impossible.</div>';
           continue;
         }
 

--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -47,7 +47,7 @@ export function jsonResponseProcess(response) {
       const openModalElement = document.querySelector('.fr-modal--opened');
       if (openModalElement) {
         dsfr(openModalElement).modal.conceal();
-        if(response.resetForm) {
+        if (response.resetForm) {
           const formElement = openModalElement.querySelector('form');
           if (formElement) {
             formElement.reset();

--- a/assets/scripts/vanilla/services/form/ajax_form_handler.js
+++ b/assets/scripts/vanilla/services/form/ajax_form_handler.js
@@ -209,7 +209,12 @@ document.addEventListener('click', (event) => {
 
   event.preventDefault();
 
-  if (confirm('Voulez-vous vraiment supprimer cet élément ?')) {
+  let messageConfirmation = 'Voulez-vous vraiment supprimer cet élément ?';
+  if (actionBtn.dataset.isSynchronized === '1') {
+    messageConfirmation =
+      'Attention, ce dossier est synchronisé avec un service externe.\nVoulez-vous vraiment supprimer cet élément ?';
+  }
+  if (confirm(messageConfirmation)) {
     const formData = new FormData();
     formData.append('_token', actionBtn.getAttribute('data-token'));
     fetch(actionBtn.getAttribute('data-delete'), {

--- a/src/Factory/InterventionFactory.php
+++ b/src/Factory/InterventionFactory.php
@@ -4,6 +4,7 @@ namespace App\Factory;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\InterventionType;
+use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\ProcedureType;
 use App\Entity\Intervention;
 
@@ -40,7 +41,13 @@ class InterventionFactory
             ->setAdditionalInformation($additionalInformation);
 
         if ($doneBy) {
-            if ('ARS' === $doneBy) {
+            $partnerType = match ($doneBy) {
+                'SCHS' => PartnerType::COMMUNE_SCHS,
+                'ARS' => PartnerType::ARS,
+                default => PartnerType::tryFrom($doneBy),
+            };
+
+            if (null !== $partnerType && $affectation->getPartner()->getType() === $partnerType) {
                 $intervention->setPartner($affectation->getPartner());
             } else {
                 $intervention->setExternalOperator($doneBy)->setPartner(null);

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -242,6 +242,16 @@ class AffectationManager extends Manager
 
     public function removeAffectationAndSubscriptions(Affectation $affectation): void
     {
+        if ($affectation->isSynchronized() && AffectationStatus::ACCEPTED === $affectation->getStatut()) {
+            $message = \sprintf(
+                '[%s][%s] Suppression du partenaire %s sur le dossier synchronisé #%s',
+                $affectation->getSignalement()->getTerritory()->getZipAndName(),
+                $affectation->getPartner()->getType()->value,
+                $affectation->getPartner()->getId(),
+                $affectation->getSignalement()->getReference()
+            );
+            \Sentry\captureMessage($message);
+        }
         $this->removeSubscriptionsOfAffectation($affectation);
         $this->remove($affectation);
     }

--- a/src/Messenger/Message/Esabora/DossierMessageSISH.php
+++ b/src/Messenger/Message/Esabora/DossierMessageSISH.php
@@ -88,6 +88,8 @@ final class DossierMessageSISH implements DossierMessageInterface
      */
     private ?array $personnes = null;
 
+    private ?string $errorCode = null;
+
     public function __construct()
     {
         $this->personnes = [];
@@ -887,6 +889,18 @@ final class DossierMessageSISH implements DossierMessageInterface
     public function setAttachmentsSize(?int $attachmentsSize): self
     {
         $this->attachmentsSize = $attachmentsSize;
+
+        return $this;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    public function setErrorCode(?string $errorCode): self
+    {
+        $this->errorCode = $errorCode;
 
         return $this;
     }

--- a/src/Messenger/MessageHandler/Esabora/DossierMessageSISHHandler.php
+++ b/src/Messenger/MessageHandler/Esabora/DossierMessageSISHHandler.php
@@ -33,9 +33,14 @@ final class DossierMessageSISHHandler
     {
         /** @var DossierSISHHandlerInterface $dossierSISHHandler */
         foreach ($this->dossierSISHHandlers as $dossierSISHHandler) {
-            $dossierSISHHandler->handle($dossierMessageSISH);
+            $isSuccessful = $dossierSISHHandler->handle($dossierMessageSISH);
+
             if ($dossierSISHHandler->canFlagAsSynchronized()) {
                 $this->affectationManager->flagAsSynchronized($dossierMessageSISH);
+            }
+
+            if (!$isSuccessful) {
+                break;
             }
         }
     }

--- a/src/Service/Interconnection/Esabora/Handler/AbstractDossierSISHHandler.php
+++ b/src/Service/Interconnection/Esabora/Handler/AbstractDossierSISHHandler.php
@@ -10,27 +10,43 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractDossierSISHHandler implements DossierSISHHandlerInterface
 {
+    public const string ERROR_SQL_DUPLICATE_KEY = 'WS_ERR_SQL';
+
     protected ?Partner $partner = null;
     protected ?string $action = null;
     protected mixed $response = null;
     protected ?int $sasAdresseId = null;
     protected ?int $sasDossierId = null;
     protected string $status = JobEvent::STATUS_FAILED;
+    protected ?string $errorCode = null;
 
     public function __construct()
     {
     }
 
-    public function handle(DossierMessageSISH $dossierMessageSISH): void
+    public function handle(DossierMessageSISH $dossierMessageSISH): bool
     {
         $this->sasAdresseId = $dossierMessageSISH->getSasAdresse();
         $this->sasDossierId = $dossierMessageSISH->getSasDossierId();
         $this->status = Response::HTTP_OK === $this->response->getStatusCode() ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED;
+        if (JobEvent::STATUS_FAILED === $this->status) {
+            $this->errorCode = $this->response->getErrorCode() ?? null;
+
+            return false;
+        }
+
+        return true;
     }
 
     public function canFlagAsSynchronized(): bool
     {
         return AbstractEsaboraService::ACTION_PUSH_DOSSIER_PERSONNE === $this->action
-            && JobEvent::STATUS_SUCCESS === $this->status;
+            && JobEvent::STATUS_SUCCESS === $this->status
+            || $this->dossierAlreadyExists();
+    }
+
+    public function dossierAlreadyExists(): bool
+    {
+        return self::ERROR_SQL_DUPLICATE_KEY === $this->errorCode;
     }
 }

--- a/src/Service/Interconnection/Esabora/Handler/DossierAdresseServiceHandler.php
+++ b/src/Service/Interconnection/Esabora/Handler/DossierAdresseServiceHandler.php
@@ -16,7 +16,7 @@ class DossierAdresseServiceHandler extends AbstractDossierSISHHandler
         parent::__construct();
     }
 
-    public function handle(DossierMessageSISH $dossierMessageSISH): void
+    public function handle(DossierMessageSISH $dossierMessageSISH): bool
     {
         $dossierMessageSISH
             ->setAction($this->action)
@@ -24,7 +24,12 @@ class DossierAdresseServiceHandler extends AbstractDossierSISHHandler
             ->setAttachmentsCount(null);
         $this->response = $this->esaboraSISHService->pushAdresse($dossierMessageSISH);
         $dossierMessageSISH->setSasAdresse($this->response->getSasId());
-        parent::handle($dossierMessageSISH);
+
+        if (null !== $this->response->getErrorCode()) {
+            $dossierMessageSISH->setErrorCode($this->response->getErrorCode());
+        }
+
+        return parent::handle($dossierMessageSISH);
     }
 
     public static function getPriority(): int

--- a/src/Service/Interconnection/Esabora/Handler/DossierPersonneServiceHandler.php
+++ b/src/Service/Interconnection/Esabora/Handler/DossierPersonneServiceHandler.php
@@ -16,7 +16,7 @@ class DossierPersonneServiceHandler extends AbstractDossierSISHHandler
         parent::__construct();
     }
 
-    public function handle(DossierMessageSISH $dossierMessageSISH): void
+    public function handle(DossierMessageSISH $dossierMessageSISH): bool
     {
         $dossierMessageSISH
             ->setAction($this->action)
@@ -27,6 +27,8 @@ class DossierPersonneServiceHandler extends AbstractDossierSISHHandler
             $this->response = $this->esaboraSISHService->pushPersonne($dossierMessageSISH, $dossierPersonne);
             parent::handle($dossierMessageSISH);
         }
+
+        return true; // last SISH web service called; no need to handle further
     }
 
     public static function getPriority(): int

--- a/src/Service/Interconnection/Esabora/Handler/DossierSISHHandlerInterface.php
+++ b/src/Service/Interconnection/Esabora/Handler/DossierSISHHandlerInterface.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('app.dossier_sish_handler')]
 interface DossierSISHHandlerInterface
 {
-    public function handle(DossierMessageSISH $dossierMessageSISH): void;
+    public function handle(DossierMessageSISH $dossierMessageSISH): bool;
 
     public function canFlagAsSynchronized(): bool;
 

--- a/src/Service/Interconnection/Esabora/Handler/DossierServiceHandler.php
+++ b/src/Service/Interconnection/Esabora/Handler/DossierServiceHandler.php
@@ -16,7 +16,7 @@ class DossierServiceHandler extends AbstractDossierSISHHandler
         parent::__construct();
     }
 
-    public function handle(DossierMessageSISH $dossierMessageSISH): void
+    public function handle(DossierMessageSISH $dossierMessageSISH): bool
     {
         $piecesJointes = $dossierMessageSISH->getPiecesJointesDocuments();
         if (!empty($piecesJointes)) {
@@ -30,7 +30,8 @@ class DossierServiceHandler extends AbstractDossierSISHHandler
         $dossierMessageSISH->setAction($this->action);
         $this->response = $this->esaboraSISHService->pushDossier($dossierMessageSISH);
         $dossierMessageSISH->setSasDossierId($this->response->getSasId());
-        parent::handle($dossierMessageSISH);
+
+        return parent::handle($dossierMessageSISH);
     }
 
     public static function getPriority(): int

--- a/src/Service/Interconnection/Esabora/Response/DossierPushSISHResponse.php
+++ b/src/Service/Interconnection/Esabora/Response/DossierPushSISHResponse.php
@@ -9,6 +9,7 @@ class DossierPushSISHResponse implements DossierResponseInterface
     private ?int $sasId = null;
     private ?int $statusCode = null;
     private ?string $errorReason = null;
+    private ?string $errorCode = null;
 
     /**
      * @param array<mixed> $response
@@ -21,6 +22,7 @@ class DossierPushSISHResponse implements DossierResponseInterface
                 $this->sasId = $data;
             } else {
                 $this->errorReason = (string) json_encode($response);
+                $this->errorCode = $response['code'] ?? null;
             }
         }
         $this->statusCode = $statusCode;
@@ -64,5 +66,10 @@ class DossierPushSISHResponse implements DossierResponseInterface
     public function getNameSI(): ?string
     {
         return EsaboraSISHService::NAME_SI;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
     }
 }

--- a/templates/back/signalement/view/affectation/_item-with-action.html.twig
+++ b/templates/back/signalement/view/affectation/_item-with-action.html.twig
@@ -65,6 +65,7 @@
                             {% if signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}
                                 <button title="Désaffecter le partenaire"
                                         data-delete="{{ path('back_signalement_remove_partner',{uuid:signalement.uuid,affectation:partnerAffectation.id}) }}"
+                                        data-is-synchronized="{{ partnerAffectation.isSynchronized and partnerAffectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').ACCEPTED ? 1 : 0 }}"
                                         data-token="{{ csrf_token('signalement_remove_partner_'~signalement.id) }}"
                                         data-move-affectation-partner-id="{{ partnerAffectation.partner.id }}"
                                         class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line partner-row-delete"></button>

--- a/tests/Functional/Controller/Back/AffectationControllerTest.php
+++ b/tests/Functional/Controller/Back/AffectationControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Functional\Controller;
+namespace App\Tests\Functional\Controller\Back;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;

--- a/tests/Unit/Messenger/MessageHandler/Esabora/DossierMessageHandlerTest.php
+++ b/tests/Unit/Messenger/MessageHandler/Esabora/DossierMessageHandlerTest.php
@@ -7,13 +7,17 @@ use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Messenger\MessageHandler\Esabora\DossierMessageSCHSHandler;
 use App\Messenger\MessageHandler\Esabora\DossierMessageSISHHandler;
 use App\Service\Interconnection\Esabora\EsaboraSCHSService;
+use App\Service\Interconnection\Esabora\EsaboraSISHService;
+use App\Service\Interconnection\Esabora\Handler\DossierAdresseServiceHandler;
 use App\Service\Interconnection\Esabora\Handler\DossierSISHHandlerInterface;
+use App\Service\Interconnection\Esabora\Response\DossierPushSISHResponse;
 use App\Tests\FixturesHelper;
 use Faker\Factory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
@@ -81,5 +85,30 @@ class DossierMessageHandlerTest extends TestCase
 
         $handler = new DossierMessageSISHHandler(['handler' => $dossierSISHHandlerMock], $affectationManagerMock);
         $handler($dossierMessageSISH);
+    }
+
+    public function testHandleReturnsFalseAndCanFlagAsSynchronizedWhenWsErrSql(): void
+    {
+        $esaboraSISHService = $this->createMock(EsaboraSISHService::class);
+        $esaboraSISHService
+            ->expects($this->once())
+            ->method('pushAdresse')
+            ->willReturn(
+                new DossierPushSISHResponse(
+                    [
+                        'code' => 'WS_ERR_SQL',
+                        'message' => '23505 - ERROR:  duplicate key value violates unique constraint',
+                    ],
+                    Response::HTTP_BAD_REQUEST
+                )
+            );
+
+        $handler = new DossierAdresseServiceHandler($esaboraSISHService);
+        $dossierMessageSISH = $this->getDossierMessageSISH();
+        $isSuccessful = $handler->handle($dossierMessageSISH);
+
+        self::assertFalse($isSuccessful);
+        self::assertTrue($handler->canFlagAsSynchronized());
+        self::assertTrue($handler->dossierAlreadyExists());
     }
 }

--- a/tools/wiremock/src/Mock/Esabora/AbstractEsaboraMock.php
+++ b/tools/wiremock/src/Mock/Esabora/AbstractEsaboraMock.php
@@ -8,32 +8,39 @@ use WireMock\Client\WireMock;
 
 abstract class AbstractEsaboraMock
 {
-    protected const REQUEST_CONTENT_TYPE = 'application/json';
-    protected const REQUEST_AUTHORIZATION = 'Bearer';
-    protected const RESPONSE_CONTENT_TYPE = self::REQUEST_CONTENT_TYPE;
-    protected const MATCH_JSON_PATH = '$.criterionList[0].criterionValueList[0]';
-    protected const SIGNALEMENT_SUBCRIBED_SISH = '00000000-0000-0000-2023-000000000010';
-    protected const SIGNALEMENT_SUBCRIBED_SISH_SCHS = '00000000-0000-0000-2023-000000000012';
+    protected const string REQUEST_CONTENT_TYPE = 'application/json';
+    protected const string REQUEST_AUTHORIZATION = 'Bearer';
+    protected const string RESPONSE_CONTENT_TYPE = self::REQUEST_CONTENT_TYPE;
+    protected const string MATCH_JSON_PATH = '$.criterionList[0].criterionValueList[0]';
+    protected const string SIGNALEMENT_SUBSCRIBED_SISH = '00000000-0000-0000-2023-000000000010';
+    protected const string SIGNALEMENT_SUBSCRIBED_SISH_SCHS = '00000000-0000-0000-2023-000000000012';
 
     protected static function createPushDossierMock(
         WireMock $wiremock,
         string $task,
         string $service,
         string $response,
-        ?string $basePath,
-        ?string $resourcesDir,
+        int $statusCode = 200,
+        ?string $bodyMatcher = null,
+        ?string $basePath = null,
+        ?string $resourcesDir = null,
     ): void {
+        $request = WireMock::post(WireMock::urlMatching($basePath.'/modbdd/\\?task='.$task))
+            ->withHeader('Authorization', WireMock::containing(self::REQUEST_AUTHORIZATION))
+            ->withHeader('Content-Type', WireMock::containing(self::REQUEST_CONTENT_TYPE))
+            ->withRequestBody(WireMock::matchingJsonPath('$.treatmentName', WireMock::equalTo($service)));
+
+        if (null !== $bodyMatcher) {
+            $request->withRequestBody(WireMock::matchingJsonPath($bodyMatcher));
+        }
+
         $wiremock->stubFor(
-            WireMock::post(WireMock::urlMatching($basePath.'/modbdd/\\?task='.$task))
-                ->withHeader('Authorization', WireMock::containing(self::REQUEST_AUTHORIZATION))
-                ->withHeader('Content-Type', WireMock::containing(self::REQUEST_CONTENT_TYPE))
-                ->withRequestBody(WireMock::matchingJsonPath('$.treatmentName', WireMock::equalTo($service)))
-                ->willReturn(
-                    WireMock::aResponse()
-                        ->withStatus(200)
-                        ->withHeader('Content-Type', self::RESPONSE_CONTENT_TYPE)
-                        ->withBody(AppMock::getMockContent($resourcesDir.$response))
-                )
+            $request->willReturn(
+                WireMock::aResponse()
+                    ->withStatus($statusCode)
+                    ->withHeader('Content-Type', self::RESPONSE_CONTENT_TYPE)
+                    ->withBody(AppMock::getMockContent($resourcesDir.$response))
+            )
         );
     }
 

--- a/tools/wiremock/src/Mock/Esabora/EsaboraSCHSMock.php
+++ b/tools/wiremock/src/Mock/Esabora/EsaboraSCHSMock.php
@@ -19,6 +19,8 @@ class EsaboraSCHSMock extends AbstractEsaboraMock
             'doTreatment',
             'Import HISTOLOGE',
             'ws_import.json',
+            200,
+            null,
             self::BASE_PATH,
             self::RESOURCES_DIR,
         );
@@ -49,7 +51,7 @@ class EsaboraSCHSMock extends AbstractEsaboraMock
 
         self::createCustomStateDossierMock(
             $wiremock,
-            self::SIGNALEMENT_SUBCRIBED_SISH_SCHS,
+            self::SIGNALEMENT_SUBSCRIBED_SISH_SCHS,
             'etat_termine.json'
         );
 
@@ -58,7 +60,7 @@ class EsaboraSCHSMock extends AbstractEsaboraMock
             '00000000-0000-0000-2022-000000000002',
             '00000000-0000-0000-2022-000000000008',
             '00000000-0000-0000-2023-000000000009',
-            self::SIGNALEMENT_SUBCRIBED_SISH_SCHS,
+            self::SIGNALEMENT_SUBSCRIBED_SISH_SCHS,
         ];
 
         self::createSearchDossierMock(

--- a/tools/wiremock/src/Mock/Esabora/EsaboraSISHMock.php
+++ b/tools/wiremock/src/Mock/Esabora/EsaboraSISHMock.php
@@ -18,7 +18,20 @@ class EsaboraSISHMock extends AbstractEsaboraMock
             $wiremock,
             'doTreatment',
             'SISH_ADRESSE',
+            'error/ws_dossier_adresse.json',
+            400,
+            '$.fieldList[?(@.fieldName == "Reference_Adresse" && @.fieldValue == "00000000-0000-0000-2023-000000000020")]',
+            self::BASE_PATH,
+            self::RESOURCES_DIR,
+        );
+
+        self::createPushDossierMock(
+            $wiremock,
+            'doTreatment',
+            'SISH_ADRESSE',
             'ws_dossier_adresse.json',
+            200,
+            '$.fieldList[?(@.fieldName == "Reference_Adresse" && @.fieldValue != "00000000-0000-0000-2023-000000000020")]',
             self::BASE_PATH,
             self::RESOURCES_DIR,
         );
@@ -28,6 +41,8 @@ class EsaboraSISHMock extends AbstractEsaboraMock
             'doTreatment',
             'SISH_DOSSIER',
             'ws_dossier.json',
+            200,
+            null,
             self::BASE_PATH,
             self::RESOURCES_DIR,
         );
@@ -37,6 +52,8 @@ class EsaboraSISHMock extends AbstractEsaboraMock
             'doTreatment',
             'SISH_DOSSIER_PERSONNE',
             'ws_dossier_personne.json',
+            200,
+            null,
             self::BASE_PATH,
             self::RESOURCES_DIR,
         );
@@ -47,9 +64,22 @@ class EsaboraSISHMock extends AbstractEsaboraMock
             self::SISH_ETAT_DOSSIER_SAS,
             WireMock::matchingJsonPath(
                 self::MATCH_JSON_PATH,
-                WireMock::equalTo(self::SIGNALEMENT_SUBCRIBED_SISH)
+                WireMock::equalTo(self::SIGNALEMENT_SUBSCRIBED_SISH)
             ),
             'ws_etat_dossier_sas/etat_importe.json',
+            self::BASE_PATH,
+            self::RESOURCES_DIR,
+        );
+
+        self::createSearchDossierMock(
+            $wiremock,
+            'doSearch',
+            self::SISH_ETAT_DOSSIER_SAS,
+            WireMock::matchingJsonPath(
+                self::MATCH_JSON_PATH,
+                WireMock::equalTo('00000000-0000-0000-2023-000000000020')
+            ),
+            'ws_etat_dossier_sas/etat_importe_sish_schs.json',
             self::BASE_PATH,
             self::RESOURCES_DIR,
         );
@@ -73,7 +103,7 @@ class EsaboraSISHMock extends AbstractEsaboraMock
             self::SISH_ETAT_DOSSIER_SAS,
             WireMock::matchingJsonPath(
                 self::MATCH_JSON_PATH,
-                WireMock::equalTo(self::SIGNALEMENT_SUBCRIBED_SISH_SCHS)
+                WireMock::equalTo(self::SIGNALEMENT_SUBSCRIBED_SISH_SCHS)
             ),
             'ws_etat_dossier_sas/etat_termine.json',
             self::BASE_PATH,
@@ -84,20 +114,27 @@ class EsaboraSISHMock extends AbstractEsaboraMock
             $wiremock,
             self::SISH_VISITES_DOSSIER_SAS,
             'ws_visites_dossier_sas.json',
-            self::SIGNALEMENT_SUBCRIBED_SISH
+            self::SIGNALEMENT_SUBSCRIBED_SISH
         );
 
         self::createMockIntervention(
             $wiremock,
             self::SISH_ARRETES_DOSSIER_SAS,
             'ws_arretes_dossier_sas.json',
-            self::SIGNALEMENT_SUBCRIBED_SISH
+            self::SIGNALEMENT_SUBSCRIBED_SISH
         );
 
         self::createMockIntervention(
             $wiremock,
             self::SISH_VISITES_DOSSIER_SAS,
             'ws_visites_dossier_sas_en_cours.json'
+        );
+
+        self::createMockIntervention(
+            $wiremock,
+            self::SISH_VISITES_DOSSIER_SAS,
+            'ws_visites_dossier_sas_en_cours_sish_schs.json',
+            '00000000-0000-0000-2023-000000000020'
         );
 
         self::createMockIntervention(
@@ -119,8 +156,8 @@ class EsaboraSISHMock extends AbstractEsaboraMock
         WireMock $wiremock,
         string $service,
         string $response,
-        string $uuidSignalement = self::SIGNALEMENT_SUBCRIBED_SISH_SCHS,
-    ) {
+        string $uuidSignalement = self::SIGNALEMENT_SUBSCRIBED_SISH_SCHS,
+    ): void {
         self::createSearchDossierMock(
             $wiremock,
             'doSearch',

--- a/tools/wiremock/src/Resources/Esabora/sish/error/ws_dossier_adresse.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/error/ws_dossier_adresse.json
@@ -1,0 +1,4 @@
+{
+  "code": "WS_ERR_SQL",
+  "message": "23505 - ERROR:  duplicate key value violates unique constraint \"imdo_cledoss_unik\"\nDETAIL:  Key (imdo_cledoss, imdo_typimport)=(00000000-0000-0000-2023-000000000020, H) already exists."
+}

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_importe_sish_schs.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_importe_sish_schs.json
@@ -1,0 +1,44 @@
+{
+  "searchId": "00000000-0000-0000-2023-000000000020",
+  "nbResults": 1,
+  "columnList": [
+    "Reference_Dossier",
+    "EsaboraStatusSAS_Etat",
+    "Sas_DateDecision",
+    "Sas_CauseRefus",
+    "SISH_DossId",
+    "SISH_DossNum",
+    "SISH_DossObjet",
+    "SISH_DossDateCloture",
+    "SISH_DossStatutAbr",
+    "SISH_DossStatut",
+    "SISH_DossEtat",
+    "SISH_DossTypeCode",
+    "SISH_DossTypeLib"
+  ],
+  "keyList": [
+    "i1.imdo_id"
+  ],
+  "rowList": [
+    {
+      "columnDataList": [
+        "00000000-0000-0000-2023-000000000020",
+        "Importé",
+        "14/02/2026 10:16",
+        null,
+        "2026",
+        "2026/SISH/0020",
+        "7 Av. Rostand - Appartement 962, 13003 Marseille",
+        null,
+        "A traiter",
+        "A traiter",
+        "en cours",
+        "INS",
+        "Insalubrité"
+      ],
+      "keyDataList": [
+        "9"
+      ]
+    }
+  ]
+}

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours_sish_schs.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours_sish_schs.json
@@ -1,0 +1,34 @@
+{
+  "searchId": "00000000-0000-0000-2023-000000000020",
+  "nbResults": 1,
+  "columnList": [
+    "Sas_LogicielProvenance",
+    "Reference_Dossier",
+    "SISH_DossNum",
+    "SISH_VisiteDate",
+    "SISH_VisiteNum",
+    "SISH_VisiteType",
+    "SISH_VisitePar"
+  ],
+  "keyList": [
+    "i1.imdo_id",
+    "v4_t2.visi_id"
+  ],
+  "rowList": [
+    {
+      "columnDataList": [
+        "Histologe",
+        "00000000-0000-0000-2023-000000000020",
+        "2023/DD13/0011",
+        "16/05/2025 10:00",
+        "2023/DD13/00665-13/05/2025 10:16",
+        "Visite",
+        "ARS"
+      ],
+      "keyDataList": [
+        10,
+        799
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Ticket

#5715    
#5714

## Description
- Suppression affectation : Ajout message d'avertissement si dossier synchronisation
<img width="562" height="247" alt="image" src="https://github.com/user-attachments/assets/230370a8-152a-4c75-b084-22c89c9fe9fe" />

- Réaffectation : Forcer la resynchronisation selon le code erreur
<img width="377" height="120" alt="image" src="https://github.com/user-attachments/assets/6cfb82d3-6135-4cce-9374-0c4c6a6791da" />

<img width="559" height="175" alt="image" src="https://github.com/user-attachments/assets/f8f48704-8d3b-4d58-af5c-f71a95e730b1" />


- Synchronisation des visites : Vérification du partenaire ayant fait la visite (Dossier affecté SCHS mais visite faite par ARS et vice versa)

<img width="1436" height="122" alt="image" src="https://github.com/user-attachments/assets/49b627ae-436d-4fe5-88a0-49995865a4c7" />


## Changements apportés
* Mise à jour handlers SISH gérant les appels HTTP pour gérer les erreurs de doublon et éviter les appels inutiles en cas d'échec
* Ajout nouveau mocks pour tester les visites faite par un autre partenaire que celui affecté
* Mise à jour js pour message de confirmation

## Pré-requis

`make mock-restart`

`make worker-stop && make worker-consume`

## Tests

#### Message de confirmation (lors de la suppression de l'affectation)
- [ ] Aller sur un signalement non synchronisé et vérifier que le message actuel s'affiche http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000020
- [ ] Aller sur un signalement synchronisé http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000120 et vérifier la mention lié à la synchronisation du dossier 


#### Resynchronisation
- [ ] Aller sur le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000020 et affecter Partenaire SCHS via Santé Habitat 
        - Vérifier que le mock a bien renvoyé un code erreur de doublon sur le premier appel http://localhost:8080/bo/connexions-si/
        - Vérifier que les autres appels ne sont pas effectué 
        - Vérifier que l'affectation est bien taggé comme synchronisé en base
 
#### Synchronisation des visites
- [ ] Lancer `make sync-sish` et vérifier que le partenaire d'affectation n'est pas repris dans le message de suivi mais plutôt le partenaire fourni par le web-service car différent 