### PR TITLE
[Accessibilité] Améliorer le focus sur les champs liste simple

### DIFF
--- a/assets/scripts/vanilla/services/form/form_helper.js
+++ b/assets/scripts/vanilla/services/form/form_helper.js
@@ -50,13 +50,14 @@ export function reloadTinyMCE(selector) {
 }
 
 document.querySelectorAll('label[for]').forEach((label) => {
-  const target = document.getElementById(label.htmlFor);
+  const scope = label.closest('form, dialog, [role="dialog"], .fr-modal') ?? document;
+  const target = scope.querySelector(`#${CSS.escape(label.htmlFor)}`);
   if (!target || target.tagName !== 'SELECT' || target.disabled) {
     return;
   }
   label.addEventListener('click', (e) => {
     e.preventDefault();
-    target.focus();
+    target.focus({ focusVisible: true });
     if (typeof target.showPicker === 'function') {
       try {
         target.showPicker();

--- a/assets/scripts/vanilla/services/form/form_helper.js
+++ b/assets/scripts/vanilla/services/form/form_helper.js
@@ -48,3 +48,21 @@ export function reloadTinyMCE(selector) {
 
   initTinyMCE(selector);
 }
+
+document.querySelectorAll('label[for]').forEach((label) => {
+  const target = document.getElementById(label.htmlFor);
+  if (!target || target.tagName !== 'SELECT' || target.disabled) {
+    return;
+  }
+  label.addEventListener('click', (e) => {
+    e.preventDefault();
+    target.focus();
+    if (typeof target.showPicker === 'function') {
+      try {
+        target.showPicker();
+      } catch {
+        // showPicker() fails if the element is not visible or not attached
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Ticket

#5767   

## Description
Les champs de type liste simple ne s'ouvrent pas quand on clique sur le label (contrairement aux champ input ou aux champs liste multiple)

## Changements apportés
* Ajout d'un code js pour ouvrir la liste et mettre l'outline bleu quand on clique sur le label d'une liste simple, histoire d'être cohérent avec les listes custom à choix multiples

## Pré-requis
`make npm-watch`
## Tests
- [ ] Tester plusieurs formulaires dans des modales ou pas
