### PR TITLE
[Tech - Performance dashboard] Utilsation du champ dénormalisé lastSuiviAt

### DIFF
--- a/src/Repository/Query/Dashboard/DossiersSuivisUsagerQuery.php
+++ b/src/Repository/Query/Dashboard/DossiersSuivisUsagerQuery.php
@@ -44,11 +44,7 @@ class DossiersSuivisUsagerQuery
         }
 
         if ($onlyLastSuivi) {
-            $subQb = $this->entityManager->createQueryBuilder()
-                ->select('MAX(s2.createdAt)')
-                ->from(Suivi::class, 's2')
-                ->where('s2.signalement = signalement');
-            $qb->andWhere('s.createdAt = ('.$subQb->getDQL().')');
+            $qb->andWhere('s.createdAt = signalement.lastSuiviAt');
         }
 
         if ($params?->territoireId) {
@@ -150,7 +146,7 @@ class DossiersSuivisUsagerQuery
                 SELECT MAX(s4.createdAt)
                 FROM '.Suivi::class.' s4
                 WHERE s4.signalement = signalement
-                AND s4.createdAt < s.createdAt
+                AND s4.createdAt < signalement.lastSuiviAt
             )
         )')
         ->setParameter('askFeedbackCategory', SuiviCategory::ASK_FEEDBACK_SENT)


### PR DESCRIPTION
## Ticket

#2777

## Description
Utilisation du champ dénormalisé `lastSuiviAt` plutot que 'aller rechercher la valeurs dans le suivi, quand cela est possible.
Cela apporte une amélioration limité des perf (env 0.5 seconde de moins dans mon cas, passage de 7 a 6.5 au global en SA sur le dashboard)

## Tests
- [ ] Vérifier que le changement de la requête ne modifie pas les résultats affichés.
