### PR TITLE
[BO - Esabora] Message de resynchronisation

### DIFF
--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -281,13 +281,22 @@ class SuiviRepository extends ServiceEntityRepository
     /**
      * @return array<int, Suivi>
      */
-    public function findSuiviByDescription(Signalement $signalement, string $description): array
-    {
+    public function findSuiviByDescription(
+        Signalement $signalement,
+        string $description,
+        ?SuiviCategory $suiviCategory = null,
+    ): array {
         $qb = $this->createQueryBuilder('s');
         $qb->where('s.signalement = :signalement')
             ->andWhere('s.description LIKE :description')
             ->setParameter('signalement', $signalement)
             ->setParameter('description', '%'.$description.'%');
+
+        if (null !== $suiviCategory) {
+            $qb
+                ->andWhere('s.category = :category')
+                ->setParameter('category', SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO);
+        }
 
         return $qb->getQuery()->getResult();
     }

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -22,6 +22,7 @@ use App\Manager\SuiviManager;
 use App\Manager\UserManager;
 use App\Manager\UserSignalementSubscriptionManager;
 use App\Repository\InterventionRepository;
+use App\Repository\SuiviRepository;
 use App\Service\Files\ImageManipulationHandler;
 use App\Service\Files\ZipHelper;
 use App\Service\Interconnection\Esabora\Enum\EsaboraStatus;
@@ -112,6 +113,7 @@ class EsaboraManager
         : '';
 
         $namePartner = $affectation->getPartner()->getNom();
+        $signalement = $affectation->getSignalement();
         switch ($esaboraStatus) {
             case EsaboraStatus::ESABORA_WAIT->value:
                 if (AffectationStatus::WAIT !== $currentStatus) {
@@ -125,7 +127,19 @@ class EsaboraManager
                     $this->affectationManager->updateAffectation($affectation, $user, AffectationStatus::ACCEPTED, $affectation->getPartner());
                     $this->userSignalementSubscriptionManager->createDefaultSubscriptionsForAffectation($affectation);
                     $this->userSignalementSubscriptionManager->flush();
+
+                    /** @var SuiviRepository $suiviRepository */
+                    $suiviRepository = $this->suiviManager->getRepository();
                     $description = 'accepté par '.$namePartner.' via '.$dossierResponse->getNameSI();
+                    $suivis = $suiviRepository->findSuiviByDescription(
+                        $signalement,
+                        'Signalement <b>'.$description,
+                        SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO
+                    );
+
+                    if (count($suivis) > 0) {
+                        $description = 'resynchronisé avec '.$namePartner.' via '.$dossierResponse->getNameSI();
+                    }
                 }
 
                 if ($this->shouldBeClosedViaEsabora($esaboraDossierStatus, $currentStatus)) {

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -3,9 +3,12 @@
 namespace App\Tests\Unit\Service\Esabora;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\SuiviCategory;
 use App\Entity\Intervention;
+use App\Entity\Suivi;
 use App\Entity\User;
 use App\Factory\FileFactory;
 use App\Factory\InterventionFactory;
@@ -14,9 +17,12 @@ use App\Manager\SuiviManager;
 use App\Manager\UserManager;
 use App\Manager\UserSignalementSubscriptionManager;
 use App\Repository\InterventionRepository;
+use App\Repository\SuiviRepository;
 use App\Service\Files\ImageManipulationHandler;
 use App\Service\Files\ZipHelper;
+use App\Service\Interconnection\Esabora\Enum\EsaboraStatus;
 use App\Service\Interconnection\Esabora\EsaboraManager;
+use App\Service\Interconnection\Esabora\Response\DossierResponseInterface;
 use App\Service\Security\FileScanner;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Service\TimezoneProvider;
@@ -344,5 +350,69 @@ class EsaboraManagerTest extends KernelTestCase
         $this->assertEquals(new \DateTimeImmutable('2023-05-03 08:16:00'), $intervention->getScheduledAt());
         $this->assertEquals('SH', $intervention->getDoneBy());
         $this->assertEquals('SH', $intervention->getExternalOperator());
+    }
+
+    /**
+     * @throws \DateInvalidTimeZoneException
+     * @throws \DateMalformedStringException
+     */
+    public function testUpdateStatusAndBuildDescriptionWithResynchronisation(): void
+    {
+        $signalement = $this->getSignalement();
+        $partner = $this->getPartner();
+        $partner->setNom('Partenaire 01-01');
+        $affectation = $this->getAffectation(PartnerType::ARS);
+        $affectation->setPartner($partner);
+        $affectation->setSignalement($signalement);
+        $affectation->setStatut(AffectationStatus::WAIT);
+        $user = $this->getUser([User::ROLE_ADMIN]);
+
+        $dossierResponse = $this->createMock(DossierResponseInterface::class);
+        $dossierResponse->method('getSasEtat')->willReturn(EsaboraStatus::ESABORA_ACCEPTED->value);
+        $dossierResponse->method('getEtat')->willReturn(EsaboraStatus::ESABORA_IN_PROGRESS->value);
+        $dossierResponse->method('getNameSI')->willReturn('SISH');
+        $dossierResponse->method('getDossNum')->willReturn('2023/SISH/0010');
+
+        $suiviRepository = $this->createMock(SuiviRepository::class);
+        $this->suiviManager->method('getRepository')->willReturn($suiviRepository);
+
+        $suiviRepository
+            ->expects($this->once())
+            ->method('findSuiviByDescription')
+            ->with(
+                $signalement,
+                'Signalement <b>accepté par Partenaire 01-01 via SISH',
+                SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO
+            )
+            ->willReturn([new Suivi()]);
+
+        $this->userManager
+            ->expects($this->once())
+            ->method('getSystemUser')
+            ->willReturn($user);
+
+        $esaboraManager = new EsaboraManager(
+            $this->affectationManager,
+            $this->suiviManager,
+            $this->interventionRepository,
+            $this->interventionFactory,
+            $this->eventDispatcher,
+            $this->userManager,
+            $this->logger,
+            $this->entityManager,
+            $this->zipHelper,
+            $this->fileScanner,
+            $this->uploadHandler,
+            $this->imageManipulationHandler,
+            $this->fileFactory,
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizer,
+            $this->workflow,
+            $this->userSignalementSubscriptionManager,
+            true,
+        );
+
+        $description = $esaboraManager->updateStatusAndBuildDescription($affectation, $user, $dossierResponse);
+        $this->assertStringContainsString('resynchronisé avec Partenaire 01-01 via SISH (Dossier 2023/SISH/0010)', $description);
     }
 }


### PR DESCRIPTION
## Ticket

#5754    
<img width="1295" height="894" alt="image" src="https://github.com/user-attachments/assets/981e1296-ce3d-4047-ac03-427b280f29e8" />

## Description
Lors d'une resynchronisation, il faudrait un message plus explicite que le message standard signalement accepté


## Changements apportés
* Permettre le filtrage par `SuiviCategory` dans `findSuiviByDescription`
* Conditionner le nouveau message dans `EsaboraManager`

## Pré-requis
Travailler avec la fiche http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000010 qui a un message d'acceptation

`make mock-restart`

make worker-stop && make worker-consume`

## Tests
- [ ] Désaffecter puis réaffecter le partenaire Partenaire 13-06 ESABORA ARS
- [ ] Exécuter` make sync-sish` et vérifier la présence du message de resynchronisation
