### PR TITLE
[BO - Notifications] Ajout d'une confirmation sur le bouton pour vider les notifications

### DIFF
--- a/assets/scripts/vanilla/controllers/form_notification.js
+++ b/assets/scripts/vanilla/controllers/form_notification.js
@@ -17,7 +17,6 @@ histoNotificationsContainer?.addEventListener('change', (event) => {
 });
 
 export function histoReinitNotification() {
-  console.log('histoReinitNotification called');
   histoNotificationSelected = [];
   countNotificationsSelected = 0;
 }
@@ -28,8 +27,7 @@ export function histoRefreshNotificationButtons() {
   if (deleteBtn) {
     countNotificationsSelected = histoNotificationSelected.length;
     if (countNotificationsSelected > 0) {
-      nbSelectedLabel.textContent =
-        countNotificationsSelected + ' sélectionnée(s) :';
+      nbSelectedLabel.textContent = countNotificationsSelected + ' sélectionnée(s) :';
       markAsReadBtn.textContent = 'Marquer comme lue(s)';
       deleteBtn.textContent = 'Supprimer';
       // remove listeners to delete all notifications
@@ -37,8 +35,7 @@ export function histoRefreshNotificationButtons() {
       deleteBtn.parentNode.replaceChild(newDeleteBtn, deleteBtn);
     } else {
       nbSelectedLabel.textContent = '';
-      markAsReadBtn.textContent =
-        'Marquer comme lue(s) (tous)';
+      markAsReadBtn.textContent = 'Marquer comme lue(s) (tous)';
       deleteBtn.textContent = 'Vider';
       // add confirmation to delete all notifications
       deleteBtn.addEventListener('click', (event) => {

--- a/assets/scripts/vanilla/controllers/form_notification.js
+++ b/assets/scripts/vanilla/controllers/form_notification.js
@@ -19,22 +19,20 @@ histoRefreshNotificationButtons();
 
 function histoRefreshNotificationButtons() {
   const deleteBtn = document.querySelector('#delete-notifications-btn');
-  const countNotificationsSelected = histoNotificationSelected.length;
-  if (countNotificationsSelected > 0) {
-    document.querySelector('#notification-selected-buttons-count').textContent =
-      countNotificationsSelected + ' sélectionnée(s) :';
-    document.querySelector('#mark-as-read-notifications-btn').textContent = 'Marquer comme lue(s)';
-    if (deleteBtn) {
+  if (deleteBtn) {
+    const countNotificationsSelected = histoNotificationSelected.length;
+    if (countNotificationsSelected > 0) {
+      document.querySelector('#notification-selected-buttons-count').textContent =
+        countNotificationsSelected + ' sélectionnée(s) :';
+      document.querySelector('#mark-as-read-notifications-btn').textContent = 'Marquer comme lue(s)';
       deleteBtn.textContent = 'Supprimer';
       // remove listeners to delete all notifications
       const newDeleteBtn = deleteBtn.cloneNode(true);
       deleteBtn.parentNode.replaceChild(newDeleteBtn, deleteBtn);
-    }
-  } else {
-    document.querySelector('#notification-selected-buttons-count').textContent = '';
-    document.querySelector('#mark-as-read-notifications-btn').textContent =
-      'Marquer comme lue(s) (tous)';
-    if (deleteBtn) {
+    } else {
+      document.querySelector('#notification-selected-buttons-count').textContent = '';
+      document.querySelector('#mark-as-read-notifications-btn').textContent =
+        'Marquer comme lue(s) (tous)';
       deleteBtn.textContent = 'Vider';
       // add confirmation to delete all notifications
       deleteBtn.addEventListener('click', (event) => {
@@ -48,10 +46,10 @@ function histoRefreshNotificationButtons() {
         }
       });
     }
+    document
+      .querySelectorAll('#notification-selected-buttons input[name=selected_notifications]')
+      ?.forEach((element) => {
+        element.value = histoNotificationSelected.join(',');
+      });
   }
-  document
-    .querySelectorAll('#notification-selected-buttons input[name=selected_notifications]')
-    ?.forEach((element) => {
-      element.value = histoNotificationSelected.join(',');
-    });
 }

--- a/assets/scripts/vanilla/controllers/form_notification.js
+++ b/assets/scripts/vanilla/controllers/form_notification.js
@@ -1,4 +1,5 @@
-const histoNotificationSelected = [];
+let histoNotificationSelected = [];
+let countNotificationsSelected = 0;
 const histoNotificationsContainer = document.querySelector('#table-list-results');
 histoNotificationsContainer?.addEventListener('change', (event) => {
   const element = event.target;
@@ -15,28 +16,33 @@ histoNotificationsContainer?.addEventListener('change', (event) => {
   histoRefreshNotificationButtons();
 });
 
-histoRefreshNotificationButtons();
-
-function histoRefreshNotificationButtons() {
+export function histoReinitNotification() {
+  console.log('histoReinitNotification called');
+  histoNotificationSelected = [];
+  countNotificationsSelected = 0;
+}
+export function histoRefreshNotificationButtons() {
   const deleteBtn = document.querySelector('#delete-notifications-btn');
+  const markAsReadBtn = document.querySelector('#mark-as-read-notifications-btn');
+  const nbSelectedLabel = document.querySelector('#notification-selected-buttons-count');
   if (deleteBtn) {
-    const countNotificationsSelected = histoNotificationSelected.length;
+    countNotificationsSelected = histoNotificationSelected.length;
     if (countNotificationsSelected > 0) {
-      document.querySelector('#notification-selected-buttons-count').textContent =
+      nbSelectedLabel.textContent =
         countNotificationsSelected + ' sélectionnée(s) :';
-      document.querySelector('#mark-as-read-notifications-btn').textContent = 'Marquer comme lue(s)';
+      markAsReadBtn.textContent = 'Marquer comme lue(s)';
       deleteBtn.textContent = 'Supprimer';
       // remove listeners to delete all notifications
       const newDeleteBtn = deleteBtn.cloneNode(true);
       deleteBtn.parentNode.replaceChild(newDeleteBtn, deleteBtn);
     } else {
-      document.querySelector('#notification-selected-buttons-count').textContent = '';
-      document.querySelector('#mark-as-read-notifications-btn').textContent =
+      nbSelectedLabel.textContent = '';
+      markAsReadBtn.textContent =
         'Marquer comme lue(s) (tous)';
       deleteBtn.textContent = 'Vider';
       // add confirmation to delete all notifications
       deleteBtn.addEventListener('click', (event) => {
-        if (histoNotificationSelected.length === 0) {
+        if (countNotificationsSelected === 0) {
           const confirmDeleteAll = confirm(
             'Êtes-vous sûr de vouloir supprimer toutes les notifications ?'
           );
@@ -53,3 +59,5 @@ function histoRefreshNotificationButtons() {
       });
   }
 }
+histoReinitNotification();
+histoRefreshNotificationButtons();

--- a/assets/scripts/vanilla/controllers/form_notification.js
+++ b/assets/scripts/vanilla/controllers/form_notification.js
@@ -15,18 +15,39 @@ histoNotificationsContainer?.addEventListener('change', (event) => {
   histoRefreshNotificationButtons();
 });
 
+histoRefreshNotificationButtons();
+
 function histoRefreshNotificationButtons() {
+  const deleteBtn = document.querySelector('#delete-notifications-btn');
   const countNotificationsSelected = histoNotificationSelected.length;
   if (countNotificationsSelected > 0) {
     document.querySelector('#notification-selected-buttons-count').textContent =
       countNotificationsSelected + ' sélectionnée(s) :';
     document.querySelector('#mark-as-read-notifications-btn').textContent = 'Marquer comme lue(s)';
-    document.querySelector('#delete-notifications-btn').textContent = 'Supprimer';
+    if (deleteBtn) {
+      deleteBtn.textContent = 'Supprimer';
+      // remove listeners to delete all notifications
+      const newDeleteBtn = deleteBtn.cloneNode(true);
+      deleteBtn.parentNode.replaceChild(newDeleteBtn, deleteBtn);
+    }
   } else {
     document.querySelector('#notification-selected-buttons-count').textContent = '';
     document.querySelector('#mark-as-read-notifications-btn').textContent =
       'Marquer comme lue(s) (tous)';
-    document.querySelector('#delete-notifications-btn').textContent = 'Vider';
+    if (deleteBtn) {
+      deleteBtn.textContent = 'Vider';
+      // add confirmation to delete all notifications
+      deleteBtn.addEventListener('click', (event) => {
+        if (histoNotificationSelected.length === 0) {
+          const confirmDeleteAll = confirm(
+            'Êtes-vous sûr de vouloir supprimer toutes les notifications ?'
+          );
+          if (!confirmDeleteAll) {
+            event.preventDefault();
+          }
+        }
+      });
+    }
   }
   document
     .querySelectorAll('#notification-selected-buttons input[name=selected_notifications]')

--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -6,7 +6,10 @@ import { initializeVisitesUploadFilesModal } from '../../controllers/back_signal
 import { openPhotoAlbumAddEventListeners } from '../../controllers/back_signalement_view/back_view_signalement.js';
 import { btnSignalementFileEditAddEventListeners } from '../../controllers/back_signalement_edit_file/back_signalement_edit_file.js';
 import { btnSignalementFileDeleteAddEventListeners } from '../file/file_delete.js';
-import { histoReinitNotification, histoRefreshNotificationButtons } from '../../controllers/form_notification.js';
+import {
+  histoReinitNotification,
+  histoRefreshNotificationButtons,
+} from '../../controllers/form_notification.js';
 
 const flashMessagesContainer = document.getElementById('flash-messages-live-container');
 

--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -6,6 +6,7 @@ import { initializeVisitesUploadFilesModal } from '../../controllers/back_signal
 import { openPhotoAlbumAddEventListeners } from '../../controllers/back_signalement_view/back_view_signalement.js';
 import { btnSignalementFileEditAddEventListeners } from '../../controllers/back_signalement_edit_file/back_signalement_edit_file.js';
 import { btnSignalementFileDeleteAddEventListeners } from '../file/file_delete.js';
+import { histoReinitNotification, histoRefreshNotificationButtons } from '../../controllers/form_notification.js';
 
 const flashMessagesContainer = document.getElementById('flash-messages-live-container');
 
@@ -81,6 +82,12 @@ export function jsonResponseProcess(response) {
             break;
           case 'btnSignalementFileDeleteAddEventListeners':
             btnSignalementFileDeleteAddEventListeners();
+            break;
+          case 'histoReinitNotification':
+            histoReinitNotification();
+            break;
+          case 'histoRefreshNotificationButtons':
+            histoRefreshNotificationButtons();
             break;
           default:
             console.warn(`Unknown function name: ${fn.name}`);

--- a/src/Controller/Back/NotificationController.php
+++ b/src/Controller/Back/NotificationController.php
@@ -96,15 +96,17 @@ class NotificationController extends AbstractController
             return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages]);
         }
 
+        $functions = [['name' => 'histoReinitNotification'], ['name' => 'histoRefreshNotificationButtons']];
         if ($request->request->get('selected_notifications')) {
             $notificationRepository->markUserNotificationsAsSeen($user, explode(',', (string) $request->request->get('selected_notifications')));
+            $flashMessages[] = ['type' => 'success', 'title' => 'Modifications enregistrées', 'message' => 'Les notifications sélectionnées ont bien été marquées comme lues.'];
         } else {
             $notificationRepository->markUserNotificationsAsSeen($user);
             $flashMessages[] = ['type' => 'success', 'title' => 'Modifications enregistrées', 'message' => 'Toutes les notifications ont bien été marquées comme lues.'];
         }
         $htmlTargetContents = $this->getHtmlTargetContentsForNotificationAction($request);
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/notifications/supprimer', name: 'back_notifications_list_delete')]
@@ -121,8 +123,10 @@ class NotificationController extends AbstractController
 
             return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages]);
         }
+        $functions = [['name' => 'histoReinitNotification'], ['name' => 'histoRefreshNotificationButtons']];
         if ($request->request->get('selected_notifications')) {
             $notificationRepository->deleteUserNotifications($user, explode(',', (string) $request->request->get('selected_notifications')));
+            $flashMessages[] = ['type' => 'success', 'title' => 'Notifications supprimées', 'message' => 'Les notifications sélectionnées ont bien été supprimées.'];
         } else {
             $notificationRepository->deleteUserNotifications($user);
             $flashMessages[] = ['type' => 'success', 'title' => 'Notifications supprimées', 'message' => 'Toutes les notifications ont bien été supprimées.'];
@@ -130,7 +134,7 @@ class NotificationController extends AbstractController
 
         $htmlTargetContents = $this->getHtmlTargetContentsForNotificationAction($request);
 
-        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'htmlTargetContents' => $htmlTargetContents]);
+        return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'htmlTargetContents' => $htmlTargetContents, 'functions' => $functions]);
     }
 
     #[Route('/notifications/{id}/supprimer', name: 'back_notifications_delete_notification')]

--- a/templates/back/notifications/_mass-action-btns.html.twig
+++ b/templates/back/notifications/_mass-action-btns.html.twig
@@ -6,7 +6,7 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token('mark_as_read_'~app.user.id) }}">
     <input type="hidden" name="search_params" value="{{searchParams}}">
 </form>
-<form method="POST" action="{{ path('back_notifications_list_delete') }}" class="simple-ajax-form">
+<form method="POST" action="{{ path('back_notifications_list_delete') }}" class="simple-ajax-form fr-ml-2w">
     <button type="submit" class="fr-btn fr-fi-delete-line fr-btn--danger fr-btn--icon-left" id="delete-notifications-btn">Vider</button>
     <input type="hidden" name="selected_notifications" value="">
     <input type="hidden" name="csrf_token" value="{{ csrf_token('delete_notifications_'~app.user.id) }}">

--- a/tests/Functional/Controller/NotificationControllerTest.php
+++ b/tests/Functional/Controller/NotificationControllerTest.php
@@ -87,7 +87,7 @@ class NotificationControllerTest extends WebTestCase
         $response = json_decode((string) $client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('stayOnPage', $response);
         $this->assertTrue($response['stayOnPage']);
-        $this->assertEquals([], $response['flashMessages']);
+        $this->assertEquals($msgFlash, $response['flashMessages'][0]['message']);
     }
 
     public function provideSelectedNotificationOptions(): \Generator


### PR DESCRIPTION
## Ticket

#3848   

## Description
Ajout d'une confirmation sur le bouton pour vider les notifications (pas de confirmation si une ou plusieurs notifs sélectionnées)
Et ajout d'une marge entre les boutons

## Pré-requis
`make npm-watch`

## Tests
- [ ] Vérifier le fonctionnement du bouton selon si il y a des notifs sélectionnées ou non
