### PR TITLE
[BO - Signalement] Pouvoir masquer tous les signalements automatiques

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -1,6 +1,6 @@
 {% for suivi in signalement.suivis|reverse %}
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--blue-france fr-border-background-action-high-blue-france fr-p-3v fr-mb-3v suivi-item
-        {% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}suivi-auto{% endif %}
+        {% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_AUTO') or suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}suivi-auto{% endif %}
         {% if loop.index > 3 %}fr-hidden{% endif %}
         ">
         <div class="fr-col-3">


### PR DESCRIPTION
## Ticket

#5795   

## Description
Dans la fiche signalement, le toggle qui permet de masquer les suivis automatiques prend en compte les suivis automatiques aussi (et pas juste les suivis techniques).

## Tests
- [ ] Vérifier l'effet du toggle
