### PR TITLE
[BO - Tableau de bord] Amélioration du passage d'un onglet à l'autre au clavier

### DIFF
--- a/assets/scripts/vanilla/controllers/back_dashboard/pagination_handler.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/pagination_handler.js
@@ -17,7 +17,7 @@ export default function paginationHandler(loadPanelContent) {
       container = link.closest('.fr-tabs__panel')?.querySelector('[data-url]');
     }
     if (!container) {
-      const error = "Pagination: aucun container avec data-url trouvé";
+      const error = 'Pagination: aucun container avec data-url trouvé';
       console.error(error);
       Sentry.captureException(new Error(error));
       return;

--- a/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
@@ -31,16 +31,6 @@ export default function initTabsLoader() {
     });
   });
 
-  document.querySelectorAll('.fr-tabs__tab').forEach((tab) => {
-    tab?.addEventListener('click', () => {
-      const panelId = tab.getAttribute('aria-controls');
-      const panel = document.getElementById(panelId);
-      if (panel) {
-        loadPanelContent(panel);
-      }
-    });
-  });
-
   async function loadPanelContent(panelOrBody) {
     if (currentAbortController) {
       currentAbortController.abort();

--- a/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
@@ -31,6 +31,16 @@ export default function initTabsLoader() {
     });
   });
 
+  document.querySelectorAll('.fr-tabs__tab').forEach((tab) => {
+    tab?.addEventListener('click', () => {
+      const panelId = tab.getAttribute('aria-controls');
+      const panel = document.getElementById(panelId);
+      if (panel) {
+        loadPanelContent(panel);
+      }
+    });
+  });
+
   async function loadPanelContent(panelOrBody) {
     if (currentAbortController) {
       currentAbortController.abort();
@@ -93,8 +103,7 @@ export default function initTabsLoader() {
         }
 
         if (err.message.includes('404')) {
-          loader.innerHTML =
-              '<div class="fr-text--error">Chargement de données impossible.</div>';
+          loader.innerHTML = '<div class="fr-text--error">Chargement de données impossible.</div>';
           continue;
         }
 

--- a/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
@@ -25,11 +25,9 @@ export default function initTabsLoader() {
     }
   });
 
-  document.querySelectorAll('.fr-tabs__tab').forEach((tab) => {
-    tab.addEventListener('click', function () {
-      const panelId = this.getAttribute('aria-controls');
-      const panel = document.getElementById(panelId);
-      loadPanelContent(panel);
+  document.querySelectorAll('[data-fr-js-tab-panel]').forEach((panel) => {
+    panel?.addEventListener('dsfr.disclose', (e) => {
+      loadPanelContent(e.target);
     });
   });
 

--- a/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
@@ -25,7 +25,7 @@ export default function initTabsLoader() {
     }
   });
 
-  document.querySelectorAll('[data-fr-js-tab-panel]').forEach((panel) => {
+  document.querySelectorAll('.fr-tabs__panel').forEach((panel) => {
     panel?.addEventListener('dsfr.disclose', (e) => {
       loadPanelContent(e.target);
     });

--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -47,7 +47,7 @@ export function jsonResponseProcess(response) {
       const openModalElement = document.querySelector('.fr-modal--opened');
       if (openModalElement) {
         dsfr(openModalElement).modal.conceal();
-        if(response.resetForm) {
+        if (response.resetForm) {
           const formElement = openModalElement.querySelector('form');
           if (formElement) {
             formElement.reset();

--- a/tests/e2e/tests/dashboard_tabs.spec.ts
+++ b/tests/e2e/tests/dashboard_tabs.spec.ts
@@ -1,11 +1,21 @@
 import { test, Page } from '@playwright/test';
 
 async function clickTabAndTriggerDisclose(page: Page, tabName: string) {
-  await page.getByRole('tab', { name: tabName }).click();
-  await page.evaluate(() => {
-    const panel = document.querySelector('.fr-tabs__panel--selected');
-    if (panel) panel.dispatchEvent(new Event('dsfr.disclose', { bubbles: true }));
-  });
+  const tab = page.getByRole('tab', { name: tabName });
+  await tab.click();
+
+  // Attendre que le DSFR ait changé le panel actif
+  const panelId = await tab.getAttribute('aria-controls');
+  
+  // Dispatcher l'événement sur le bon panel et vérifier
+  await page.evaluate((id) => {
+    const panel = document.getElementById(id);
+    if (panel) {
+      panel.dispatchEvent(new Event('dsfr.disclose', { bubbles: true }));
+      return true;
+    }
+    return false;
+  }, panelId);
 }
 
 test('dashboard tabs for admin', async ({page, context}) => {

--- a/tests/e2e/tests/dashboard_tabs.spec.ts
+++ b/tests/e2e/tests/dashboard_tabs.spec.ts
@@ -1,4 +1,12 @@
-import { test } from '@playwright/test';
+import { test, Page } from '@playwright/test';
+
+async function clickTabAndTriggerDisclose(page: Page, tabName: string) {
+  await page.getByRole('tab', { name: tabName }).click();
+  await page.evaluate(() => {
+    const panel = document.querySelector('.fr-tabs__panel--selected');
+    if (panel) panel.dispatchEvent(new Event('dsfr.disclose', { bubbles: true }));
+  });
+}
 
 test('dashboard tabs for admin', async ({page, context}) => {
   await context.clearCookies();
@@ -15,21 +23,21 @@ test('dashboard tabs for admin', async ({page, context}) => {
 
   // Attendre la navigation après connexion
   await page.waitForURL('**/bo/**', { timeout: 10000 });
-  await page.getByRole('tab', { name: 'Accueil' }).click();
+  await clickTabAndTriggerDisclose(page, 'Accueil');
   await page.getByRole('heading', { name: 'Vos dernières actions' }).click();
-  await page.getByRole('tab', { name: 'Nouveaux dossiers' }).click();
+  await clickTabAndTriggerDisclose(page, 'Nouveaux dossiers');
   await page.getByRole('heading', { name: 'Dossiers déposés depuis le formulaire usager' }).click();
   await page.evaluate(() => window.scrollTo(0, 0));
-  await page.getByRole('tab', { name: 'A fermer' }).click();
+  await clickTabAndTriggerDisclose(page, 'A fermer');
   await page.getByRole('heading', { name: 'Dossiers fermés par tous les' }).click();
   await page.evaluate(() => window.scrollTo(0, 0));
-  await page.getByRole('tab', { name: 'Messages usagers' }).click();
+  await clickTabAndTriggerDisclose(page, 'Messages usagers');
   await page.getByRole('heading', { name: 'Nouveaux messages' }).click();
   await page.evaluate(() => window.scrollTo(0, 0));
-  await page.getByRole('tab', { name: 'A vérifier' }).click();
+  await clickTabAndTriggerDisclose(page, 'A vérifier');
   await page.getByRole('heading', { name: 'Dossier sans activité' }).click();
   await page.evaluate(() => window.scrollTo(0, 0));
-  await page.getByRole('tab', { name: 'Activité récente' }).click();
+  await clickTabAndTriggerDisclose(page, 'Activité récente');
   await page.locator('#dossiers-activite-recente').getByRole('heading', { name: 'Activité récente' }).click();
 
   await page.getByRole('link', { name: 'Se déconnecter' }).click();
@@ -50,17 +58,17 @@ test('dashboard tabs for RT', async ({page, context}) => {
 
   // Attendre la navigation après connexion
   await page.waitForURL('**/bo/**', { timeout: 10000 });
-  await page.getByRole('tab', { name: 'Accueil' }).click();
+  await clickTabAndTriggerDisclose(page, 'Accueil');
   await page.getByRole('heading', { name: 'Vos dernières actions' }).click();
-  await page.getByRole('tab', { name: 'Nouveaux dossiers' }).click();
+  await clickTabAndTriggerDisclose(page, 'Nouveaux dossiers');
   await page.getByRole('heading', { name: 'Dossiers déposés depuis le formulaire usager' }).click();
-  await page.getByRole('tab', { name: 'A fermer' }).click();
+  await clickTabAndTriggerDisclose(page, 'A fermer');
   await page.getByRole('heading', { name: 'Dossiers fermés par tous les' }).click();
-  await page.getByRole('tab', { name: 'Messages usagers' }).click();
+  await clickTabAndTriggerDisclose(page, 'Messages usagers');
   await page.getByRole('heading', { name: 'Nouveaux messages' }).click();
-  await page.getByRole('tab', { name: 'A vérifier' }).click();
+  await clickTabAndTriggerDisclose(page, 'A vérifier');
   await page.getByRole('heading', { name: 'Dossier sans activité' }).click();
-  await page.getByRole('tab', { name: 'Activité récente' }).click();
+  await clickTabAndTriggerDisclose(page, 'Activité récente');
   await page.locator('#dossiers-activite-recente').getByRole('heading', { name: 'Activité récente' }).click();
 
   await page.getByRole('link', { name: 'Se déconnecter' }).click();
@@ -82,15 +90,15 @@ test('dashboard tabs for Agent', async ({page, context}) => {
 
   // Attendre la navigation après connexion
   await page.waitForURL('**/bo/**', { timeout: 10000 });
-  await page.getByRole('tab', { name: 'Accueil' }).click();
+  await clickTabAndTriggerDisclose(page, 'Accueil');
   await page.getByRole('heading', { name: 'Vos dernières actions' }).click();
-  await page.getByRole('tab', { name: 'Nouveaux dossiers' }).click();
+  await clickTabAndTriggerDisclose(page, 'Nouveaux dossiers');
   await page.getByRole('heading', { name: 'Nouveaux dossiers' }).click();
-  await page.getByRole('tab', { name: 'Messages usagers' }).click();
+  await clickTabAndTriggerDisclose(page, 'Messages usagers');
   await page.getByRole('heading', { name: 'Nouveaux messages' }).click();
-  await page.getByRole('tab', { name: 'A vérifier' }).click();
+  await clickTabAndTriggerDisclose(page, 'A vérifier');
   await page.getByRole('heading', { name: 'Dossier sans activité' }).click();
-  await page.getByRole('tab', { name: 'Activité récente' }).click();
+  await clickTabAndTriggerDisclose(page, 'Activité récente');
   await page.locator('#dossiers-activite-recente').getByRole('heading', { name: 'Activité récente' }).click();
 
   await page.getByRole('link', { name: 'Se déconnecter' }).click();


### PR DESCRIPTION
## Ticket

#5719   

## Description
En utilisant l'événement `click` pour changer d'onglet, la navigation au clavier changeait d'onglet mais ne chargeait pas le contenu (sauf en appuyant sur Entrée).

## Changements apportés
Utilisation de l'événement `dsfr.disclose` pour déclencher le chargement de contenu des onglets

## Pré-requis
`make npm-watch`

## Tests
- [ ] Vérifier le passage d'un onglet à l'autre en navigant au clavier et à la souris
