### PR TITLE
[Tech - Local] Config innodb-buffer-pool-size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   signal_logement_mysql:
     image: 'mysql:8.4.8'
-    command: --max_allowed_packet=32505856
+    command: --max_allowed_packet=32505856 --innodb-buffer-pool-size=4G
     container_name: signal_logement_mysql
     restart: always
     environment:


### PR DESCRIPTION
## Ticket

#5791

## Description
Ajout de la configuration `--innodb-buffer-pool-size=4G` sur le `docker-compose.yml` afin d'avoir la même config que la base de prod, et pouvoir travailler en condition plus proche du réel sur les optimisation de performances des requêtes.

Vous pouvez vérifier la config en prod avec cette requete : 
`SHOW VARIABLES LIKE 'innodb_buffer_pool_size';`

## Pré-requis
`make build`

## Tests
- [ ] Pas de test à faire, mais sur une copie de prod, on voir que ca répond plus vite sur les page lentes
