### PR TITLE
[BO - Connexions SI] Fix bug sur la pagination

### DIFF
--- a/src/Form/SearchInterconnexionType.php
+++ b/src/Form/SearchInterconnexionType.php
@@ -63,6 +63,11 @@ class SearchInterconnexionType extends AbstractType
             if (isset($data['page']) && (!is_numeric($data['page']))) {
                 $data['page'] = 1;
             }
+
+            if (isset($data['service']) && isset($data['action'])) {
+                $data['action'] = $data['service'].' - '.$data['action'];
+                unset($data['service']);
+            }
             $event->setData($data);
         });
 


### PR DESCRIPTION
## Ticket

#5755   

## Description
Sur la page BO des connexions SI, bo.signal-logement.beta.gouv.fr/bo/connexions-si/, je filtre sur un événement, je vais en page 2, et j'ai l'erreur `Ce formulaire ne doit pas contenir de champs supplémentaires. `

<img width="1265" height="331" alt="Image" src="https://github.com/user-attachments/assets/141a4437-0716-40de-b21e-288bf4753c7e" />

## Changements apportés
* Dans SearchInterconnexionType, ajout d'un bout de code pour retransformer service et action en une seule donnée dans action

## Pré-requis
Se mettre sur la base de prod

## Tests
- [ ] Vérifier la page BO des connexions SI externes en sélectionnant différents filtres (dont action) et en naviguant entre les pages
