### PR TITLE
[Email] Pb affichage d'heure dans les mail évènement

### DIFF
--- a/src/Command/Cron/SendDailyEmailsCommand.php
+++ b/src/Command/Cron/SendDailyEmailsCommand.php
@@ -8,6 +8,7 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Mailer\SummaryMailService;
+use App\Service\TimezoneProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,6 +32,7 @@ class SendDailyEmailsCommand extends AbstractCronCommand
         private readonly ClubEventRepository $clubEventRepository,
         private readonly SummaryMailService $summaryMailService,
         private readonly NotificationMailerRegistry $notificationMailerRegistry,
+        private readonly TimezoneProvider $timezoneProvider,
         private readonly ParameterBagInterface $parameterBag,
     ) {
         parent::__construct($this->parameterBag);
@@ -98,8 +100,8 @@ class SendDailyEmailsCommand extends AbstractCronCommand
                         to: $user->getEmail(),
                         params: [
                             'name' => $club->getName(),
-                            'date' => $club->getDateEvent()->format('d/m/Y'),
-                            'hour' => $club->getDateEvent()->format('H:i'),
+                            'date' => $club->getDateEvent(),
+                            'timezone' => $this->timezoneProvider->getTimezone($user),
                             'url' => $club->getUrl(),
                         ],
                     )

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -258,6 +258,12 @@ users:
     statut: "ARCHIVE"
     is_mailing_active: 1
   -
+    email: admin-territoire-974-01@signal-logement.fr
+    roles: "[\"ROLE_ADMIN_TERRITORY\"]"
+    partner: "Partenaire 974-01"
+    statut: "ACTIVE"
+    is_mailing_active: 1
+  -
     email: user-01-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-04"

--- a/src/Service/TimezoneProvider.php
+++ b/src/Service/TimezoneProvider.php
@@ -13,10 +13,10 @@ readonly class TimezoneProvider
     {
     }
 
-    public function getTimezone(): string
+    public function getTimezone(?User $user = null): string
     {
         /** @var User $user */
-        $user = $this->security->getUser();
+        $user = $user ?? $this->security->getUser();
         if ($user && $user instanceof User && $user->getFirstTerritory()) {
             return $user->getFirstTerritory()->getTimezone();
         }

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -76,7 +76,7 @@
                         title: items.nextClubEvent.name,
                         description: 'Cliquez pour vous inscrire',
                         badge_class: 'fr-badge--purple-glycine',
-                        badge_label: items.nextClubEvent.dateEvent|date('d/m/Y H:i'),
+                        badge_label: items.nextClubEvent.dateEvent|format_datetime(locale='fr', timezone=territory_timezone, pattern='dd/MM/yyyy HH:mm'),
                         link: items.nextClubEvent.url,
                         blank: true
                     } %}

--- a/templates/emails/club_event_email.html.twig
+++ b/templates/emails/club_event_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>
-        Signal Logement vous invite à participer à l'évènement <strong>{{name}}</strong> qui aura lieu le <strong>{{date}}</strong> à <strong>{{hour}}</strong>.
+        Signal Logement vous invite à participer à l'évènement <strong>{{name}}</strong> qui aura lieu le <strong>{{ date|format_datetime(locale='fr', timezone=timezone, pattern='dd/MM/yyyy') }}</strong> à <strong>{{ date|format_datetime(locale='fr', timezone=territory_timezone, pattern='HH:mm') }}</strong>.
         <br>
         Pour vous inscrire à cet évènement, cliquez sur le bouton ci-dessous.
     </p>

--- a/templates/emails/club_event_reminder_email.html.twig
+++ b/templates/emails/club_event_reminder_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>
-        L'évènement <strong>{{name}}</strong> a lieu dans 2 jours, le <strong>{{date}}</strong> à <strong>{{hour}}</strong>.
+        L'évènement <strong>{{name}}</strong> a lieu dans 2 jours, le <strong>{{ date|format_datetime(locale='fr', timezone=timezone, pattern='dd/MM/yyyy à HH:mm') }}</strong>.
         <br>
         Si ce n'est pas déjà fait, cliquez sur le bouton ci-dessous pour vous inscrire à cet évènement.
     </p>

--- a/tests/Functional/Command/Cron/SendDailyEmailsCommandTest.php
+++ b/tests/Functional/Command/Cron/SendDailyEmailsCommandTest.php
@@ -27,8 +27,8 @@ class SendDailyEmailsCommandTest extends KernelTestCase
         $nb = (int) str_replace(['[OK] ', ' emails récapitulatifs envoyés.'], '', $recapLine);
         ++$nb;
         $this->assertStringContainsString('14 emails de clubs envoyés à moins 7 jours.', $output); // 14 email + 1
-        $this->assertStringContainsString('19 emails de clubs envoyés à moins 2 jours.', $output); // 19 email + 1
-        $this->assertEmailCount($nb + 15 + 20);
+        $this->assertStringContainsString('20 emails de clubs envoyés à moins 2 jours.', $output); // 20 email + 1
+        $this->assertEmailCount($nb + 15 + 21);
 
         $commandTester->execute([]);
         $commandTester->assertCommandIsSuccessful();
@@ -38,7 +38,7 @@ class SendDailyEmailsCommandTest extends KernelTestCase
         $this->assertStringContainsString('0 emails récapitulatifs envoyés.', $recapLine);
         ++$nb;
         $this->assertStringContainsString('14 emails de clubs envoyés à moins 7 jours.', $output); // 14 email + 1
-        $this->assertStringContainsString('19 emails de clubs envoyés à moins 2 jours.', $output); // 19 email + 1
-        $this->assertEmailCount($nb + 15 + 20 + 15 + 20);
+        $this->assertStringContainsString('20 emails de clubs envoyés à moins 2 jours.', $output); // 20 email + 1
+        $this->assertEmailCount($nb + 15 + 21 + 15 + 21);
     }
 }

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -36,8 +36,8 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): \Generator
     {
-        yield 'Search without params' => [[], 70];
-        yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 22];
+        yield 'Search without params' => [[], 71];
+        yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 23];
         yield 'Search with territory 13' => [['territory' => 13], 18];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];
         yield 'Search with status INACTIVE' => [['statut' => 'INACTIVE'], 11];


### PR DESCRIPTION
## Ticket

#5778

## Description
Problème remonté : les dates/heures des club était affiché en UTC dans les mail J-2 et J-7.
- On affiche à présent  les dates/heures selon le timezone du territoire de l'utilisateur concerné par l'email
- On fait de même sur le widget du tableau de bord (plutôt que toujours en `Europe/Paris` par défaut

## Changements apportés
- Ajout d'un RT actif à la réunion pour pouvoir vérifier les affichages.

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Se connecter au dashboard en SA et avec `admin-territoire-974-01@signal-logement.fr` voir que le widget des club affiche une date différente selon les cas
- [ ] Lancer `make symfony cmd="app:send-daily-emails"` et voir que dans les email envoyé la date pour l'user `admin-territoire-974-01@signal-logement.fr` est adapté
