### PR TITLE
[Accessibilité] Ajout et édition de partenaire

### DIFF
--- a/templates/_partials/_modal_user_create.html.twig
+++ b/templates/_partials/_modal_user_create.html.twig
@@ -8,6 +8,7 @@
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-user-create-title" class="fr-modal__title">Chargement en cours...</h1>
+                        <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
                         <div id="fr-modal-user-create-form-container">Chargement en cours...</div>
                     </div>
                     <div class="fr-modal__footer">

--- a/templates/_partials/_modal_user_edit_form.html.twig
+++ b/templates/_partials/_modal_user_edit_form.html.twig
@@ -7,7 +7,7 @@
         </p>
     </div>
 {% else %}
-    <span class="fr-mb-3v">Tous les champs sont obligatoires</span>
+    <span class="fr-mb-3v">Tous les champs sont obligatoires, sauf mention contraire.</span>
 {% endif %}
 {{ form_start(formUserPartner, {'attr': {'id': 'fr-modal-user-edit-form'}}) }}
 {{ form_errors(formUserPartner) }}

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -81,11 +81,13 @@
 	<div class="fr-col-12">
 		<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
 			<li>
-				{% if create %}
-					<button class="fr-btn fr-btn--primary fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">Créer le partenaire</button>
-				{% else %}
-					<button class="fr-btn fr-btn--primary fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">Enregistrer</button>
-				{% endif %}
+				<button class="fr-btn fr-btn--primary fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">
+					{% if create %}
+						Créer le partenaire
+					{% else %}
+						Enregistrer
+					{% endif %}
+				</button>
 			</li>
 			<li>
 				{% if create %}

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -77,20 +77,24 @@
 				</div>
 			</div>
 		</fieldset>
-	</div>
-	<div class="fr-col-6">
-		{% if create %}
-			<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_partner_index') }}" data-filter-list-partner>Annuler</a>
-		{% else %}
-			<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_partner_view', {'id': partner.id}) }}">Annuler</a>
-		{% endif %}
-	</div>
-	<div class="fr-col-6 fr-text--right">
-		{% if create %}
-			<button class="fr-btn fr-btn--success fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">Créer le partenaire</button>
-		{% else %}
-			<button class="fr-btn fr-btn--success fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">Enregistrer</button>
-		{% endif %}
+	</div>	
+	<div class="fr-col-12">
+		<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<li>
+				{% if create %}
+					<button class="fr-btn fr-btn--primary fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">Créer le partenaire</button>
+				{% else %}
+					<button class="fr-btn fr-btn--primary fr-fi-check-line fr-btn--icon-left" id="submit_btn_partner">Enregistrer</button>
+				{% endif %}
+			</li>
+			<li>
+				{% if create %}
+					<a class="fr-btn fr-btn--secondary fr-fi-close-line fr-btn--icon-left" href="{{ path('back_partner_index') }}" data-filter-list-partner>Annuler</a>
+				{% else %}
+					<a class="fr-btn fr-btn--secondary fr-fi-close-line fr-btn--icon-left" href="{{ path('back_partner_view', {'id': partner.id}) }}">Annuler</a>
+				{% endif %}
+			</li>
+		</ul>
 	</div>
 </div>
 {{ form_end(form) }}

--- a/templates/back/partner/edit-perimetre.html.twig
+++ b/templates/back/partner/edit-perimetre.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Modifier le partenaire {{ partner.nom }}{% endblock %}
+{% block title %}Modifier le périmètre du partenaire {{ partner.nom }}{% endblock %}
 
 {% block content %}
     <section class="fr-col-12 fr-pt-4v">
@@ -19,7 +19,6 @@
                 'level5Label': '',
             } %}
             <h1>Modifier le périmètre d'intervention du partenaire {{partner.nom}}</h1>
-            <span>Tous les champs sont facultatifs.</span>
 
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12">
@@ -35,6 +34,8 @@
                         Par exemple : vous ajoutez le code INSEE d'une commune et une zone OPAH à un partenaire, le partenaire pourra être affecté aux dossiers qui sont dans la commune <u>ET</u> aux dossiers se trouvant dans la zone OPAH sélectionnée, même si elle ne correspond pas à ce code INSEE.
                     </p>
                 </div>
+                <span>Tous les champs sont facultatifs.</span>
+                <br><br>
                 <h2>Périmètre d'intervention</h2>
                 <p>
                     Définissez ci-dessous les zones géographiques dans lesquelles le partenaire doit intervenir. 

--- a/templates/back/partner/edit-perimetre.html.twig
+++ b/templates/back/partner/edit-perimetre.html.twig
@@ -34,8 +34,7 @@
                         Par exemple : vous ajoutez le code INSEE d'une commune et une zone OPAH à un partenaire, le partenaire pourra être affecté aux dossiers qui sont dans la commune <u>ET</u> aux dossiers se trouvant dans la zone OPAH sélectionnée, même si elle ne correspond pas à ce code INSEE.
                     </p>
                 </div>
-                <span>Tous les champs sont facultatifs.</span>
-                <br><br>
+                <p>Tous les champs sont facultatifs.</p>
                 <h2>Périmètre d'intervention</h2>
                 <p>
                     Définissez ci-dessous les zones géographiques dans lesquelles le partenaire doit intervenir. 

--- a/templates/back/partner/edit-perimetre.html.twig
+++ b/templates/back/partner/edit-perimetre.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Partenaire{% endblock %}
+{% block title %}Modifier le partenaire {{ partner.nom }}{% endblock %}
 
 {% block content %}
     <section class="fr-col-12 fr-pt-4v">
@@ -19,6 +19,7 @@
                 'level5Label': '',
             } %}
             <h1>Modifier le périmètre d'intervention du partenaire {{partner.nom}}</h1>
+            <span>Tous les champs sont facultatifs.</span>
 
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12">
@@ -65,11 +66,15 @@
                         {{ form_row(form.excludedZones) }}
                     </div>
                     <div class="fr-col-6"></div>
-                    <div class="fr-col-6">
-                        <a href="{{path('back_partner_view', {id:partner.id})}}#perimetre" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
-                    </div>
-                    <div class="fr-col-6">
-                        {{ form_row(form.save) }}
+                    <div class="fr-col-12">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                            <li>
+                                {{ form_row(form.save) }}
+                            </li>
+                            <li>
+                                <a href="{{path('back_partner_view', {id:partner.id})}}#perimetre" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                            </li>
+                        </ul>
                     </div>
                 </div>
                 {{ form_end(form) }}

--- a/templates/back/partner/edit.html.twig
+++ b/templates/back/partner/edit.html.twig
@@ -1,6 +1,12 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Partenaire{% endblock %}
+{% block title %}
+    {% if create %}
+        Ajouter un partenaire
+    {% else %}
+        Modifier le partenaire {{ partner.nom }}
+    {% endif %}
+{% endblock %}
 
 {% block content %}
     <section class="fr-col-12 fr-pt-4v">

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Partenaire{% endblock %}
+{% block title %}Partenaire {{ partner.nom }}{% endblock %}
 
 {% block content %}
     {% if is_granted('ROLE_ADMIN_TERRITORY') and app.request.attributes.get('_route') is not same as('back_partner_new') %}


### PR DESCRIPTION
## Ticket

#5768   

## Description

- Ajout partenaire http://localhost:8080/bo/partenaires/ajout
inverser le bouton `créer le partenaire` et `annuler` dans le DOM (si c'est bien ce qu'on a décidé partout ailleurs) pour la navigation au clavier
Les passer en bleu et blanc pour être dsfr compatible
Titre de la page à rvoir ? (actuellement `Partenaire - Signal Logement`, passer sur `Ajouter un partenaire - Signal Logement`)


- Edition partenaire http://localhost:8080/bo/partenaires/28/voir
inverser le bouton `enregistrer` et `annuler` dans le DOM (si c'est bien ce qu'on a décidé partout ailleurs) pour la navigation au clavier (onglets `informations` et `périmètre`)
Les passer en bleu et blanc pour être dsfr compatible (onglet informations, l'onglet périmètre est ok))
Modifier le titre de la page "`Editer le partenaire xx - Signal Logement`" plutôt que "`Partenaire - Signal Logement`"
Sur l'édition du périmètre, préciser que tous les champs sont facultatifs
Sur la modale d'ajout d'utilisateur, préciser que les champs sont obligatoires sauf mention contraire


## Changements apportés
* Changement des twigs

## Pré-requis

## Tests
- [ ] Tester l'ajout et l'édition d'un partenaire
- [ ] Vérifier les points ci-dessus, et vérifier que tout fonctionne toujours
