### PR TITLE
[BO - Tableau de bord] Accessibilité : zoom sur l'avatar texte / libellé du lien vers les dossier

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -866,41 +866,11 @@ ul + p {
     font-weight: bold;
 }
 
-.avatar-124 {
-    width: 124px;
-    height: 124px;
-    font-size: 62px;
-}
-
-.avatar-80 {
-    width: 80px;
-    height: 80px;
-    font-size: 62px;
-}
-
-.avatar-74 {
-    width: 74px;
-    height: 74px;
-    font-size: 37px;
-}
-
-.avatar-45 {
-    width: 45px;
-    height: 45px;
-    font-size: 23px;
-}
-
-.avatar-26 {
-    width: 26px;
-    height: 26px;
-    font-size: 13px;
-}
-
-.avatar-18 {
-    width: 18px;
-    height: 18px;
-    font-size: 8px;
-}
+.avatar-124 {font-size: 62px; width: 2em; height: 2em; }
+.avatar-80 { font-size: 50px; width: 1.6em; height: 1.6em; }
+.avatar-74 { font-size: 37px; width: 2em; height: 2em; }
+.avatar-45 {font-size: 23px; width: 2em; height: 2em; }
+.avatar-18 { font-size: 9px; width: 2em; height: 2em; }
 
 .search-checkbox-container {
     position: relative;

--- a/templates/back/dashboard/_header.html.twig
+++ b/templates/back/dashboard/_header.html.twig
@@ -8,8 +8,9 @@
                         <strong class="fr-h2 fr-mt-1v">Bonjour {{ app.user.prenom }}</strong>
                         <p class="fr-mt-1v fr-ml-1v">
                             Bienvenue sur votre tableau de bord !
-                            <br>
+                            {# <br>
                             <span class="fr-text--xs">Les compteurs de l'intitulé des onglets se mettent à jour toutes les 5 minutes.</span>
+                                #}
                         </p>
                     </div>
                 </div>

--- a/templates/back/dashboard/_header.html.twig
+++ b/templates/back/dashboard/_header.html.twig
@@ -8,9 +8,8 @@
                         <strong class="fr-h2 fr-mt-1v">Bonjour {{ app.user.prenom }}</strong>
                         <p class="fr-mt-1v fr-ml-1v">
                             Bienvenue sur votre tableau de bord !
-                            {# <br>
+                            <br>
                             <span class="fr-text--xs">Les compteurs de l'intitulé des onglets se mettent à jour toutes les 5 minutes.</span>
-                                #}
                         </p>
                     </div>
                 </div>

--- a/templates/back/dashboard/components/_card.html.twig
+++ b/templates/back/dashboard/components/_card.html.twig
@@ -17,7 +17,7 @@
                             </div>
                         {% endfor %}
                         <div class="fr-col-auto fr-py-10v">
-                            <a href="{{ link }}" class="fr-btn fr-icon-arrow-right-line"></a>
+                            <a href="{{ link }}" class="fr-btn fr-icon-arrow-right-line">Accéder au dossier</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Ticket

#5721 
#5723

## Description
#5721 
- Ajout du libellé "Accéder au dossier" sur les lien "boutons carrés en forme de flèche" sur chaqué élément de liste des panels du dashboard

#5723
- Modification du CSS des avatars pour que le contour s'adapte aussi au zoom et ainsi régler le problème de débordement du texte (généralisé pour toute les taille d'avar, suppression d'une taille inutilisé du CSS)

## Pré-requis
`make npm-watch`

## Tests
- [ ] Vérifier l'affichage des avatar en mode texte et photo
