### PR TITLE
[Démarche accélérée - FO Bailleur] Permettre au bailleur d'envoyer un suivi et des docs pendant la procédure

### DIFF
--- a/assets/scripts/app-back-bo.ts
+++ b/assets/scripts/app-back-bo.ts
@@ -9,7 +9,6 @@ import './vanilla/services/component/component_search_checkbox.js';
 import './vanilla/services/component/component_select_all_checkbox.js';
 import './vanilla/services/component/component_search_autocomplete.js';
 import './vanilla/services/component/component_search_and_select_badges.js';
-import './vanilla/services/form/ajax_form_handler.js';
 import './vanilla/services/ui/list_filter_helper.js';
 import './vanilla/services/ui/metabase_resizer.js';
 import './vanilla/services/ui/modales_helper.js';

--- a/assets/scripts/app.ts
+++ b/assets/scripts/app.ts
@@ -11,6 +11,7 @@ import './vanilla/services/component/pick-localisation.js';
 import './vanilla/services/component/component_autocomplete_bailleur.js';
 import './vanilla/services/cookie/cookie_banner.js';
 import './vanilla/services/file/file_delete.js';
+import './vanilla/services/form/ajax_form_handler.js';
 import './vanilla/services/form/form_helper.js';
 import './vanilla/services/matomo/matomo_events_pusher.js';
 import './vanilla/services/ui/notice_helper.js';

--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -21,11 +21,14 @@ export function jsonResponseProcess(response) {
     const currentUrl = new URL(window.location.href);
 
     if (currentUrl.pathname === targetUrl.pathname && currentUrl.search === targetUrl.search) {
-      if (response._fragment) {
-        window.location.hash = `#${response._fragment}`;
+      if (response.scrollToTop) {
+        window.location.href = targetUrl.href;
+      } else {
+        if (response._fragment) {
+          window.location.hash = `#${response._fragment}`;
+        }
+        window.location.reload();
       }
-
-      window.location.reload();
     } else {
       window.location.href = targetUrl.href;
     }

--- a/migrations/Version20260504151832.php
+++ b/migrations/Version20260504151832.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Enum\SuiviCategory;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260504151832 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set is_visible_for_bailleur = true for all suivis submitted by bailleur';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (SuiviCategory::CategoriesSubmittedByBailleur() as $category) {
+            $this->addSql('UPDATE suivi SET is_visible_for_bailleur = 1 WHERE category = :category', ['category' => $category->value]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (SuiviCategory::CategoriesSubmittedByBailleur() as $category) {
+            $this->addSql('UPDATE suivi SET is_visible_for_bailleur = 0 WHERE category = :category', ['category' => $category->value]);
+        }
+    }
+}

--- a/src/Controller/SuiviBailleurController.php
+++ b/src/Controller/SuiviBailleurController.php
@@ -230,7 +230,7 @@ class SuiviBailleurController extends AbstractController
             $files = $formMessage->get('files')->getData();
             $fileList = $signalementFileProcessor->process($files, DocumentType::MESSAGE_BAILLEUR);
             if (!$signalementFileProcessor->isValid()) {
-                $errors = ['files' => ['errors' => [$signalementFileProcessor->getErrorMessages().'TEST']]];
+                $errors = ['files' => ['errors' => [$signalementFileProcessor->getErrorMessages()]]];
                 $response = ['code' => Response::HTTP_BAD_REQUEST, 'errors' => $errors];
 
                 return $this->json($response, $response['code']);

--- a/src/Controller/SuiviBailleurController.php
+++ b/src/Controller/SuiviBailleurController.php
@@ -7,17 +7,24 @@ use App\Dto\StopProcedure;
 use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
+use App\Entity\Suivi;
+use App\Form\MessageBailleurType;
 use App\Form\ReponseInjonctionBailleurType;
 use App\Form\SignalementeEditFO\CoordonneesBailleurType;
 use App\Form\StopProcedureType;
+use App\Manager\SuiviManager;
 use App\Repository\FileRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\SuiviRepository;
 use App\Security\User\SignalementBailleur;
+use App\Security\Voter\SignalementBailleurVoter;
 use App\Service\Files\ImageVariantProvider;
 use App\Service\InjonctionBailleur\EngagementTravauxBailleurGenerator;
 use App\Service\InjonctionBailleur\InjonctionBailleurService;
 use App\Service\Signalement\SignalementDesordresProcessor;
+use App\Service\Signalement\SignalementFileProcessor;
+use App\Utils\FormHelper;
+use App\Utils\HtmlCleaner;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -51,6 +58,10 @@ class SuiviBailleurController extends AbstractController
         $suiviReponse = $suiviRepository->findOneBy(['signalement' => $signalement, 'category' => SuiviCategory::injonctionBailleurReponseCategories()]);
         $suiviBasculeProcedure = $suiviRepository->findOneBy(['signalement' => $signalement, 'category' => SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR]);
         $suiviDemandeCloture = $suiviRepository->findOneBy(['signalement' => $signalement, 'category' => SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR]);
+        $formMessage = null;
+        if ($this->isGranted(SignalementBailleurVoter::SIGN_BAILLEUR_ADD_SUIVI, $signalement)) {
+            $formMessage = $this->createForm(MessageBailleurType::class, null, ['action' => $this->generateUrl('front_dossier_bailleur_add_message')]);
+        }
 
         $engagementTravauxPdf = null;
         $form = null;
@@ -109,6 +120,7 @@ class SuiviBailleurController extends AbstractController
             'suiviDemandeCloture' => $suiviDemandeCloture,
             'dateLimit' => $dateLimit,
             'form' => $form,
+            'formMessage' => $formMessage,
             'engagementTravauxPdf' => $engagementTravauxPdf,
         ]);
     }
@@ -193,5 +205,54 @@ class SuiviBailleurController extends AbstractController
         $response->headers->set('Content-Disposition', 'inline; filename="engagement-travaux-'.$signalement->getReferenceInjonction().'.pdf"');
 
         return $response;
+    }
+
+    #[Route('/envoie-message', name: 'front_dossier_bailleur_add_message', methods: ['POST'])]
+    public function addMessage(
+        Request $request,
+        SignalementRepository $signalementRepository,
+        SignalementFileProcessor $signalementFileProcessor,
+        SuiviManager $suiviManager,
+    ): Response {
+        /**
+         * @var SignalementBailleur $user
+         */
+        $user = $this->getUser();
+        $signalement = $signalementRepository->findOneBy(['uuid' => $user->getUserIdentifier()]);
+
+        if (!$this->isGranted(SignalementBailleurVoter::SIGN_BAILLEUR_ADD_SUIVI, $signalement)) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $formMessage = $this->createForm(MessageBailleurType::class, null, ['action' => $this->generateUrl('front_dossier_bailleur_add_message')]);
+        $formMessage->handleRequest($request);
+        if ($formMessage->isSubmitted() && $formMessage->isValid()) {
+            $files = $formMessage->get('files')->getData();
+            $fileList = $signalementFileProcessor->process($files, DocumentType::MESSAGE_BAILLEUR);
+            if (!$signalementFileProcessor->isValid()) {
+                $errors = ['files' => ['errors' => [$signalementFileProcessor->getErrorMessages().'TEST']]];
+                $response = ['code' => Response::HTTP_BAD_REQUEST, 'errors' => $errors];
+
+                return $this->json($response, $response['code']);
+            }
+            $filesToAttach = $signalementFileProcessor->addFilesToSignalement(fileList: $fileList, signalement: $signalement);
+            $description = HtmlCleaner::cleanFrontEndEntry($formMessage->get('description')->getData());
+            $suiviManager->createSuivi(
+                signalement: $signalement,
+                description: $description,
+                type: Suivi::TYPE_USAGER,
+                category: SuiviCategory::MESSAGE_BAILLEUR,
+                isVisibleForBailleur: true,
+                files: $filesToAttach
+            );
+
+            $this->addFlash('success', ['title' => 'Message envoyé', 'message' => 'Votre message a été envoyé avec succès.']);
+
+            return $this->json(['redirect' => true, 'scrollToTop' => true, 'url' => $this->generateUrl('front_dossier_bailleur')]);
+        }
+
+        $response = ['code' => Response::HTTP_BAD_REQUEST, 'errors' => FormHelper::getErrorsFromForm($formMessage)];
+
+        return $this->json($response, $response['code']);
     }
 }

--- a/src/Controller/SuiviBailleurController.php
+++ b/src/Controller/SuiviBailleurController.php
@@ -207,7 +207,7 @@ class SuiviBailleurController extends AbstractController
         return $response;
     }
 
-    #[Route('/envoie-message', name: 'front_dossier_bailleur_add_message', methods: ['POST'])]
+    #[Route('/envoi-message', name: 'front_dossier_bailleur_add_message', methods: ['POST'])]
     public function addMessage(
         Request $request,
         SignalementRepository $signalementRepository,

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -154,6 +154,27 @@ suivis:
   type: 1
   category: "INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE"
 - 
+  created_by: viens@ramontafrez.com
+  description: "Tout a été fait, le locataire est extrêmement satisfait."
+  is_public: 0
+  signalement: "00000000-0000-0000-2025-000000000012"
+  type: 2
+  category: "MESSAGE_BAILLEUR"
+- 
+  created_by: fox.mulder@fbi.com
+  description: "Le bailleur est vraiment casse pied, Je n'en peux plus de lui !"
+  is_public: 1
+  signalement: "00000000-0000-0000-2025-000000000012"
+  type: 2
+  category: "MESSAGE_USAGER"
+- 
+  created_by: user-34-01@signal-logement.fr
+  description: "Suivi privé : le bailleur indique avoir fait les travaux mais le locataire dément."
+  is_public: 0
+  signalement: "00000000-0000-0000-2025-000000000012"
+  type: 3
+  category: "MESSAGE_PARTNER"
+- 
   created_by: admin-partenaire-13-01@signal-logement.fr
   description: "Un suivi pour abonner l'utilisateur."
   is_public: 0

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -99,6 +99,7 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             partner: $createdBy?->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $createdBy,
             isVisibleForUsager: $row['is_public'],
+            isVisibleForBailleur: in_array($category, SuiviCategory::CategoriesSubmittedByBailleur()),
             createdAt: $createdAt,
             context: $context,
             flush: false,

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -32,6 +32,7 @@ enum DocumentType: string
     case ANNUAIRE = 'ANNUAIRE';
     case AUTRE = 'AUTRE';
     case ENGAGEMENT_TRAVAUX_BAILLEUR = 'ENGAGEMENT_TRAVAUX_BAILLEUR';
+    case MESSAGE_BAILLEUR = 'MESSAGE_BAILLEUR';
 
     /** @return array<string, string> */
     public static function getLabelList(): array
@@ -61,6 +62,7 @@ enum DocumentType: string
             self::ANNUAIRE->name => 'Annuaire',
             self::AUTRE->name => 'Autre',
             self::ENGAGEMENT_TRAVAUX_BAILLEUR->name => 'Engagement travaux bailleur',
+            self::MESSAGE_BAILLEUR->name => 'Message bailleur',
         ];
     }
 

--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -37,6 +37,7 @@ enum SuiviCategory: string
     case DOCUMENT_DELETED_BY_USAGER = 'DOCUMENT_DELETED_BY_USAGER';
     case DOCUMENT_DELETED_BY_PARTNER = 'DOCUMENT_DELETED_BY_PARTNER';
     case MESSAGE_USAGER = 'MESSAGE_USAGER';
+    case MESSAGE_BAILLEUR = 'MESSAGE_BAILLEUR';
     case MESSAGE_USAGER_POST_CLOTURE = 'MESSAGE_USAGER_POST_CLOTURE';
     case SIGNALEMENT_EDITED_FO = 'SIGNALEMENT_EDITED_FO';
     case DEMANDE_ABANDON_PROCEDURE = 'DEMANDE_ABANDON_PROCEDURE';
@@ -106,6 +107,7 @@ enum SuiviCategory: string
             'DOCUMENT_DELETED_BY_USAGER' => 'Document supprimé par l\'usager',
             'DOCUMENT_DELETED_BY_PARTNER' => 'Document supprimé par le partenaire',
             'MESSAGE_USAGER' => 'Message de l\'usager',
+            'MESSAGE_BAILLEUR' => 'Message du bailleur',
             'MESSAGE_USAGER_POST_CLOTURE' => 'Message de l\'usager après clôture',
             'SIGNALEMENT_EDITED_FO' => 'Édition du dossier par l\'usager',
             'DEMANDE_ABANDON_PROCEDURE' => 'Demande d\'abandon de procédure par l\'usager',
@@ -131,6 +133,7 @@ enum SuiviCategory: string
     public static function CategoriesSubmittedByBailleur(): array
     {
         return [
+            self::MESSAGE_BAILLEUR,
             self::INJONCTION_BAILLEUR_REPONSE_OUI,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES,

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -428,6 +428,16 @@ class File implements EntityHistoryInterface
         return $this->isTypeImage() && $this->isProcedure() && null === $this->intervention;
     }
 
+    public function isBailleurImage(): bool
+    {
+        return $this->isTypeImage() && DocumentType::MESSAGE_BAILLEUR === $this->documentType;
+    }
+
+    public function isBailleurDocument(): bool
+    {
+        return $this->isTypeDocument() && DocumentType::MESSAGE_BAILLEUR === $this->documentType;
+    }
+
     /**
      * @noinspection PhpUnused
      *

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -8,6 +8,7 @@ use App\Entity\Behaviour\EntityHistoryInterface;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\CreationSource;
 use App\Entity\Enum\DebutDesordres;
+use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\MotifClotureUsager;
@@ -2548,6 +2549,17 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
             return true;
         });
+    }
+
+    public function hasFilesBailleur(): bool
+    {
+        foreach ($this->files as $file) {
+            if (DocumentType::MESSAGE_BAILLEUR === $file->getDocumentType()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function addFile(File $file): static

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -202,7 +202,7 @@ class Suivi implements EntityHistoryInterface
         return $this->getCreatedBy()?->getNomComplet($firstNameFirst);
     }
 
-    public function getCreatedByLabel(string $separator = ' : '): ?string
+    public function getCreatedByLabel(string $separator = ' : ', bool $forBailleur = false): ?string
     {
         if (self::TYPE_TECHNICAL === $this->type) {
             return 'Suivi automatique';
@@ -226,7 +226,7 @@ class Suivi implements EntityHistoryInterface
             return $this->getCreatedBy()->getPartnerInTerritoryOrFirstOne($this->getSignalement()->getTerritory())?->getNom().$separator.$this->getCreatedBy()->getNomComplet(true);
         }
         if (in_array($this->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
-            return 'Bailleur';
+            return $forBailleur ? 'Vous (bailleur)' : 'Bailleur';
         }
         if ($this->getCreatedAt()->format('Y') >= 2024) {
             return 'Occupant ou déclarant';

--- a/src/Form/MessageBailleurType.php
+++ b/src/Form/MessageBailleurType.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\File;
+use App\Service\UploadHandlerService;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class MessageBailleurType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('description', TextareaType::class, [
+                'label' => 'Votre message',
+                'help' => 'Dix (10) caractères minimum.',
+                'attr' => [
+                    'rows' => 5,
+                ],
+                'required' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(
+                        min: 10,
+                        minMessage: 'Le message doit contenir au moins {{ limit }} caractères.',
+                    ),
+                ],
+            ])
+            ->add('files', FileType::class, [
+                'label' => 'Ajouter des documents (facultatif)',
+                'help' => 'Taille maximale par document : 10 Mo, Formats supportés : '.UploadHandlerService::getAcceptedExtensions(),
+                'required' => false,
+                'multiple' => true,
+                'constraints' => [
+                    new Assert\All([
+                        new Assert\File([
+                            'maxSize' => '10M',
+                            'mimeTypes' => File::DOCUMENT_MIME_TYPES,
+                            'mimeTypesMessage' => 'Veuillez télécharger un fichier au format '.UploadHandlerService::getAcceptedExtensions().', et ne dépassant pas 10 Mo.',
+                        ]),
+                    ]),
+                ],
+            ])
+        ;
+    }
+}

--- a/src/Form/MessageUsagerType.php
+++ b/src/Form/MessageUsagerType.php
@@ -13,7 +13,8 @@ class MessageUsagerType extends AbstractType
     {
         $builder
             ->add('description', TextareaType::class, [
-                'label' => false,
+                'label' => 'Votre message',
+                'help' => 'Dix (10) caractères minimum.',
                 'attr' => [
                     'rows' => 5,
                 ],

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -130,6 +130,7 @@ class SuiviManager extends Manager
             SuiviCategory::AFFECTATION_IS_REFUSED,
             SuiviCategory::MESSAGE_USAGER,
             SuiviCategory::MESSAGE_USAGER_POST_CLOTURE,
+            SuiviCategory::MESSAGE_BAILLEUR,
             SuiviCategory::DOCUMENT_DELETED_BY_USAGER,
             SuiviCategory::DEMANDE_ABANDON_PROCEDURE,
             SuiviCategory::DEMANDE_POURSUITE_PROCEDURE,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -21,10 +21,10 @@ use App\Service\Security\PartnerAuthorizedResolver;
 use App\Utils\Address\CommuneHelper;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -522,20 +522,22 @@ class SignalementRepository extends ServiceEntityRepository
                     )
                 AND s.statut = :statusSignalement
                 AND s.territory_id = :territoryId
-                AND su.type IN (:suiviTypeUsagers)
+                AND su.category IN (:suiviTypeUsagers)
                 GROUP BY s.id
                 HAVING dernier_suivi_date > \''.self::DATE_FEEDBACK_USAGER_ONLINE.'\'
                 ORDER BY dernier_suivi_date DESC
                 LIMIT '.$limit.';';
 
-        $statement = $connexion->prepare($sql);
-
-        return $statement->executeQuery([
-            'statusSignalement' => SignalementStatus::ACTIVE->value,
-            'territoryId' => $territory->getId(),
-            'suiviTypeTechnical' => Suivi::TYPE_TECHNICAL,
-            'suiviTypeUsagers' => SuiviCategory::categoriesSubmittedByUsager(),
-        ])->fetchAllAssociative();
+        return $connexion->executeQuery(
+            $sql,
+            [
+                'statusSignalement' => SignalementStatus::ACTIVE->value,
+                'territoryId' => $territory->getId(),
+                'suiviTypeTechnical' => Suivi::TYPE_TECHNICAL,
+                'suiviTypeUsagers' => array_map(static fn ($c) => $c->value, SuiviCategory::categoriesSubmittedByUsager()),
+            ],
+            ['suiviTypeUsagers' => ArrayParameterType::STRING]
+        )->fetchAllAssociative();
     }
 
     /**

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -522,7 +522,7 @@ class SignalementRepository extends ServiceEntityRepository
                     )
                 AND s.statut = :statusSignalement
                 AND s.territory_id = :territoryId
-                AND su.type = :suiviTypeUsager
+                AND su.type IN (:suiviTypeUsagers)
                 GROUP BY s.id
                 HAVING dernier_suivi_date > \''.self::DATE_FEEDBACK_USAGER_ONLINE.'\'
                 ORDER BY dernier_suivi_date DESC
@@ -534,7 +534,7 @@ class SignalementRepository extends ServiceEntityRepository
             'statusSignalement' => SignalementStatus::ACTIVE->value,
             'territoryId' => $territory->getId(),
             'suiviTypeTechnical' => Suivi::TYPE_TECHNICAL,
-            'suiviTypeUsager' => Suivi::TYPE_USAGER,
+            'suiviTypeUsagers' => SuiviCategory::categoriesSubmittedByUsager(),
         ])->fetchAllAssociative();
     }
 

--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -90,6 +90,9 @@ class FileVoter extends Voter
         if ($file->getIntervention() && DocumentType::PROCEDURE_RAPPORT_DE_VISITE === $file->getDocumentType()) {
             return false;
         }
+        if (DocumentType::MESSAGE_BAILLEUR === $file->getDocumentType()) {
+            return false;
+        }
 
         return $this->canCreate($file, $user) && ($this->isFileUploadedByUser($file, $user) || $this->isAdminOrRTonHisTerritory($file, $user));
     }

--- a/src/Security/Voter/SignalementBailleurVoter.php
+++ b/src/Security/Voter/SignalementBailleurVoter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Enum\SignalementStatus;
+use App\Entity\Signalement;
+use App\Entity\User;
+use App\Security\User\SignalementBailleur;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<string, Signalement>
+ */
+class SignalementBailleurVoter extends Voter
+{
+    public const string SIGN_BAILLEUR_HAS_RESPONSE_INJONCTION = 'SIGN_BAILLEUR_HAS_RESPONSE_INJONCTION';
+    public const string SIGN_BAILLEUR_ADD_SUIVI = 'SIGN_BAILLEUR_ADD_SUIVI';
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return \in_array($attribute, [self::SIGN_BAILLEUR_ADD_SUIVI, self::SIGN_BAILLEUR_HAS_RESPONSE_INJONCTION]) && ($subject instanceof Signalement);
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        /** @var User|null $user */
+        $user = $token->getUser();
+
+        if (!$user instanceof SignalementBailleur) {
+            $vote?->addReason('Le bailleur n\'est pas authentifié');
+
+            return false;
+        }
+
+        return match ($attribute) {
+            self::SIGN_BAILLEUR_HAS_RESPONSE_INJONCTION => $this->isSignalementHasResponseInjonction($subject),
+            self::SIGN_BAILLEUR_ADD_SUIVI => $this->canBailleurAddSuivi($subject),
+            default => false,
+        };
+    }
+
+    private function isSignalementHasResponseInjonction(Signalement $signalement): bool
+    {
+        return $signalement->getSuiviReponseBailleur() ? true : false;
+    }
+
+    private function canBailleurAddSuivi(Signalement $signalement): bool
+    {
+        if (in_array($signalement->getStatut(), [
+            SignalementStatus::CLOSED,
+            SignalementStatus::ARCHIVED,
+            SignalementStatus::REFUSED,
+            SignalementStatus::INJONCTION_CLOSED,
+        ], true)) {
+            return false;
+        }
+
+        // autorisé si le bailleur a répondu à l'injonction et que le signalement est encore en cours, y compris aprés bascule de procédure
+        return $this->isSignalementHasResponseInjonction($signalement);
+    }
+}

--- a/src/Service/Files/FileListService.php
+++ b/src/Service/Files/FileListService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Files;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -43,8 +44,19 @@ class FileListService
             });
             $choices['Documents liés à la procédure'] = $procedureFilesSorted;
         }
+        // 3. Documents bailleur
+        $bailleurFiles = $signalement->getFiles()->filter(static function (File $file) {
+            return !$file->getIsSuspicious() && DocumentType::MESSAGE_BAILLEUR === $file->getDocumentType();
+        });
+        if (!$bailleurFiles->isEmpty()) {
+            $bailleurFilesSorted = $bailleurFiles->toArray();
+            usort($bailleurFilesSorted, static function (File $a, File $b) {
+                return strcmp($a->getTitle(), $b->getTitle());
+            });
+            $choices['Documents du bailleur'] = $bailleurFilesSorted;
+        }
 
-        // 3. Documents types (fichiers standalone)
+        // 4. Documents types (fichiers standalone)
         $standaloneFiles = $this->fileRepository->createQueryBuilder('f')
             ->where('f.isStandalone = :isStandalone')
             ->andWhere('f.territory = :territory OR f.territory IS NULL')

--- a/src/Service/InjonctionBailleur/InjonctionBailleurService.php
+++ b/src/Service/InjonctionBailleur/InjonctionBailleurService.php
@@ -59,7 +59,8 @@ class InjonctionBailleurService
                     description: $contenu,
                     type: Suivi::TYPE_AUTO,
                     category: $category,
-                    isVisibleForUsager: true
+                    isVisibleForUsager: true,
+                    isVisibleForBailleur: true
                 );
                 if (!empty($description)) {
                     $this->createInjonctionBailleurCommentaireSuivi($signalement, $description);
@@ -74,7 +75,8 @@ class InjonctionBailleurService
                     description: $contenu,
                     type: Suivi::TYPE_AUTO,
                     category: $category,
-                    isVisibleForUsager: true
+                    isVisibleForUsager: true,
+                    isVisibleForBailleur: true
                 );
                 $this->createInjonctionBailleurCommentaireSuivi($signalement, $description);
                 $this->saveEngagementTravauxBailleurPdf($signalement);
@@ -88,7 +90,8 @@ class InjonctionBailleurService
                     description: $contenu,
                     type: Suivi::TYPE_AUTO,
                     category: $category,
-                    isVisibleForUsager: true
+                    isVisibleForUsager: true,
+                    isVisibleForBailleur: true
                 );
                 $this->createInjonctionBailleurCommentaireSuivi($signalement, $description);
                 $this->saveEngagementTravauxBailleurPdf($signalement);
@@ -101,7 +104,8 @@ class InjonctionBailleurService
                     description: $contenu,
                     type: Suivi::TYPE_AUTO,
                     category: $category,
-                    isVisibleForUsager: true
+                    isVisibleForUsager: true,
+                    isVisibleForBailleur: true
                 );
                 $this->createInjonctionBailleurCommentaireSuivi($signalement, $description);
                 $this->switchFromInjonctionToProcedure($signalement);
@@ -131,6 +135,7 @@ class InjonctionBailleurService
             description: HtmlCleaner::cleanFrontEndEntry($description),
             type: Suivi::TYPE_AUTO,
             category: SuiviCategory::INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE,
+            isVisibleForBailleur: true
         );
     }
 
@@ -168,7 +173,8 @@ class InjonctionBailleurService
                 description: 'Le bailleur souhaite arrêter la procédure d\'injonction, le signalement va être pris en charge par les partenaires compétents.',
                 type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR,
-                isVisibleForUsager: true
+                isVisibleForUsager: true,
+                isVisibleForBailleur: true
             );
 
             $this->suiviManager->createSuivi(
@@ -176,6 +182,7 @@ class InjonctionBailleurService
                 description: HtmlCleaner::cleanFrontEndEntry($description),
                 type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR_COMMENTAIRE,
+                isVisibleForBailleur: true
             );
 
             $this->switchFromInjonctionToProcedure($signalement);
@@ -187,7 +194,8 @@ class InjonctionBailleurService
                 description: 'Votre bailleur souhaite terminer la démarche pour le motif suivant : les travaux ont été réalisés. Veuillez confirmer sur la page d\'accueil de votre dossier.',
                 type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR,
-                isVisibleForUsager: true
+                isVisibleForUsager: true,
+                isVisibleForBailleur: true
             );
 
             $this->suiviManager->createSuivi(
@@ -195,6 +203,7 @@ class InjonctionBailleurService
                 description: HtmlCleaner::cleanFrontEndEntry($description),
                 type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR_COMMENTAIRE,
+                isVisibleForBailleur: true
             );
             $this->entityManager->flush();
         }

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
+use App\Entity\Enum\SuiviCategory;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -40,6 +41,8 @@ class SuiviNewCommentBackMailer extends AbstractNotificationMailer
             if ($suivi->getPartner()) {
                 $suiviCreator .= ' ('.$suivi->getPartner()->getNom().')';
             }
+        } elseif (in_array($suivi->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
+            $suiviCreator = $signalement->getDisplayedNomProprio().' (bailleur)';
         } elseif ($signalement->getPrenomDeclarant()) {
             $suiviCreator = $signalement->getPrenomDeclarant().' '.$signalement->getNomDeclarant();
         }

--- a/src/Service/Signalement/PhotoHelper.php
+++ b/src/Service/Signalement/PhotoHelper.php
@@ -27,13 +27,15 @@ class PhotoHelper
     public static function getSortedPhotos(Signalement $signalement, ?string $type = null): array
     {
         $photoList = $signalement->getPhotos()->toArray();
-        $photoListByType = ['situation' => [], 'procédure' => [], 'visite' => []];
+        $photoListByType = ['situation' => [], 'procédure' => [], 'visite' => [], 'bailleur' => []];
 
         foreach ($photoList as $photoItem) {
             if ($photoItem->isSituationImage()) {
                 $photoListByType['situation'][] = $photoItem;
             } elseif ($photoItem->isProcedureImage()) {
                 $photoListByType['procédure'][] = $photoItem;
+            } elseif ($photoItem->isBailleurImage()) {
+                $photoListByType['bailleur'][] = $photoItem;
             } else {
                 $photoListByType['visite'][] = $photoItem;
             }
@@ -65,6 +67,6 @@ class PhotoHelper
             return $photoListByType[$type] ?? [];
         }
 
-        return array_merge($photoListByType['situation'], $photoListByType['procédure'], $photoListByType['visite']);
+        return array_merge($photoListByType['situation'], $photoListByType['procédure'], $photoListByType['visite'], $photoListByType['bailleur']);
     }
 }

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -1,83 +1,91 @@
 {% if zonetitle is not null and listAllPhotos is not defined %}
-    <div class="fr-grid-row">
-        <div class="fr-col-9 fr-col-md-6">
-            <h3 class="fr-h5">{{ zonetitle }}</h3>
+    {% if context is same as 'documents-bailleur' and signalement.hasFilesBailleur() %}
+        <div class="fr-grid-row">
+            <div class="fr-col-12">
+                <h3 class="fr-h5">{{ zonetitle }}</h3>
+            </div>
         </div>
-        <div class="fr-col-3 fr-col-md-6 fr-text--right">
-            {% if (is_granted('SIGN_EDIT_ACTIVE', signalement)
-                or is_granted('SIGN_EDIT_CLOSED', signalement)
-                or is_granted('SIGN_EDIT_INJONCTION', signalement))
-                and filesFilter is not same as 'visite'
-            %}
-                {% if filesFilter is same as 'procédure' %}
-                    <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
-                        <li>
-                            <button
-                            class="fr-btn fr-btn--secondary fr-icon-file-add-line open-modal-upload-files-btn"
-                            data-fr-opened="false"
-                            aria-controls="fr-modal-upload-files"
-                            data-file-filter={{filesFilter}}
-                            >
-                                Ajouter des documents sur la {{filesFilter}}
-                            </button>
-                        </li>
-                    </ul>
-                {% elseif filesFilter is same as 'situation'
-                    and (context is same as 'documents-situation' or context is same as 'allphotosituation')
+    {% else %}
+        <div class="fr-grid-row">
+            <div class="fr-col-9 fr-col-md-6">
+                <h3 class="fr-h5">{{ zonetitle }}</h3>
+            </div>
+            <div class="fr-col-3 fr-col-md-6 fr-text--right">
+                {% if (is_granted('SIGN_EDIT_ACTIVE', signalement)
+                    or is_granted('SIGN_EDIT_CLOSED', signalement)
+                    or is_granted('SIGN_EDIT_INJONCTION', signalement))
+                    and filesFilter is not same as 'visite'
                 %}
-                    {% include'back/signalement/view/_menu_actions_photo_situation.html.twig' %}
+                    {% if filesFilter is same as 'procédure' %}
+                        <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
+                            <li>
+                                <button
+                                class="fr-btn fr-btn--secondary fr-icon-file-add-line open-modal-upload-files-btn"
+                                data-fr-opened="false"
+                                aria-controls="fr-modal-upload-files"
+                                data-file-filter={{filesFilter}}
+                                >
+                                    Ajouter des documents sur la {{filesFilter}}
+                                </button>
+                            </li>
+                        </ul>
+                    {% elseif filesFilter is same as 'situation'
+                        and (context is same as 'documents-situation' or context is same as 'allphotosituation')
+                    %}
+                        {% include'back/signalement/view/_menu_actions_photo_situation.html.twig' %}
+                    {% endif %}
                 {% endif %}
+            </div>
+            {% if filesFilter is same as 'situation' %}
+                <p class="fr-text--sm fr-mt-n2w fr-mb-2w">
+                    Ajoutez ici des photos ou documents concernant la situation de l'usager (photos de désordres, bail, DPE, diagnostic et état des lieux). 
+                    Les fichiers ajoutés sont partagés à l'usager.
+                    <br>
+                    Vous ne pouvez pas supprimer les documents ajoutés par l'usager.
+                </p>
+            {% endif %}
+            {% if filesFilter is same as 'procédure' %}
+                <p class="fr-text--sm fr-mt-n2w fr-mb-2w">
+                    Ajoutez ici les documents liés à la procédure (mise en demeure, rapport de visite, arrêté, etc.).
+                    <br>
+                    Vous pouvez supprimer uniquement les documents que vous avez ajoutés.
+                </p>
+            {% endif %}
+            {% if  filesFilter is same as 'situation'
+                and (context is same as 'documents-situation' or context is same as 'allphotosituation')
+            %}
+                <div class="fr-col-12">
+                    <div id="zip-selection-bar" class="zip-selection-bar fr-display-flex-row fr-justify-content-right fr-mb-2w">
+                        <strong><span id="zip-selection-count">0</span> photos sélectionnées</strong>
+                        <form method="post"
+                            action="{{ path('back_signalement_generate_zip_selection', {uuid: signalement.uuid}) }}"
+                            class="zip-selection-bar__form">
+                            <input type="hidden" name="_token" value="{{ csrf_token('zip_selection_' ~ signalement.uuid) }}">
+                            <div id="zip-selection-hidden-fields"></div>
+                            <div class="zip-selection-bar__actions">
+                                <button
+                                        type="button"
+                                        id="zip-selection-cancel"
+                                        class="fr-btn fr-btn--secondary fr-icon-close-line fr-btn--icon-left"
+                                >
+                                    Annuler
+                                </button>
+                                <button
+                                        type="submit"
+                                        id="zip-selection-submit"
+                                        class="fr-btn fr-icon-download-line fr-btn--icon-left"
+                                        aria-disabled="true"
+                                        disabled
+                                >
+                                    Télécharger la sélection
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             {% endif %}
         </div>
-        {% if filesFilter is same as 'situation' %}
-            <p class="fr-text--sm fr-mt-n2w fr-mb-2w">
-                Ajoutez ici des photos ou documents concernant la situation de l'usager (photos de désordres, bail, DPE, diagnostic et état des lieux). 
-                Les fichiers ajoutés sont partagés à l'usager.
-                <br>
-                Vous ne pouvez pas supprimer les documents ajoutés par l'usager.
-            </p>
-        {% endif %}
-        {% if filesFilter is same as 'procédure' %}
-            <p class="fr-text--sm fr-mt-n2w fr-mb-2w">
-                Ajoutez ici les documents liés à la procédure (mise en demeure, rapport de visite, arrêté, etc.).
-                <br>
-                Vous pouvez supprimer uniquement les documents que vous avez ajoutés.
-            </p>
-        {% endif %}
-        {% if  filesFilter is same as 'situation'
-            and (context is same as 'documents-situation' or context is same as 'allphotosituation')
-        %}
-            <div class="fr-col-12">
-                <div id="zip-selection-bar" class="zip-selection-bar fr-display-flex-row fr-justify-content-right fr-mb-2w">
-                    <strong><span id="zip-selection-count">0</span> photos sélectionnées</strong>
-                    <form method="post"
-                          action="{{ path('back_signalement_generate_zip_selection', {uuid: signalement.uuid}) }}"
-                          class="zip-selection-bar__form">
-                        <input type="hidden" name="_token" value="{{ csrf_token('zip_selection_' ~ signalement.uuid) }}">
-                        <div id="zip-selection-hidden-fields"></div>
-                        <div class="zip-selection-bar__actions">
-                            <button
-                                    type="button"
-                                    id="zip-selection-cancel"
-                                    class="fr-btn fr-btn--secondary fr-icon-close-line fr-btn--icon-left"
-                            >
-                                Annuler
-                            </button>
-                            <button
-                                    type="submit"
-                                    id="zip-selection-submit"
-                                    class="fr-btn fr-icon-download-line fr-btn--icon-left"
-                                    aria-disabled="true"
-                                    disabled
-                            >
-                                Télécharger la sélection
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        {% endif %}
-    </div>
+    {% endif %}
 {% endif %}
 
 {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
@@ -185,6 +193,7 @@
             and (
                 (filesFilter is same as 'situation' and doc.isSituationDocument()) or 
                 (filesFilter is same as 'procédure' and doc.isProcedureDocument()) or 
+                (filesFilter is same as 'bailleur' and doc.isBailleurDocument()) or 
                 (filesFilter is same as 'visite' and doc.intervention is not null and doc.intervention.id is same as interventionId)
             )
         )|reverse %}

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -48,14 +48,19 @@
         </div>
         {% set nbCol = is_granted('SUIVI_DELETE', suivi) or is_granted('SUIVI_EDIT', suivi) ? '2' : '3' %}
         <div class="fr-col-{{ nbCol }}">
-            {% if suivi.isVisibleForUsager %}
-                <span class="fr-badge fr-badge--no-icon" title="Visible par l'usager">Visible par l'usager</span>
+            {% if suivi.isVisibleForUsager or suivi.isVisibleForBailleur %}
+                {% if suivi.isVisibleForUsager %}
+                    <span class="fr-badge fr-badge--no-icon" title="Visible par l'usager">Visible par l'usager</span>
+                {% endif %}
+                {% if suivi.isVisibleForBailleur %}
+                    <span class="fr-badge fr-badge--no-icon" title="Visible par le bailleur">Visible par le bailleur</span>
+                {% endif %}
             {% else %}
                 <span class="fr-badge fr-badge--no-icon" title="Suivi interne">Suivi interne</span>
             {% endif %}
             <br>
-            {% if suivi.isVisibleForUsager and suivi.type is not same as constant('App\\Entity\\Suivi::TYPE_USAGER') %}
-                <span class="fr-badge fr-badge--{{ suivi.isSeenByUsager ? 'success fr-background--notif-info' : 'error fr-background--notif-error' }} fr-mt-1v">{{ suivi.isSeenByUsager ? 'Lu' : 'Non lu' }}</span>
+            {% if suivi.isVisibleForUsager and suivi.category not in enum('App\\Entity\\Enum\\SuiviCategory').categoriesSubmittedByUsager %}
+                <span class="fr-badge fr-badge--{{ suivi.isSeenByUsager ? 'success fr-background--notif-info' : 'error fr-background--notif-error' }} fr-mt-1v">{{ suivi.isSeenByUsager ? 'Lu par l\'usager' : 'Non lu par l\'usager' }}</span>
             {% endif %}
         </div>
         {% if is_granted('SUIVI_DELETE', suivi) or is_granted('SUIVI_EDIT', suivi) %}

--- a/templates/back/signalement/view/tabs/tab-documents.html.twig
+++ b/templates/back/signalement/view/tabs/tab-documents.html.twig
@@ -4,6 +4,8 @@
 
 {% include 'back/signalement/view/photos-documents.html.twig' with {'zonetitle': "Photos et documents concernant la procédure",'filesFilter': 'procédure','context': 'documents-procedure'} %}
 
+{% include 'back/signalement/view/photos-documents.html.twig' with {'zonetitle': "Photos et documents transmis par le bailleur",'filesFilter': 'bailleur','context': 'documents-bailleur'} %}
+
 {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}
     <div class="fr-mt-5v"></div>
     {% include 'back/signalement/view/photos-documents.html.twig' with {

--- a/templates/front/_partials/_suivi_signalement_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_suivi.html.twig
@@ -1,0 +1,25 @@
+<div id="suivi_{{ suivi.id }}" class="message-box {{ messageBoxClass }}">
+	<div>
+		<strong>
+			{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
+				Suivi automatique
+			{% elseif suivi.partner %}
+				{{ suivi.partner.isArchive ? 'Partenaire supprimé' : suivi.partner.nom }}
+			{% elseif suivi.createdBy is not null and suivi.category in enum('App\\Entity\\Enum\\SuiviCategory').categoriesSubmittedByUsager() %}
+				{{ suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT' }}
+			{% elseif suivi.createdBy is not null %}
+				{{ suivi.createdBy.getPartnerInTerritoryOrFirstOne(suivi.signalement.territory) ? suivi.createdBy.getPartnerInTerritoryOrFirstOne(suivi.signalement.territory).nom : '' }}
+			{% else %}
+				{{ suivi.getCreatedByLabel(forBailleur: forBailleur) }}
+			{% endif %}
+			-
+			{{ suivi.createdAt|date('d/m/Y') }}
+		</strong>
+	</div>
+	{% if isUnreadMessage %}
+		<span class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--warning fr-mb-1w">Nouveau message</span>
+	{% endif %}
+	<div class="message-box-message">
+		{{ suivi.description|replace({'___TOKEN___':csrf_token('suivi_signalement_ext_file_view')})|raw }}
+	</div>
+</div>

--- a/templates/front/dossier_bailleur/dossier_bailleur.html.twig
+++ b/templates/front/dossier_bailleur/dossier_bailleur.html.twig
@@ -335,7 +335,7 @@
 
 						{% if suiviDemandeCloture is empty %}
 							<h3 class="title-blue-france fr-mt-5w" id="form_stop_procedure_bailleur_title">Demander l'arrêt de la procédure</h3>
-							<div class="fr-mt-3w">
+							<div class="fr-my-3w">
 								<a class="fr-btn  fr-btn--secondary" href="{{ path('front_dossier_bailleur_cloture') }}"
 									data-matomo-clickable-event-category="Espace bailleur"
 									data-matomo-clickable-event-action="clickButton"
@@ -386,5 +386,61 @@
 			{% endif %}
 		</div>
 	</div>
+
+	{% if is_granted('SIGN_BAILLEUR_HAS_RESPONSE_INJONCTION', signalement) %}
+		<hr>
+		<div class="fr-grid-row fr-grid-row--gutters">		
+			<div class="fr-col-12 fr-col-md-6">
+				<h2 class="title-blue-france">Envoyer un message</h2>
+				{% if is_granted('SIGN_BAILLEUR_ADD_SUIVI', signalement) %}
+					<div data-ajax-form>
+						<div class="single-ajax-form-container">
+							{{ form_start(formMessage, {'attr': {'id': 'form-message-usager'}}) }}
+							{{ form_errors(formMessage) }}
+							<p>
+								Nous vous rappelons que les échanges doivent se faire dans le respect mutuel. 
+								Nous invitons chaque partie à adopter une attitude courtoise et bienveillante.
+							</p>
+							{{ form_row(formMessage.description) }}
+							{{ form_row(formMessage.files) }}
+
+							{{ form_end(formMessage) }}
+							<ul class="fr-btns-group fr-btns-group--icon-left">
+								<li>
+									<button class="fr-btn fr-icon-check-line" type="submit" id="form_finish_submit" form="form-message-usager">
+										Envoyer le message
+									</button>
+								</li>
+							</ul>
+						</div>
+					</div>
+				{% else %}
+					<div class="fr-notice fr-notice--alert">
+                        <div class="fr-container">
+                            <div class="fr-notice__body">
+								<p>
+									<span class="fr-notice__title">Vous ne pouvez plus envoyer de messages suite à la fermeture du dossier.</span>
+								</p>
+                            </div>
+                        </div>
+                    </div>	
+				{% endif %}
+			</div>
+
+			<div class="fr-col-12 fr-col-md-6">
+				<h2 class="title-blue-france">Suivre vos échanges</h2>
+				{% for suivi in signalement.suivis|filter(s => s.isVisibleForBailleur)|reverse %}
+					{% set isUnreadMessage = false %}
+					{% set messageBoxClass = 'message-box--usager' %}
+					{% if suivi.category not in enum('App\\Entity\\Enum\\SuiviCategory').categoriesSubmittedByBailleur() %}
+						{% set messageBoxClass = 'message-box--partner message-box--unread' %}
+					{% endif %}
+					{% include 'front/_partials/_suivi_signalement_suivi.html.twig' with {'forBailleur': true} %}
+				{% endfor %}
+			</div>
+		</div>
+	{% endif %}
+
+
 </main>
 {% endblock %}

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -29,7 +29,6 @@
 				{{ form_start(formMessage, {'attr': {'id': 'form-message-usager'}}) }}
 				{{ form_errors(formMessage) }}
 				<p>Nous vous rappelons que les échanges entre les agents en charge de votre dossier et vous doivent se faire dans le respect mutuel. Nous invitons chaque partie à adopter une attitude courtoise et bienveillante.</p>
-				<p class="fr-hint-text fr-my-2v">Dix (10) caractères minimum</p>
 				<div class="fr-notice fr-notice--info fr-mb-3w">
 					<div class="fr-container">
 						<div class="fr-notice__body">
@@ -100,41 +99,16 @@
 			<div>Votre dossier a bien été enregistré le {{ signalement.createdAt|date('d/m/Y') }}.</div>
 			{% for suivi in signalement.suivis|reverse %}
 				{% set isUnreadMessage = false %}
-			    {% if suivi.category not in enum('App\\Entity\\Enum\\SuiviCategory').categoriesSubmittedByUsager() %}
+				{% set messageBoxClass = 'message-box--usager' %}
+				{% if suivi.category not in enum('App\\Entity\\Enum\\SuiviCategory').categoriesSubmittedByUsager() %}
 					{% if suivi.isSeenByUsager %}
 						{% set messageBoxClass = 'message-box--partner' %}
 					{% else %}
 						{% set messageBoxClass = 'message-box--partner message-box--unread' %}
 						{% set isUnreadMessage = true %}
 					{% endif %}
-				{% else %}
-					{% set messageBoxClass = 'message-box--usager' %}
 				{% endif %}
-				<div id="suivi_{{ suivi.id }}" class="message-box {{ messageBoxClass }}">
-					<div>
-						<strong>
-							{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
-								Suivi automatique
-							{% elseif suivi.partner %}
-								{{ suivi.partner.isArchive ? 'Partenaire supprimé' : suivi.partner.nom }}
-							{% elseif suivi.createdBy is not null and suivi.category in enum('App\\Entity\\Enum\\SuiviCategory').categoriesSubmittedByUsager() %}
-								{{ suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT' }}
-							{% elseif suivi.createdBy is not null %}
-								{{ suivi.createdBy.getPartnerInTerritoryOrFirstOne(suivi.signalement.territory) ? suivi.createdBy.getPartnerInTerritoryOrFirstOne(suivi.signalement.territory).nom : '' }}
-							{% else %}
-								{{ suivi.getCreatedByLabel() }}
-							{% endif %}
-							-
-							{{ suivi.createdAt|date('d/m/Y') }}
-						</strong>
-					</div>
-					{% if isUnreadMessage %}
-						<span class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--warning fr-mb-1w">Nouveau message</span>
-					{% endif %}
-					<div class="message-box-message">
-						{{ suivi.description|replace({'___TOKEN___':csrf_token('suivi_signalement_ext_file_view')})|raw }}
-					</div>
-				</div>
+				{% include 'front/_partials/_suivi_signalement_suivi.html.twig' with {'forBailleur': false} %}
 			{% endfor %}
 		</div>
 	</div>

--- a/tests/Functional/Command/Cron/SendSuiviWaitingNotificationCommandTest.php
+++ b/tests/Functional/Command/Cron/SendSuiviWaitingNotificationCommandTest.php
@@ -27,8 +27,8 @@ class SendSuiviWaitingNotificationCommandTest extends KernelTestCase
         $commandTester->assertCommandIsSuccessful();
         $output = $commandTester->getDisplay();
 
-        $this->assertEquals('[OK] Les notifications de 6 suivis ont été envoyées avec succès.', trim($output));
-        $this->assertEmailCount(10);
+        $this->assertEquals('[OK] Les notifications de 7 suivis ont été envoyées avec succès.', trim($output));
+        $this->assertEmailCount(11);
 
         $suiviRepository = static::getContainer()->get(SuiviRepository::class);
 

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -296,6 +296,25 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
     }
 
+    public function testSuiviSignalementMessages(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get('doctrine');
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['referenceInjonction' => '2364']);
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $urlSuiviSignalementUserResponse = $router->generate('front_suivi_signalement_messages', ['code' => $signalement->getCodeSuivi()]);
+
+        $signalementUser = $this->getSignalementUser($signalement);
+        $client->loginUser($signalementUser, 'code_suivi');
+
+        $crawler = $client->request('GET', $urlSuiviSignalementUserResponse);
+        $this->assertCount(2, $crawler->filter('.message-box'));
+    }
+
     #[DataProvider('provideStatusSignalement')]
     public function testPostUsagerResponse(string $status): void
     {

--- a/tests/Functional/Controller/SuiviBailleurControllerTest.php
+++ b/tests/Functional/Controller/SuiviBailleurControllerTest.php
@@ -313,4 +313,62 @@ class SuiviBailleurControllerTest extends WebTestCase
         $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['uuid' => self::SIGN_2025_11_UUID]);
         $this->assertEquals(SignalementStatus::INJONCTION_BAILLEUR, $signalement->getStatut());
     }
+
+    public function testDossierBailleurCountMessage(): void
+    {
+        $client = static::createClient();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['referenceInjonction' => '2364']);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $urlDossierBailleur = $router->generate('front_dossier_bailleur');
+        $uuid = $signalement->getUuid();
+        if (empty($uuid)) {
+            throw new \RuntimeException('Le signalement n’a pas d’UUID');
+        }
+        $signalementUser = new SignalementBailleur(userIdentifier: $uuid);
+        $client->loginUser($signalementUser, 'login_bailleur');
+        $crawler = $client->request('GET', $urlDossierBailleur);
+        $this->assertCount(3, $crawler->filter('.message-box'));
+    }
+
+    public function testDossierBailleurSendMessage(): void
+    {
+        $client = static::createClient();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['referenceInjonction' => '2364']);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $urlDossierBailleur = $router->generate('front_dossier_bailleur');
+        $uuid = $signalement->getUuid();
+        if (empty($uuid)) {
+            throw new \RuntimeException('Le signalement n’a pas d’UUID');
+        }
+        $signalementUser = new SignalementBailleur(userIdentifier: $uuid);
+        $client->loginUser($signalementUser, 'login_bailleur');
+        $crawler = $client->request('GET', $urlDossierBailleur);
+        $this->assertCount(3, $crawler->filter('.message-box'));
+
+        $form = $crawler->filter('form[name="message_bailleur"]')->form();
+        $form['message_bailleur[description]'] = 'Un message du bailleur';
+        $client->submit($form);
+
+        $this->assertEmailCount(1);
+        $this->assertResponseIsSuccessful();
+        $responseData = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertTrue($responseData['redirect']);
+        $this->assertTrue($responseData['scrollToTop']);
+        $this->assertStringContainsString('/dossier-bailleur/', $responseData['url']);
+
+        $crawler = $client->request('GET', $urlDossierBailleur);
+        $this->assertCount(4, $crawler->filter('.message-box'));
+    }
 }

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -36,6 +36,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(7, $notificationCount);
+        $this->assertEquals(9, $notificationCount);
     }
 }


### PR DESCRIPTION
## Ticket

#5728

## Description
Ajout de la possibilité pour les bailleur d'envoyer des message (et de joindre des document) depuis son espace bailleur.
- Possibilité ouverte après la réponse à l'injonction bailleur (quelle que soit la réponse) et tant que le signalement n'est pas refusé/cloturé/archivé.
- Migration pour marquer tous les suivi bailleur (réponse bailleur, bascule procédure) visible au bailleur afin de les afficher dans sons espace messagerie.
- Ajout du nouveau type de document `MESSAGE_BAILLEUR` qui sont repris dans une section dédié de l'onglet documents et photos de la fiche signalement BO
- Ajout de ces documents dans la liste des doc que l'on peux attaché au suivi créer depuis le BO
- Gestion des badges de visibilité des suivi dans le BO "Suivi interne/Visible par l'usager/Visible par le bailleur"
- Ajout de fixtures et tests

## Pré-requis
`make execute-migration name=Version20260504151832 direction=up`
`make load-fixtures`
`make npm-watch`

## Tests
- [ ] Se connecter en tant que bailleur, donner une réponse, envoyer des message avec ou sans documents.
- [ ] Verifier que les notifications sont correctes
- [ ] Verifier que l'affichage BO et FO (suivi bailleur / suivi usager) est correct
