### PR TITLE
[BO - Esabora] SCHS - Récupérer des suivis (events) uniquement après acceptation du dossier 

### DIFF
--- a/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command\Cron;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\AffectationStatus;
 use App\Entity\Suivi;
 use App\Messenger\Message\Esabora\DossierMessageSCHS;
 use App\Repository\AffectationRepository;
@@ -80,6 +81,7 @@ class SynchronizeEsaboraSCHSCommand extends AbstractSynchronizeEsaboraCommand
     {
         $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
             partnerType: DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
+            affectationStatus: AffectationStatus::ACCEPTED
         );
         $this->existingEvents = $this->suiviRepository->findExistingEventsForSCHS();
         $count = 0;

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -66,6 +66,7 @@ class AffectationRepository extends ServiceEntityRepository
         ?bool $isSynchronized = true,
         ?string $uuidSignalement = null,
         ?Territory $territory = null,
+        ?AffectationStatus $affectationStatus = null,
     ): array {
         $qb = $this->createQueryBuilder('a');
         $qb->select('a AS affectation', 's.uuid AS signalement_uuid');
@@ -109,6 +110,12 @@ class AffectationRepository extends ServiceEntityRepository
             $qb->andWhere($esaboraCondition);
         } else {
             $qb->andWhere($qb->expr()->not($esaboraCondition));
+        }
+
+        if (null !== $affectationStatus) {
+            $qb
+                ->andWhere('a.statut = :status')
+                ->setParameter('status', $affectationStatus);
         }
 
         return $qb->getQuery()->getResult();


### PR DESCRIPTION
## Ticket

#5713   

## Description
Ajout filtre pour conditionner la récupération à l'acceptation du dossier

## Changements apportés
* Ajout filtre 

## Pré-requis
`make mock-restart`
`make worker-stop && make worker-start`
Fiche avec des events mockés http://localhost:8080/bo/signalements/00000000-0000-0000-2024-000000000010

## Tests
- [ ] Supprimer l'affectation Partenaire 13-10 EPCI connecté au SCHS puis reaffecter dans la foulée
- [ ] Exécuter la commande `make console app="sync-esabora-schs"`, comme l'affectation est en attente, aucun suivi n'est récupéré
- [ ] Changer le statut de l'affectation en base de données en `EN_COURS`
- [ ] Reexécuter la commande, vérifier la création des suivis provenant du WS
