### PR TITLE
[Sentry] Invalid datetime format: 1292 Incorrect datetime value: '-0001-11-30 00:00:00' for column 'date_prise_de_vue'

### DIFF
--- a/src/Service/Files/FileReaderExif.php
+++ b/src/Service/Files/FileReaderExif.php
@@ -25,7 +25,14 @@ class FileReaderExif
         $datePriseDeVue = isset($image) ? $image->exif('EXIF.DateTimeOriginal') : null;
         if ($datePriseDeVue) {
             try {
-                $file->setDatePriseDeVue(new \DateTimeImmutable($datePriseDeVue));
+                $date = new \DateTimeImmutable($datePriseDeVue);
+                $year = (int) $date->format('Y');
+                $nextYear = (int) date('Y');
+                ++$nextYear;
+                // ticket #5801 : prevent error type "Invalid datetime format value: '-0001-11-30 00:00:00'"
+                if ($year > 1970 && $year < $nextYear) {
+                    $file->setDatePriseDeVue($date);
+                }
             } catch (\Exception $e) {
                 $this->logger->error('Impossible de convertir la donnée EXIF DateTimeOriginal ("'.$datePriseDeVue.'") en DateTimeImmutable pour le fichier : '.$file->getFilename());
             }


### PR DESCRIPTION
## Ticket

#5801

## Description
Dans le cas ou la date de prise de vu d'une photo est corrompu (a 0000:00:00 00:00:00 par exemple) cela provoque une erreur à la tentative d'insertion en base, par effet domino la fermeture de entityManager et donc un vilain crash.

Correction en contrôlant que l'année de la date soit compris entre 1970 et l'année prochaine (ex 2026+1)

## Tests
- [ ] Tester l'upload d'une photo avec la date de prise de vu a 0000:00:00 00:00:00 et voir que ca fonctionne (sans enregistrer de date de pris de vue)
- [ ] Tester l'upload d'une photo avec date de prise de vue correcte et voir que ca fonctionne
