### PR TITLE
[Tech] Ignorer le répertoire test dans le déploiement

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -18,3 +18,4 @@ assets
 tools
 node_modules
 vendor/node
+tests

--- a/.slugignore
+++ b/.slugignore
@@ -1,7 +1,9 @@
 .buildpacks
 .env.sample
+.env.ci
 .gitignore
 .php-cs-fixer.dist.php
+.git
 docker-compose.yml
 docker-compose.tools.yml
 grumphp.yml
@@ -12,6 +14,7 @@ phpunit.xml.dist
 scalingo.json
 scripts/upload-s3.sh
 
+.ai
 .docker
 .github
 assets

--- a/tests/Functional/Repository/Behaviour/AffectationUpdaterTest.php
+++ b/tests/Functional/Repository/Behaviour/AffectationUpdaterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Functional\Repository\Query\Statistics;
+namespace App\Tests\Functional\Repository\Behaviour;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;


### PR DESCRIPTION
## Ticket

#5817   

## Description
Ignorer le répertoire tests dans le déploiement

## Changements apportés
* Mise à jour `.slugignore`

## Pré-requis

## Tests
- [ ] CD OK avec absence du répertoire tests sur le serveur
- [ ] Voir logs déploiement https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging-pr5818/deploy/list 
- [ ] App OK https://histologe-staging-pr5818.osc-fr1.scalingo.io/bo/