### PR TITLE
Nombre de recherches / QR code service secours / Wording

### DIFF
--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -2203,9 +2203,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement.",
+          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme va prévenir le bailleur (propriétaire) de votre logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -2203,9 +2203,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}} ou un service compétent pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme ou un service compétent pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1769,9 +1769,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme va prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1769,9 +1769,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}} ou un service compétent pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme ou un service compétent pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -2100,9 +2100,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}} ou un service compétent pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme ou un service compétent pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -2100,9 +2100,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme va prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -2096,9 +2096,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme va prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -2096,9 +2096,9 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}}, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.",
+          "label": "Je comprends que {{formStore.props.platformName}} ou un service compétent pourront prévenir le bailleur (propriétaire) du logement.",
           "validate": {
-            "message": "Veuillez confirmer que vous comprenez que la plateforme, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement."
+            "message": "Veuillez confirmer que vous comprenez que la plateforme ou un service compétent pourront prévenir le bailleur (propriétaire) du logement."
           },
           "accessibility": {
             "focus": true

--- a/src/Controller/Back/ConfigServiceSecoursController.php
+++ b/src/Controller/Back/ConfigServiceSecoursController.php
@@ -8,6 +8,7 @@ use App\Form\ServiceSecoursRouteType;
 use App\Repository\ServiceSecoursRouteRepository;
 use App\Service\ListFilters\SearchServiceSecoursRoute;
 use App\Service\MessageHelper;
+use App\Service\ServiceSecours\QrCodeGenerator;
 use App\Utils\FormHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -119,5 +120,19 @@ class ConfigServiceSecoursController extends AbstractController
             'form' => $form,
             'create' => true,
         ]);
+    }
+
+    #[Route('/{id}/qr-code', name: 'back_config_service_secours_route_qr_code', methods: ['GET'])]
+    public function qrCode(
+        ServiceSecoursRoute $serviceSecoursRoute,
+        QrCodeGenerator $qrCodeGenerator,
+    ): Response {
+        $pdfContent = $qrCodeGenerator->generate($serviceSecoursRoute);
+
+        $response = new Response($pdfContent);
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Disposition', 'inline; filename="qr-code-'.$serviceSecoursRoute->getSlug().'.pdf"');
+
+        return $response;
     }
 }

--- a/src/Service/ServiceSecours/QrCodeGenerator.php
+++ b/src/Service/ServiceSecours/QrCodeGenerator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Service\ServiceSecours;
+
+use App\Entity\ServiceSecoursRoute;
+use App\Utils\UrlHelper;
+use Dompdf\Dompdf;
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+class QrCodeGenerator
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly Environment $twig,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function generate(ServiceSecoursRoute $serviceSecoursRoute): string
+    {
+        $writer = new PngWriter();
+        $url = $this->urlGenerator->generate('service_secours_index', [
+            'slug' => $serviceSecoursRoute->getSlug(),
+            'uuid' => $serviceSecoursRoute->getUuid(),
+            'domain' => UrlHelper::extractRootDomain($this->requestStack->getCurrentRequest()->getHost()),
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $qrCode = new QrCode(data: $url);
+
+        $result = $writer->write($qrCode);
+        $content = $this->twig->render('back/config-service-secours-route/qr-code.html.twig', [
+            'serviceSecoursRoute' => $serviceSecoursRoute,
+            'qrCode' => $result->getDataUri(),
+            'url' => $url,
+        ]);
+
+        $domPdf = new Dompdf();
+        $domPdf->loadHtml($content);
+        $domPdf->setPaper('A4', 'portrait');
+        $domPdf->render();
+
+        return $domPdf->output();
+    }
+}

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -19,6 +19,7 @@ use App\Service\Notification\NotificationCounter;
 use App\Service\TimezoneProvider;
 use App\Service\UploadHandlerService;
 use App\Utils\AttributeParser;
+use App\Utils\UrlHelper;
 use App\Validator\EmailFormatValidator;
 use CoopTilleuls\UrlSignerBundle\UrlSigner\UrlSignerInterface;
 use Twig\Extension\AbstractExtension;
@@ -245,14 +246,7 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
 
     public function extractRootDomain(string $host): string
     {
-        $backofficeSubdomains = ['bo', 'service-secours'];
-        $parts = explode('.', $host);
-
-        if (in_array(strtolower($parts[0]), $backofficeSubdomains, true)) {
-            return implode('.', array_slice($parts, 1));
-        }
-
-        return $host;
+        return UrlHelper::extractRootDomain($host);
     }
 
     public function getAcceptedMimeTypes(?string $type = null): string

--- a/src/Utils/UrlHelper.php
+++ b/src/Utils/UrlHelper.php
@@ -22,4 +22,16 @@ class UrlHelper
 
         return preg_replace('/&/', '?', $query, 1);
     }
+
+    public static function extractRootDomain(string $host): string
+    {
+        $backofficeSubdomains = ['bo', 'service-secours'];
+        $parts = explode('.', $host);
+
+        if (in_array(strtolower($parts[0]), $backofficeSubdomains, true)) {
+            return implode('.', array_slice($parts, 1));
+        }
+
+        return $host;
+    }
 }

--- a/src/Validator/UserSearchFilterParamsValidator.php
+++ b/src/Validator/UserSearchFilterParamsValidator.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class UserSearchFilterParamsValidator extends ConstraintValidator
 {
+    public const MAX_FILTERS_PER_USER = 10;
+
     public function __construct(private UserSearchFilterRepository $repo)
     {
     }
@@ -30,9 +32,9 @@ class UserSearchFilterParamsValidator extends ConstraintValidator
         }
 
         $count = $this->repo->countForUser($user);
-        if (!$entity->getId() && $count >= 5) {
+        if (!$entity->getId() && $count >= self::MAX_FILTERS_PER_USER) {
             $this->context
-                ->buildViolation('Vous avez atteint la limite de 5 recherches enregistrées.')
+                ->buildViolation('Vous avez atteint la limite de '.self::MAX_FILTERS_PER_USER.' recherches enregistrées.')
                 ->addViolation();
         }
 

--- a/templates/back/config-service-secours-route/_title-and-table-list-results.html.twig
+++ b/templates/back/config-service-secours-route/_title-and-table-list-results.html.twig
@@ -34,6 +34,14 @@
                         aria-label="Supprimer la route {{ serviceSecoursRoute.name }}"
                         title="Supprimer la route {{ serviceSecoursRoute.name }}"
                         ></button>
+                    <a href="{{ path('back_config_service_secours_route_qr_code', { id: serviceSecoursRoute.id }) }}" 
+                        class="fr-btn fr-icon-qr-code-line fr-btn--sm fr-mb-1v" 
+                        target="_blank" 
+                        rel="noopener"
+                        aria-label="Afficher le QR code (Ouvre une nouvelle fenêtre)" 
+                        title="Afficher le QR code (Ouvre une nouvelle fenêtre)"
+                        >
+                    </a>
                 </td>
             </tr>
         {% else %}

--- a/templates/back/config-service-secours-route/qr-code.html.twig
+++ b/templates/back/config-service-secours-route/qr-code.html.twig
@@ -1,0 +1,13 @@
+<style>
+    @page {margin: 1cm;}
+    div {box-sizing: border-box;}
+</style>
+<div style="text-align: center;font-family: Arial, sans-serif;">
+     <h1 style="text-transform: uppercase;">{{ platform.name }}</h1>
+     <h2>{{ serviceSecoursRoute.name }}</h2>
+     <img src="{{ qrCode }}" alt="QR Code pour la route {{ url }}">
+
+     <br>
+     <br>
+    <a href="{{ url }}" target="_blank" rel="noopener">{{ url }}</a>
+</div>

--- a/tests/Functional/Controller/Back/UserSearchFilterControllerTest.php
+++ b/tests/Functional/Controller/Back/UserSearchFilterControllerTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Controller\Back;
 use App\Entity\UserSearchFilter;
 use App\Repository\UserRepository;
 use App\Tests\SessionHelper;
+use App\Validator\UserSearchFilterParamsValidator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -86,7 +87,7 @@ class UserSearchFilterControllerTest extends WebTestCase
         $client->loginUser($user);
         $csrfToken = $this->generateCsrfToken($client, 'save_search');
 
-        for ($i = 0; $i < 5; ++$i) {
+        for ($i = 0; $i < UserSearchFilterParamsValidator::MAX_FILTERS_PER_USER; ++$i) {
             $search = new UserSearchFilter();
             $search->setUser($user);
             $search->setName("Test $i");

--- a/tests/e2e/tests/form_usager_locataire.spec.ts
+++ b/tests/e2e/tests/form_usager_locataire.spec.ts
@@ -125,7 +125,7 @@ test('signalement form for locataire', async ({page}) => {
     await page.getByRole('textbox', { name: 'Quelle a été la réponse de' }).fill('Personne ne joue avec les mêmes cartes');
     await page.getByText('Oui, je veux rester dans mon').click();
     await page.getByRole('button', { name: 'Suivant' }).click();
-    await page.getByText('Je comprends que Signal Logement va prévenir le bailleur (propriétaire) de mon').click();
+    await page.getByText('Je comprends que Signal Logement, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.').click();
     await page.getByText('Je comprends qu\'une visite du').click();
     await page.getByText('Je comprends que Signal Logement ne permet pas de faire une demande de logement').click();
     await page.getByText('Je certifie ne pas avoir').click();

--- a/tests/e2e/tests/form_usager_locataire.spec.ts
+++ b/tests/e2e/tests/form_usager_locataire.spec.ts
@@ -125,7 +125,7 @@ test('signalement form for locataire', async ({page}) => {
     await page.getByRole('textbox', { name: 'Quelle a été la réponse de' }).fill('Personne ne joue avec les mêmes cartes');
     await page.getByText('Oui, je veux rester dans mon').click();
     await page.getByRole('button', { name: 'Suivant' }).click();
-    await page.getByText('Je comprends que Signal Logement, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement.').click();
+    await page.getByText('Je comprends que Signal Logement ou un service compétent pourront prévenir le bailleur (propriétaire) du logement.').click();
     await page.getByText('Je comprends qu\'une visite du').click();
     await page.getByText('Je comprends que Signal Logement ne permet pas de faire une demande de logement').click();
     await page.getByText('Je certifie ne pas avoir').click();


### PR DESCRIPTION
## Ticket

#5763
#5794
#5796

## Description
#5763
Modification de la case a cocher du formulaire : "Je comprends que Signal Logement, un ou des services désignés compétents sur le dossier pourront prévenir le bailleur (propriétaire) du logement"

#5794
Augmentation de la limite de recherches ques les agents peuvent sauvegardé (de 5 a 10)

#5796
Ajout d'un bouton dans la config des service secours pour générer un doc avec un qr code vers leur formulaire

## Pré-requis
`make npm-watch`

## Tests
- [ ] Aller jusqu’à la fin du formulaire FO et voir la modification de texte de la case à cocher
- [ ] Essayer d'enregistrer plus de 5 filtre sur la liste des signalement
- [ ] Afficher le PDF contenant le QR code d'une route service secours
