### PR TITLE
[BO - Signalement] Info Bulle / Format Tel

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -1025,6 +1025,10 @@ ul + p {
     border-top: 1px solid var(--border-active-blue-france);
 }
 
+.fr-tooltip hr{
+    padding-bottom: 5px;
+}
+
 .height-auto {
     height: auto;
 }

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -488,6 +488,7 @@ users:
       - "CAF 30"
     statut: "ACTIVE"
     is_mailing_active: 1
+    phone: "0639984040"
   -
     email: admin-territoire-44-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"

--- a/src/DataFixtures/Loader/LoadUserData.php
+++ b/src/DataFixtures/Loader/LoadUserData.php
@@ -133,6 +133,10 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface
             $user->setCguVersionChecked($this->parameterBag->get('cgu_current_version'));
         }
 
+        if (isset($row['phone'])) {
+            $user->setPhone($row['phone']);
+        }
+
         $password = $this->hasher->hashPassword($user, self::APP_PLAIN_PASSWORD);
         $user->setPassword($password);
 

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -21,7 +21,7 @@
                     {% endif %}
                     {% if suivi.createdBy.phone %}
                         <hr>
-                        <span class="fr-ws-nowrap">{{ suivi.createdBy.phoneDecoded }}</span>
+                        <span class="fr-ws-nowrap">{{ suivi.createdBy.phoneDecoded|phone }}</span>
                     {% endif %}
                 </span>
                 <span aria-describedby="tooltip_suivi_{{ suivi.id }}">


### PR DESCRIPTION
## Ticket

#5786

## Description
Ajustement de l'affichage du numéro du téléphone de l'agent dans le tooltip d'un suivi BO au survol du nom du partenaire.
<img width="294" height="178" alt="Capture d’écran 2026-04-29 155810" src="https://github.com/user-attachments/assets/c2c20f17-eed9-4216-8df9-732074b27f8f" />


## Changements apportés
* Modification du format du téléphone
* Modification du css pour enjoliver le tooltip
* Ajout d'un numéro de tel sur RT des fixtures pour faciliter les test visuels

## Pré-requis
`make npm-watch`
`make load-fixtures`

## Tests
- [ ] Se rendre sur un signalement validé par le partenaire CAF30 (tous le signalement du Gard) et survoler le nom du partenaire dans la liste des suivis.
