### PR TITLE
[BO - Zone] Corrections accessibilité

### DIFF
--- a/src/Form/ZoneType.php
+++ b/src/Form/ZoneType.php
@@ -79,6 +79,7 @@ class ZoneType extends AbstractType
             },
             'placeholder' => 'Sélectionner le type de zone',
             'label' => 'Type de zone',
+            'required' => false,
         ]);
         $fileConstraints = [
             new Assert\File(
@@ -91,7 +92,7 @@ class ZoneType extends AbstractType
             'label' => $zone->getId() ? 'Modifier depuis un fichier (en cas de modification des coordonnées de la zone uniquement)' : 'Importer depuis un fichier',
             'required' => false,
             'mapped' => false,
-            'help' => 'Le fichier doit être au format CSV séparé par des virgules et contenir une colonnne "WKT", <a href="'.$modeleUrl.'">voir le template</a>',
+            'help' => 'Le fichier doit être au format CSV séparé par des virgules et contenir une colonnne "WKT", <a href="'.$modeleUrl.'">voir le template (fichier CSV, 239 octets)</a>',
             'help_html' => true,
             'constraints' => $fileConstraints,
         ]);

--- a/templates/back/zone/edit.html.twig
+++ b/templates/back/zone/edit.html.twig
@@ -21,6 +21,7 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
                     <h1 class="fr-mb-0">Zone {{zone.name}}</h1>
+                    <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
                 </div>
             </div>
         </header>
@@ -49,11 +50,15 @@
                 <div class="fr-col-12">
                     {{ form_row(form.area) }}
                 </div>
-                <div class="fr-col-6">
-                    <a href="{{path('back_territory_management_zone_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
-                </div>
-                <div class="fr-col-6">
-                    {{ form_row(form.save) }}
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            {{ form_row(form.save) }}
+                        </li>
+                        <li>
+                            <a href="{{path('back_territory_management_zone_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                        </li>
+                    </ul>
                 </div>
             </div>
             {{ form_end(form) }}

--- a/templates/back/zone/index.html.twig
+++ b/templates/back/zone/index.html.twig
@@ -86,6 +86,7 @@
                                 <h1 id="fr-modal-title-zone-add" class="fr-modal__title">
                                     Ajouter une zone
                                 </h1>
+                                <span>Tous les champs sont obligatoires.</span>
                                 {{form(addForm, {'attr': {'id': 'form-add-zone'}} )}}
                             </div>
                             <div class="fr-modal__footer">


### PR DESCRIPTION
## Ticket

#5770   

## Description
- Ajouter une zone http://localhost:8080/bo/gerer-territoire/zone/
Dans la modale, ajouter une mention "`Tous les champs sont obligatoires`"
Gérer l'erreur sur le Type de zone :

- Visualisation zone http://localhost:8080/bo/gerer-territoire/zone/3
OK

- Edition zone http://localhost:8080/bo/gerer-territoire/zone/editer/3
lien "voir le template", préciser que ça télécharge un csv, et préciser le poids
Inverser le bouton `Valider` et `annuler` dans le DOM (si c'est bien ce qu'on a décidé partout ailleurs) pour la navigation au clavier 
Préciser que tous les champs sont obligatoires sauf mention contraire

## Changements apportés
* Changement des twigs et formType

## Pré-requis

## Tests
- [ ] Tester l'ajout et l'édition d'une zone
- [ ] Vérifier les points ci-dessus, et vérifier que tout fonctionne toujours
