### PR TITLE
[Tech - Export] Changer de lib pour eviter les erreurs mémoires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "maennchen/zipstream-php": "^3.2",
         "nelmio/api-doc-bundle": "^5",
         "nelmio/cors-bundle": "^2.2",
+        "openspout/openspout": "^5",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpoffice/phpspreadsheet": "^5",
         "phpstan/phpdoc-parser": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "989e1f3989c55d2c99840fef21ca2172",
+    "content-hash": "628bf34cabf73c4d0ecba7dd5307842f",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.379.0",
+            "version": "3.379.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a50c3cc2c59f5ebeb56cbe170e6f144034b252b6"
+                "reference": "261bfa48bb4dc0d9a8d0dcb5af7c329d97de7acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a50c3cc2c59f5ebeb56cbe170e6f144034b252b6",
-                "reference": "a50c3cc2c59f5ebeb56cbe170e6f144034b252b6",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/261bfa48bb4dc0d9a8d0dcb5af7c329d97de7acc",
+                "reference": "261bfa48bb4dc0d9a8d0dcb5af7c329d97de7acc",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.379.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.379.1"
             },
-            "time": "2026-04-13T18:11:10+00:00"
+            "time": "2026-04-16T18:06:02+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -3270,16 +3270,16 @@
         },
         {
             "name": "league/flysystem-bundle",
-            "version": "3.6.2",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-bundle.git",
-                "reference": "123ab96910177751faf3b6cc85eecc360ec12a1f"
+                "reference": "5eb41be38fc3759f74c9e458a6a5f0ef5f49284a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-bundle/zipball/123ab96910177751faf3b6cc85eecc360ec12a1f",
-                "reference": "123ab96910177751faf3b6cc85eecc360ec12a1f",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-bundle/zipball/5eb41be38fc3759f74c9e458a6a5f0ef5f49284a",
+                "reference": "5eb41be38fc3759f74c9e458a6a5f0ef5f49284a",
                 "shasum": ""
             },
             "require": {
@@ -3334,9 +3334,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem-bundle/issues",
-                "source": "https://github.com/thephpleague/flysystem-bundle/tree/3.6.2"
+                "source": "https://github.com/thephpleague/flysystem-bundle/tree/3.7.0"
             },
-            "time": "2026-02-05T15:26:57+00:00"
+            "time": "2026-03-28T22:14:56+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -4344,6 +4344,99 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
             "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "openspout/openspout",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openspout/openspout.git",
+                "reference": "fffe7b4a595f7bef0a505037e416c5a3a8aa11c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/fffe7b4a595f7bef0a505037e416c5a3a8aa11c3",
+                "reference": "fffe7b4a595f7bef0a505037e416c5a3a8aa11c3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-xmlreader": "*",
+                "ext-zip": "*",
+                "php": "~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "ext-zlib": "*",
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "infection/infection": "^0.32.6",
+                "phpbench/phpbench": "^1.6.1",
+                "phpstan/phpstan": "^2.1.47",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^13.1.3"
+            },
+            "suggest": {
+                "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
+                "ext-mbstring": "To handle non UTF-8 CSV files (if \"iconv\" is not already installed)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenSpout\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Adrien Loison",
+                    "email": "adrien@box.com"
+                }
+            ],
+            "description": "PHP Library to read and write spreadsheet files (CSV, XLSX and ODS), in a fast and scalable way",
+            "homepage": "https://github.com/openspout/openspout",
+            "keywords": [
+                "OOXML",
+                "csv",
+                "excel",
+                "memory",
+                "odf",
+                "ods",
+                "office",
+                "open",
+                "php",
+                "read",
+                "scale",
+                "spreadsheet",
+                "stream",
+                "write",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/openspout/openspout/issues",
+                "source": "https://github.com/openspout/openspout/tree/v5.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Slamdunk",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-16T12:10:07+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -9303,7 +9396,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -9361,7 +9454,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9385,7 +9478,7 @@
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
@@ -9449,7 +9542,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9473,7 +9566,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -9536,7 +9629,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9560,7 +9653,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -9621,7 +9714,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9645,7 +9738,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -9706,7 +9799,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9730,7 +9823,7 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
@@ -9786,7 +9879,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9810,7 +9903,7 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
@@ -9866,7 +9959,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9890,7 +9983,7 @@
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
@@ -9946,7 +10039,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9970,7 +10063,7 @@
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
@@ -10029,7 +10122,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.36.0"
             },
             "funding": [
                 {

--- a/config/reference.php
+++ b/config/reference.php
@@ -1556,18 +1556,134 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type FlysystemConfig = array{
  *     storages?: array<string, array{ // Default: []
- *         adapter: scalar|Param|null,
+ *         adapter?: scalar|Param|null, // DEPRECATED: Use the new config format instead (e.g. "local:" instead of "adapter: local")
  *         options?: list<mixed>,
- *         visibility?: scalar|Param|null, // Default: null
- *         directory_visibility?: scalar|Param|null, // Default: null
- *         retain_visibility?: bool|Param|null, // Default: null
- *         case_sensitive?: bool|Param, // Default: true
- *         disable_asserts?: bool|Param, // Default: false
+ *         asyncaws?: array{
+ *             client?: scalar|Param|null, // The AsyncAws S3 client service name
+ *             bucket?: scalar|Param|null, // The name of the AWS S3 bucket
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *         },
+ *         aws?: array{
+ *             client?: scalar|Param|null, // The AWS S3 client service name
+ *             bucket?: scalar|Param|null, // The name of the AWS S3 bucket
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *             options?: list<mixed>,
+ *             streamReads?: bool|Param, // Whether to use streaming for file reads // Default: true
+ *         },
+ *         azure?: array{
+ *             client?: scalar|Param|null, // The Azure Blob Storage client service name
+ *             container?: scalar|Param|null, // The name of the Azure Blob Storage container
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all blob names // Default: ""
+ *         },
+ *         ftp?: array{
+ *             host?: scalar|Param|null, // FTP host
+ *             username?: scalar|Param|null, // FTP username
+ *             password?: scalar|Param|null, // FTP password
+ *             port?: int|Param, // FTP port number // Default: 21
+ *             root?: scalar|Param|null, // FTP root directory // Default: ""
+ *             passive?: bool|Param, // Use passive mode // Default: true
+ *             ssl?: bool|Param, // Use SSL/TLS encryption // Default: false
+ *             timeout?: int|Param, // Connection timeout in seconds // Default: 90
+ *             ignore_passive_address?: scalar|Param|null, // Ignore passive address // Default: null
+ *             utf8?: bool|Param, // Enable UTF8 mode // Default: false
+ *             transfer_mode?: scalar|Param|null, // Transfer mode (FTP_ASCII or FTP_BINARY constante on ftp extension) // Default: null
+ *             system_type?: null|"windows"|"unix"|Param, // FTP system type // Default: null
+ *             timestamps_on_unix_listings_enabled?: bool|Param, // Enable timestamps on Unix listings // Default: false
+ *             recurse_manually?: bool|Param, // Recurse directories manually // Default: true
+ *             use_raw_list_options?: bool|Param|null, // Use raw list options // Default: null
+ *             connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
+ *             permissions?: array{ // Unix permissions configuration for files and directories
+ *                 file?: array{ // File permissions
+ *                     public?: int|Param, // Public file permissions // Default: 420
+ *                     private?: int|Param, // Private file permissions // Default: 384
+ *                 },
+ *                 dir?: array{ // Directory permissions
+ *                     public?: int|Param, // Public directory permissions // Default: 493
+ *                     private?: int|Param, // Private directory permissions // Default: 448
+ *                 },
+ *             },
+ *         },
+ *         gcloud?: array{
+ *             client?: scalar|Param|null, // The Google Cloud Storage client service name
+ *             bucket?: scalar|Param|null, // The name of the Google Cloud Storage bucket
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *             visibility_handler?: scalar|Param|null, // Optional visibility handler service name // Default: null
+ *             streamReads?: bool|Param, // Whether to use streaming for file reads // Default: false
+ *         },
+ *         gridfs?: array{
+ *             bucket?: scalar|Param|null, // GridFS bucket service name (if using an existing bucket service) // Default: null
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all file names // Default: ""
+ *             database?: scalar|Param|null, // MongoDB database name // Default: null
+ *             doctrine_connection?: scalar|Param|null, // Doctrine MongoDB connection name (mutually exclusive with mongodb_uri)
+ *             mongodb_uri?: scalar|Param|null, // MongoDB connection URI (mutually exclusive with doctrine_connection)
+ *             mongodb_uri_options?: list<mixed>,
+ *             mongodb_driver_options?: list<mixed>,
+ *         },
+ *         lazy?: array{ // Lazy adapter for runtime storage selection
+ *             source?: scalar|Param|null, // The service name of the storage to use at runtime
+ *         },
+ *         local?: array{
+ *             directory?: scalar|Param|null, // Directory path for local storage
+ *             lock?: int|Param, // Lock flags for file operations // Default: 0
+ *             skip_links?: bool|Param, // Whether to skip symbolic links // Default: false
+ *             lazy_root_creation?: bool|Param, // Whether to create the root directory lazily // Default: false
+ *             permissions?: array{ // Unix permissions configuration for files and directories
+ *                 file?: array{ // File permissions
+ *                     public?: int|Param, // Public file permissions // Default: 420
+ *                     private?: int|Param, // Private file permissions // Default: 384
+ *                 },
+ *                 dir?: array{ // Directory permissions
+ *                     public?: int|Param, // Public directory permissions // Default: 493
+ *                     private?: int|Param, // Private directory permissions // Default: 448
+ *                 },
+ *             },
+ *         },
+ *         memory?: array<mixed>,
+ *         sftp?: array{
+ *             host?: scalar|Param|null, // SFTP host
+ *             username?: scalar|Param|null, // SFTP username
+ *             password?: scalar|Param|null, // SFTP password (optional if using private key) // Default: null
+ *             privateKey?: scalar|Param|null, // Path to private key file or private key content // Default: null
+ *             passphrase?: scalar|Param|null, // Private key passphrase // Default: null
+ *             port?: int|Param, // SFTP port number // Default: 22
+ *             timeout?: int|Param, // Connection timeout in seconds // Default: 90
+ *             hostFingerprint?: scalar|Param|null, // Host fingerprint for verification // Default: null
+ *             connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
+ *             preferredAlgorithms?: list<mixed>,
+ *             root?: scalar|Param|null, // SFTP root directory // Default: ""
+ *             permissions?: array{ // Unix permissions configuration for files and directories
+ *                 file?: array{ // File permissions
+ *                     public?: int|Param, // Public file permissions // Default: 420
+ *                     private?: int|Param, // Private file permissions // Default: 384
+ *                 },
+ *                 dir?: array{ // Directory permissions
+ *                     public?: int|Param, // Public directory permissions // Default: 493
+ *                     private?: int|Param, // Private directory permissions // Default: 448
+ *                 },
+ *             },
+ *         },
+ *         webdav?: array{
+ *             client?: scalar|Param|null, // The WebDAV client service name
+ *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all paths // Default: ""
+ *             visibility_handling?: "throw"|"ignore"|Param, // How to handle visibility operations // Default: "throw"
+ *             manual_copy?: bool|Param, // Whether to handle copy operations manually // Default: false
+ *             manual_move?: bool|Param, // Whether to handle move operations manually // Default: false
+ *         },
+ *         bunnycdn?: array{
+ *             client?: scalar|Param|null, // The BunnyCDN client service name
+ *             pull_zone?: scalar|Param|null, // The BunnyCDN pull zone name // Default: ""
+ *         },
+ *         service?: scalar|Param|null, // Reference to a custom adapter service (alternative to registered adapter types)
+ *         visibility?: scalar|Param|null, // Default visibility for files // Default: null
+ *         directory_visibility?: scalar|Param|null, // Default visibility for directories // Default: null
+ *         retain_visibility?: scalar|Param|null, // Keeps the original file visibility (public/private) when copying or moving. // Default: null
+ *         case_sensitive?: bool|Param, // Deprecated: The "case_sensitive" option is deprecated and will be removed in 4.0. // Default: true
+ *         disable_asserts?: bool|Param, // Deprecated: The "disable_asserts" option is deprecated and will be removed in 4.0. // Default: false
  *         public_url?: list<scalar|Param|null>,
- *         path_normalizer?: scalar|Param|null, // Default: null
- *         public_url_generator?: scalar|Param|null, // Default: null
- *         temporary_url_generator?: scalar|Param|null, // Default: null
- *         read_only?: bool|Param, // Default: false
+ *         path_normalizer?: scalar|Param|null, // Path normalizer service name (should implement League\Flysystem\PathNormalizer) // Default: null
+ *         public_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities and public_url option, a public URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\PublicUrlGenerator) // Default: null
+ *         temporary_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities, a temporary URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\TemporaryUrlGenerator) // Default: null
+ *         read_only?: bool|Param, // Converts a file system to read-only // Default: false
  *     }>,
  * }
  * @psalm-type SentryConfig = array{

--- a/src/Messenger/MessageHandler/ListExportMessageHandler.php
+++ b/src/Messenger/MessageHandler/ListExportMessageHandler.php
@@ -12,8 +12,6 @@ use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\Export\SignalementExportLoader;
 use App\Service\TimezoneProvider;
 use App\Service\UploadHandlerService;
-use PhpOffice\PhpSpreadsheet\Writer\Csv;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -41,46 +39,38 @@ readonly class ListExportMessageHandler
             $selectedColumns = $listExportMessage->getSelectedColumns();
             $format = $listExportMessage->getFormat();
 
-            $spreadsheet = $this->signalementExportLoader->load($user, $format, $filters, $selectedColumns);
-            if (ListExportMessage::FORMAT_CSV === $format) {
-                $writer = new Csv($spreadsheet);
-            } elseif (ListExportMessage::FORMAT_XLSX === $format) {
-                $writer = new Xlsx($spreadsheet);
-            }
+            $timezone = $user->getFirstTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
+            $datetimeStr = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone($timezone))->format('Ymd-His');
+            $uuid = Uuid::v4();
+            $filename = 'export-histologe-'.$listExportMessage->getUserId().'-'.$datetimeStr.'-'.$uuid.'.'.$format;
+            $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
 
-            if (isset($writer)) {
-                $timezone = $user->getFirstTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
-                $datetimeStr = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone($timezone))->format('Ymd-His');
-                $uuid = Uuid::v4();
-                $filename = 'export-histologe-'.$listExportMessage->getUserId().'-'.$datetimeStr.'-'.$uuid.'.'.$format;
-                $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
-                $writer->save($tmpFilepath);
+            $this->signalementExportLoader->load($user, $format, $tmpFilepath, $filters, $selectedColumns);
 
-                $filename = $this->uploadHandlerService->uploadFromFilename($filename);
-                if ($filename) {
-                    $file = $this->fileManager->createOrUpdate(
-                        filename: $filename,
-                        title: $filename,
-                        user: $user,
-                        flush: true,
-                        documentType: DocumentType::EXPORT
-                    );
+            $filename = $this->uploadHandlerService->uploadFromFilename($filename);
+            if ($filename) {
+                $file = $this->fileManager->createOrUpdate(
+                    filename: $filename,
+                    title: $filename,
+                    user: $user,
+                    flush: true,
+                    documentType: DocumentType::EXPORT
+                );
 
-                    $this->notificationMailerRegistry->send(
-                        new NotificationMail(
-                            type: NotificationMailerType::TYPE_DOWNLOAD_EXPORT,
-                            to: $user->getEmail(),
-                            params: [
-                                'filename' => $filename,
-                                'file_uuid' => $file->getUuid(),
-                                'message' => 'Un export de la liste des signalements est disponible.',
-                                'button_text' => 'Afficher l\'export',
-                            ]
-                        )
-                    );
-                } else {
-                    $this->logger->error('There was an issue generating your export');
-                }
+                $this->notificationMailerRegistry->send(
+                    new NotificationMail(
+                        type: NotificationMailerType::TYPE_DOWNLOAD_EXPORT,
+                        to: $user->getEmail(),
+                        params: [
+                            'filename' => $filename,
+                            'file_uuid' => $file->getUuid(),
+                            'message' => 'Un export de la liste des signalements est disponible.',
+                            'button_text' => 'Afficher l\'export',
+                        ]
+                    )
+                );
+            } else {
+                $this->logger->error('There was an issue generating your export');
             }
         } catch (\Throwable $exception) {
             $this->logger->error(

--- a/src/Service/Signalement/Export/SignalementExportLoader.php
+++ b/src/Service/Signalement/Export/SignalementExportLoader.php
@@ -6,18 +6,19 @@ use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Messenger\Message\ListExportMessage;
 use Doctrine\DBAL\Exception;
-use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
-use PhpOffice\PhpSpreadsheet\Shared\Date as ExcelDate;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Writer\CSV\Options as CsvOptions;
+use OpenSpout\Writer\CSV\Writer as CsvWriter;
+use OpenSpout\Writer\XLSX\Writer as XlsxWriter;
 
 readonly class SignalementExportLoader
 {
-    public const int CHUNK_SIZE = 1000;
     public const array DATE_COLUMNS = ['createdAt', 'dateVisite', 'modifiedAt', 'closedAt', 'infoProcedureBailDate'];
 
     public function __construct(
-        private SignalementManager $signalementManager,
+        private readonly SignalementManager $signalementManager,
     ) {
     }
 
@@ -27,10 +28,15 @@ readonly class SignalementExportLoader
      *
      * @throws Exception
      */
-    public function load(User $user, string $format, ?array $filters, ?array $selectedColumns = null): Spreadsheet
+    public function load(User $user, string $format, string $outputFilePath, ?array $filters, ?array $selectedColumns = null): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        if (ListExportMessage::FORMAT_CSV === $format) {
+            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        } else {
+            $writer = new XlsxWriter();
+        }
+
+        $writer->openToFile($outputFilePath);
 
         $keysToRemove = [];
         $headers = SignalementExportHeader::getHeaders();
@@ -38,11 +44,9 @@ readonly class SignalementExportLoader
             $selectedColumns = [];
         }
         $headers = $this->getHeadersWithSelectedColumns($headers, $keysToRemove, $selectedColumns);
-        $sheet->fromArray([$headers]);
+        $writer->addRow($this->buildRow(array_values($headers)));
 
-        $rowIndex = 2;
-        $hasFormattedDateColumns = false;
-        $counter = 0;
+        $dateStyle = new Style(format: 'DD/MM/YYYY');
         foreach ($this->signalementManager->findSignalementAffectationIterable($user, $filters, $selectedColumns) as $signalementExportItem) {
             $rowArray = get_object_vars($signalementExportItem);
 
@@ -53,37 +57,32 @@ readonly class SignalementExportLoader
                 }
             }
 
-            if (ListExportMessage::FORMAT_XLSX === $format) {
-                foreach (self::DATE_COLUMNS as $key) {
-                    if (!empty($rowArray[$key])) {
-                        $dateTime = \DateTimeImmutable::createFromFormat('d/m/Y', $rowArray[$key]);
-                        if ($dateTime) {
-                            $rowArray[$key] = ExcelDate::PHPToExcel($dateTime);
-                        }
+            $cells = [];
+            foreach ($rowArray as $key => $value) {
+                if (ListExportMessage::FORMAT_XLSX === $format && \in_array($key, self::DATE_COLUMNS, true) && !empty($value)) {
+                    $dateTime = \DateTimeImmutable::createFromFormat('d/m/Y', $value);
+                    if ($dateTime) {
+                        $cells[] = Cell::fromValue($dateTime, $dateStyle);
+                        continue;
                     }
                 }
-
-                if (!$hasFormattedDateColumns) {
-                    $keys = array_keys($rowArray);
-                    foreach (self::DATE_COLUMNS as $key) {
-                        if (($i = array_search($key, $keys, true)) !== false) {
-                            $columnIndex = Coordinate::stringFromColumnIndex($i + 1);
-                            $sheet->getStyle($columnIndex)->getNumberFormat()->setFormatCode(NumberFormat::FORMAT_DATE_DDMMYYYY);
-                        }
-                    }
-                    $hasFormattedDateColumns = true;
-                }
+                $cells[] = Cell::fromValue($value);
             }
 
-            $sheet->fromArray([$rowArray], null, 'A'.$rowIndex++);
-
-            if (0 === ++$counter % self::CHUNK_SIZE) {
-                $spreadsheet->garbageCollect();
-            }
+            $writer->addRow(new Row($cells));
         }
-        $spreadsheet->garbageCollect();
 
-        return $spreadsheet;
+        $writer->close();
+    }
+
+    /**
+     * @param array<string> $values
+     */
+    private function buildRow(array $values): Row
+    {
+        $cells = array_map(static fn ($v) => Cell::fromValue($v), $values);
+
+        return new Row($cells);
     }
 
     /**

--- a/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
@@ -5,9 +5,12 @@ namespace App\Tests\Unit\Service\Signalement\Export;
 use App\Dto\SignalementExport;
 use App\Entity\User;
 use App\Manager\SignalementManager;
+use App\Service\Signalement\Export\SignalementExportHeader;
 use App\Service\Signalement\Export\SignalementExportLoader;
 use App\Tests\UserHelper;
-use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use OpenSpout\Reader\CSV\Options as CsvReaderOptions;
+use OpenSpout\Reader\CSV\Reader as CsvReader;
+use OpenSpout\Reader\XLSX\Reader as XlsxReader;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -16,35 +19,70 @@ class SignalementExportLoaderTest extends TestCase
     use UserHelper;
 
     /** @dataProvider provideFileFormat */
-    public function testLoad(string $formatExtension, string $formatCell): void
+    public function testLoad(string $format): void
     {
         /** @var MockObject&SignalementManager */
         $signalementManager = $this->createMock(SignalementManager::class);
         $filters = [];
         $user = $this->getUserFromRole(User::ROLE_ADMIN);
+        $selectedColumns = ['REFERENCE', 'CREATED_AT', 'STATUT'];
 
         $signalementExports = [
-            new SignalementExport(reference: '2023-01', createdAt: '31-03-2023', statut: 'nouveau'),
-            new SignalementExport(reference: '2023-02', createdAt: '31-03-2023', statut: 'nouveau'),
+            new SignalementExport(reference: '2023-01', createdAt: '31/03/2023', statut: 'nouveau'),
+            new SignalementExport(reference: '2023-02', createdAt: '31/03/2023', statut: 'nouveau'),
         ];
 
         $signalementManager->expects($this->once())
             ->method('findSignalementAffectationIterable')
-            ->with($user, $filters)
+            ->with($user, $filters, $selectedColumns)
             ->willReturn($this->getSignalementExportGenerator($signalementExports));
 
-        $loader = new SignalementExportLoader($signalementManager);
-        $spreadsheet = $loader->load($user, $formatExtension, $filters, ['REFERENCE', 'CREATED_AT', 'STATUT']);
-        $this->assertEquals('Référence', $spreadsheet->getActiveSheet()->getCell('A1')->getValue());
-        $this->assertEquals('2023-01', $spreadsheet->getActiveSheet()->getCell('A2')->getValue());
-        $style = $spreadsheet->getActiveSheet()->getStyle('A2');
-        $formatCode = $style->getNumberFormat()->getFormatCode();
-        $this->assertEquals('General', $formatCode);
+        $tmpFile = sys_get_temp_dir().'/export_test_'.uniqid().'.'.$format;
 
-        $this->assertEquals('Déposé le', $spreadsheet->getActiveSheet()->getCell('B1')->getValue());
-        $style = $spreadsheet->getActiveSheet()->getStyle('B2');
-        $formatCode = $style->getNumberFormat()->getFormatCode();
-        $this->assertEquals($formatCell, $formatCode);
+        $loader = new SignalementExportLoader($signalementManager);
+        $loader->load($user, $format, $tmpFile, $filters, $selectedColumns);
+
+        $rows = $this->readFile($tmpFile, $format);
+        unlink($tmpFile);
+
+        $this->assertEquals('Référence', $rows[0][0]);
+        $this->assertEquals('Déposé le', $rows[0][1]);
+        $this->assertEquals('2023-01', $rows[1][0]);
+
+        if ('xlsx' === $format) {
+            $this->assertInstanceOf(\DateTimeInterface::class, $rows[1][1]);
+        } else {
+            $this->assertEquals('31/03/2023', $rows[1][1]);
+        }
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    private function readFile(string $filePath, string $format): array
+    {
+        $rows = [];
+
+        if ('csv' === $format) {
+            $reader = new CsvReader(new CsvReaderOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        } else {
+            $reader = new XlsxReader();
+        }
+
+        $reader->open($filePath);
+        foreach ($reader->getSheetIterator() as $sheet) {
+            foreach ($sheet->getRowIterator() as $row) {
+                $rowValues = [];
+                foreach ($row->cells as $cell) {
+                    $rowValues[] = $cell->getValue();
+                }
+                $rows[] = $rowValues;
+            }
+            break;
+        }
+        $reader->close();
+
+        return $rows;
     }
 
     /**
@@ -59,7 +97,7 @@ class SignalementExportLoaderTest extends TestCase
 
     protected function provideFileFormat(): \Generator
     {
-        yield 'export with xlsx' => ['xlsx', NumberFormat::FORMAT_DATE_DDMMYYYY];
-        yield 'export with csv' => ['csv', 'General'];
+        yield 'export with xlsx' => ['xlsx'];
+        yield 'export with csv' => ['csv'];
     }
 }


### PR DESCRIPTION
## Ticket

#5741

## Description
Migration des export de liste de signalement de la lib `phpspreadsheet` vers `openspout` afin d'éviter les erreur mémoires sur des gros exports.
Le résultat est très net : 
- Export de tous les signalement en cours tous territoire confondus avec toutes les colonnes < 5 minutes, pas d'erreurs.

## Changements apportés
* Ajout de `openspout/openspout`
* Migration des export de  `phpspreadsheet` vers `openspout`

## Pré-requis
`make composer`

## Tests
- [ ] Sur base de prod exporté des territoire complet avec toutes les colonnes cochées.
