### PR TITLE
[BO - Dashboard] Optimisation sur le count pour le panel "Dossiers fermés par les communes"

### DIFF
--- a/migrations/Version20260416135512.php
+++ b/migrations/Version20260416135512.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260416135512 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout d\'indexs.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_affectation_statut_partner_sig ON affectation (statut, partner_id, signalement_id)');
+        $this->addSql('CREATE INDEX idx_partner_type ON partner (type)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_affectation_statut_partner_sig ON affectation');
+        $this->addSql('DROP INDEX idx_partner_type ON partner');
+    }
+}

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -16,6 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: AffectationRepository::class)]
 #[ORM\UniqueConstraint(name: 'unique_affectation_signalement_partner', columns: ['signalement_id', 'partner_id'])]
+#[ORM\Index(columns: ['statut', 'partner_id', 'signalement_id'], name: 'idx_affectation_statut_partner_sig')]
 class Affectation implements EntityHistoryInterface
 {
     #[ORM\Id]

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: PartnerRepository::class)]
 #[ORM\Index(columns: ['territory_id'], name: 'idx_partner_territory_id')]
+#[ORM\Index(columns: ['type'], name: 'idx_partner_type')]
 #[ORM\HasLifecycleCallbacks()]
 #[UniqueEntity(
     fields: ['email', 'territory', 'isArchive'],

--- a/src/Repository/Query/Dashboard/DossiersQuery.php
+++ b/src/Repository/Query/Dashboard/DossiersQuery.php
@@ -445,13 +445,19 @@ class DossiersQuery
             tabQueryParameters: $tabQueryParameters
         );
 
-        $qb->select('COUNT(DISTINCT s.id)')
-            ->innerJoin('s.affectations', 'a')
-            ->innerJoin('a.partner', 'p')
-            ->andWhere('p.type = :partnerType')
-            ->andWhere('a.statut = :closed')
-            ->setParameter('partnerType', PartnerType::COMMUNE_SCHS)
-            ->setParameter('closed', AffectationStatus::CLOSED);
+        $existsAffectationFermeeCommune = $this->entityManager->createQueryBuilder()
+            ->select('1')
+            ->from(Affectation::class, 'a_sub')
+            ->innerJoin('a_sub.partner', 'p_sub')
+            ->where('a_sub.signalement = s')
+            ->andWhere('a_sub.statut = :closed')
+            ->andWhere('p_sub.type = :partnerType')
+            ->getDQL();
+
+        $qb->andWhere($qb->expr()->exists($existsAffectationFermeeCommune))
+            ->select('COUNT(s.id)')
+            ->setParameter('closed', AffectationStatus::CLOSED)
+            ->setParameter('partnerType', PartnerType::COMMUNE_SCHS);
 
         return (int) $qb->getQuery()->getSingleScalarResult();
     }


### PR DESCRIPTION
## Ticket

#5735

## Description
La requête count du panel "Dossiers fermés par les communes" n'avait pas fait l'objet d'optimisations et prenait autour de 13 seconde en SA.
- Ajout de deux index
- Utilisation d'une sous requête `EXIST`

Résultat, passage a une durée autour de 40ms
<img width="973" height="213" alt="Screenshot 2026-04-17 at 10-22-27 Symfony Profiler" src="https://github.com/user-attachments/assets/264d9486-c493-40c4-8b5a-098d1e7b708f" />

## Pré-requis
`make execute-migration name=Version20260416135512 direction=up`

## Tests
- [ ] Se connecter en SA sur base de prod et vérifier dans le profiler le temps d’exécution de la requête dont l’aperçu est partagé au-dessus.
