### PR TITLE
[BO - Visite] Ajouter l'heure dans le suivi de visite programmée

### DIFF
--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -150,7 +150,9 @@ class Intervention implements EntityHistoryInterface, EntitySanitizerInterface
     public function getScheduledAtFormated(): string
     {
         if ($this->getScheduledAt()->format('His') > 0) {
-            $timezone = $this->getPartner()?->getTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
+            $timezone = $this->getPartner()?->getTerritory()?->getTimezone()
+                ?? $this->getSignalement()->getTimezone()
+                ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
 
             return $this->getScheduledAt()
                         ->setTimezone(new \DateTimeZone($timezone))

--- a/src/Service/Intervention/InterventionDescriptionGenerator.php
+++ b/src/Service/Intervention/InterventionDescriptionGenerator.php
@@ -34,7 +34,6 @@ class InterventionDescriptionGenerator
         $isInPast = $today > $intervention->getScheduledAt()
             && Intervention::STATUS_DONE === $intervention->getStatus();
         $commentBeforeVisite = !$isInPast ? $intervention->getCommentBeforeVisite() : '';
-        $timezone = $intervention->getSignalement()->getTimezone() ?? 'Europe/Paris';
 
         return \sprintf(
             '%s %s : une %s du logement situé %s %s le %s.<br>La %s %s par %s.%s',
@@ -43,7 +42,7 @@ class InterventionDescriptionGenerator
             $labelVisite,
             $intervention->getSignalement()->getAdresseOccupant(),
             $isInPast ? 'a été effectuée' : 'est prévue',
-            $intervention->getScheduledAt()->setTimezone(new \DateTimeZone($timezone))->format('d/m/Y'),
+            $intervention->getScheduledAtFormated(),
             $labelVisite,
             $isInPast ? 'a été réalisée' : 'sera effectuée',
             $partnerName,

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -469,7 +469,8 @@ trait FixturesHelper
         return (new Territory())
             ->setName($name)
             ->setZip($zip)
-            ->setIsActive((bool) $isActive);
+            ->setIsActive((bool) $isActive)
+            ->setTimezone('Europe/Paris');
     }
 
     public function getClosedTerritory(): Territory

--- a/tests/Unit/Command/PushEsaboraDossierCommandTest.php
+++ b/tests/Unit/Command/PushEsaboraDossierCommandTest.php
@@ -58,7 +58,7 @@ class PushEsaboraDossierCommandTest extends TestCase
                 $this->equalTo(DossierMessageSISH::CAN_SYNC_SISH_ESABORA),
                 null,
                 null,
-                (new Territory())->setZip('01')->setIsActive(true)->setName('Ain')
+                (new Territory())->setZip('01')->setIsActive(true)->setName('Ain')->setTimezone('Europe/Paris')
             )
             ->willReturn($affectations);
 

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -158,7 +158,19 @@ class InterventionDescriptionGeneratorTest extends TestCase
             'ARS',
         ];
 
-        yield 'Visite dans le futur' => [
+        yield 'Visite dans le futur à minuit' => [
+            $this->getIntervention(
+                InterventionType::VISITE,
+                $dateInFutur->setTime(0, 0, 0),
+                Intervention::STATUS_PLANNED
+            ),
+            'Visite programmée',
+            '25 rue du test',
+            $dateInFutur->format('d/m/Y').'.',
+            'ARS',
+        ];
+
+        yield 'Visite dans le futur avec heure' => [
             $this->getIntervention(
                 InterventionType::VISITE,
                 $dateInFutur,
@@ -166,7 +178,7 @@ class InterventionDescriptionGeneratorTest extends TestCase
             ),
             'Visite programmée',
             '25 rue du test',
-            $dateInFutur->format('d/m/Y'),
+            $dateInFutur->format('d/m/Y à H:i'),
             'ARS',
         ];
     }


### PR DESCRIPTION
## Ticket

#5753   

## Description
Dans InterventionDescriptionGenerator, en cas de création de visite, on utilise la fonction getScheduledAtFormated() qui permet d'afficher l'heure si elle est définie.

## Changements apportés
* Mise à jour du service, du test

## Pré-requis

## Tests
- [ ] Créer des visites sur un signalement, en précisant l'heure ou pas, et vérifier le suivi créé
