### PR TITLE
[Accessibilité] Ajout et édition de documents

### DIFF
--- a/src/Form/TerritoryFileType.php
+++ b/src/Form/TerritoryFileType.php
@@ -63,7 +63,7 @@ class TerritoryFileType extends AbstractType
         ]);
 
         if ($this->security->isGranted('ROLE_ADMIN') && !$isEdit) {
-            $builder->add('territory', TerritoryChoiceType::class);
+            $builder->add('territory', TerritoryChoiceType::class, ['label' => 'Territoire (facultatif)']);
         }
 
         $builder->add('title', null, [

--- a/templates/back/admin-territory-files/add.html.twig
+++ b/templates/back/admin-territory-files/add.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Documents types{% endblock %}
+{% block title %}Ajouter un document{% endblock %}
 
 {% block content %}
     <section class="fr-pt-4v">
@@ -18,7 +18,7 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
-                    <h1 class="fr-mb-0">Ajouter des documents</h1>
+                    <h1 class="fr-mb-0">Ajouter un document</h1>
                     <p>
                         Choisissez le document sur votre appareil puis renseignez les détails et conditions d'affichage du document.
                     </p>
@@ -35,6 +35,10 @@
                     </div>
                 </div>
                 {% endif %}
+                <div>
+                    <br>
+                    <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
+                </div>
             </div>
         </header>
     </section>
@@ -88,15 +92,19 @@
                 </div>
             </div>
             <div class="fr-grid-row fr-mt-4w">
-                <div class="fr-col-6 fr-text--left">
-                    <a href="{{ path('back_territory_management_document') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
-                        Annuler
-                    </a>
-                </div>
-                <div class="fr-col-6 fr-text--right">
-                    <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line">
-                        Ajouter le document
-                    </button>
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line">
+                                Ajouter le document
+                            </button>
+                        </li>
+                        <li>
+                            <a href="{{ path('back_territory_management_document') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
+                                Annuler
+                            </a>
+                        </li>
+                    </ul>
                 </div>
             </div>
             {{ form_end(addForm) }}

--- a/templates/back/admin-territory-files/edit.html.twig
+++ b/templates/back/admin-territory-files/edit.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Documents types{% endblock %}
+{% block title %}Éditer le document {{ file.title }}{% endblock %}
 
 {% block content %}
     <section class="fr-pt-4v">
@@ -39,6 +39,10 @@
                     </div>
                 </div>
                 {% endif %}
+                <div>
+                    <br>
+                    <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
+                </div>
             </div>
         </header>
     </section>
@@ -105,15 +109,19 @@
                 </div>
             </div>
             <div class="fr-grid-row fr-mt-4w">
-                <div class="fr-col-6 fr-text--left">
-                    <a href="{{ path('back_territory_management_document') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
-                        Annuler
-                    </a>
-                </div>
-                <div class="fr-col-6 fr-text--right">
-                    <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line">
-                        Enregistrer les modifications
-                    </button>
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line">
+                                Enregistrer les modifications
+                            </button>
+                        </li>
+                        <li>
+                            <a href="{{ path('back_territory_management_document') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
+                                Annuler
+                            </a>
+                        </li>
+                    </ul>
                 </div>
             </div>
             {{ form_end(editForm) }}


### PR DESCRIPTION
## Ticket

#5769   

## Description
- Ajout document http://localhost:8080/bo/gerer-territoire/documents-types/ajouter
Inverser le bouton `Ajouter le document` et `annuler` dans le DOM (si c'est bien ce qu'on a décidé partout ailleurs) pour la navigation au clavier 
Renommer le titre de la page en "Ajouter un document - Signal Logement" au lieu de "Documents types - Signal Logement", et le H1 en "Ajouter un document" au lieu de "Ajouter des documents"
Préciser que tous les champs sont obligatoires sauf mention contraire


- Edition document http://localhost:8080/bo/gerer-territoire/documents-types/editer/279
Inverser le bouton `Enregistrer les modifications` et `annuler` dans le DOM (si c'est bien ce qu'on a décidé partout ailleurs) pour la navigation au clavier 
Renommer le titre de la page en "Editer le document xxx - Signal Logement" au lieu de "Documents types - Signal Logement"
Préciser que tous les champs sont obligatoires sauf mention contraire


## Changements apportés
* Changement des twigs

## Pré-requis

## Tests
- [ ] Tester l'ajout et l'édition d'un document
- [ ] Vérifier les points ci-dessus, et vérifier que tout fonctionne toujours