### PR TITLE
[Esabora SCHS] Fiabiliser le mapping des réponses Esabora SCHS 

### DIFF
--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -355,3 +355,11 @@ affectations:
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
     is_synchronized: true
+  -
+    signalement: 2022-11
+    partner: "partenaire-13-05@signal-logement.fr"
+    statut: "NOUVEAU"
+    answered_by: ""
+    affected_by: "admin-territoire-13-01@signal-logement.fr"
+    motif_cloture: ""
+    territory: "Bouches-du-Rhône"

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -363,3 +363,5 @@ affectations:
     affected_by: "admin-territoire-13-01@signal-logement.fr"
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
+    is_synchronized: true
+

--- a/src/Service/Interconnection/Esabora/Response/DossierStateSCHSResponse.php
+++ b/src/Service/Interconnection/Esabora/Response/DossierStateSCHSResponse.php
@@ -4,6 +4,15 @@ namespace App\Service\Interconnection\Esabora\Response;
 
 class DossierStateSCHSResponse implements DossierResponseInterface
 {
+    public const string COL_SAS_REFERENCE = 'SAS_Référence';
+    public const string COL_SAS_ETAT = 'SAS_Etat';
+    public const string COL_DOSS_ID = 'Doss_ID';
+    public const string COL_DOSS_NUMERO = 'Doss_Numéro';
+    public const string COL_DOSS_STATUT_ABREGE = 'Doss_Statut_Abrégé';
+    public const string COL_DOSS_STATUT = 'Doss_Statut';
+    public const string COL_DOSS_ETAT = 'Doss_Etat';
+    public const string COL_DOSS_CLOTURE = 'Doss_Cloture';
+
     private ?string $sasReference = null;
     private ?string $sasEtat = null;
     private ?string $id = null;
@@ -21,16 +30,23 @@ class DossierStateSCHSResponse implements DossierResponseInterface
     public function __construct(array $response, ?int $statusCode)
     {
         if (!empty($response)) {
-            $data = $response['rowList'][0]['columnDataList'] ?? null;
-            if (null !== $data) {
-                $this->sasReference = $data[0] ?? null;
-                $this->sasEtat = $data[1] ?? null;
-                $this->id = $data[2] ?? null;
-                $this->numero = $data[3] ?? null;
-                $this->statutAbrege = $data[4] ?? null;
-                $this->statut = $data[5] ?? null;
-                $this->etat = $data[6] ?? null;
-                $this->dateCloture = $data[7] ?? null;
+            $columnList = $response['columnList'] ?? null;
+            $valueList = $response['rowList'][0]['columnDataList'] ?? null;
+
+            if (null !== $columnList && null !== $valueList) {
+                if (\count($columnList) !== \count($valueList)) {
+                    $this->errorReason = 'Nombre de colonnes et de données incohérent';
+                } else {
+                    $data = array_combine($columnList, $valueList);
+                    $this->sasReference = $data[self::COL_SAS_REFERENCE] ?? null;
+                    $this->sasEtat = $data[self::COL_SAS_ETAT] ?? null;
+                    $this->id = $data[self::COL_DOSS_ID] ?? null;
+                    $this->numero = $data[self::COL_DOSS_NUMERO] ?? null;
+                    $this->statutAbrege = $data[self::COL_DOSS_STATUT_ABREGE] ?? null;
+                    $this->statut = $data[self::COL_DOSS_STATUT] ?? null;
+                    $this->etat = $data[self::COL_DOSS_ETAT] ?? null;
+                    $this->dateCloture = $data[self::COL_DOSS_CLOTURE] ?? null;
+                }
             } else {
                 $this->errorReason = (string) json_encode($response);
             }

--- a/src/Service/Interconnection/Esabora/Response/DossierStateSISHResponse.php
+++ b/src/Service/Interconnection/Esabora/Response/DossierStateSISHResponse.php
@@ -6,6 +6,20 @@ use App\Service\Interconnection\Esabora\EsaboraSISHService;
 
 class DossierStateSISHResponse implements DossierResponseInterface
 {
+    public const string COL_REFERENCE_DOSSIER = 'Reference_Dossier';
+    public const string COL_SAS_ETAT = 'EsaboraStatusSAS_Etat';
+    public const string COL_SAS_DATE_DECISION = 'Sas_DateDecision';
+    public const string COL_SAS_CAUSE_REFUS = 'Sas_CauseRefus';
+    public const string COL_SISH_DOSS_ID = 'SISH_DossId';
+    public const string COL_SISH_DOSS_NUM = 'SISH_DossNum';
+    public const string COL_SISH_DOSS_OBJET = 'SISH_DossObjet';
+    public const string COL_SISH_DOSS_DATE_CLOTURE = 'SISH_DossDateCloture';
+    public const string COL_SISH_DOSS_STATUT_ABR = 'SISH_DossStatutAbr';
+    public const string COL_SISH_DOSS_STATUT = 'SISH_DossStatut';
+    public const string COL_SISH_DOSS_ETAT = 'SISH_DossEtat';
+    public const string COL_SISH_DOSS_TYPE_CODE = 'SISH_DossTypeCode';
+    public const string COL_SISH_DOSS_TYPE_LIB = 'SISH_DossTypeLib';
+
     private ?string $referenceDossier = null;
     private ?string $sasEtat = null;
     private ?string $sasDateDecision = null;
@@ -28,21 +42,28 @@ class DossierStateSISHResponse implements DossierResponseInterface
     public function __construct(array $response, ?int $statusCode)
     {
         if (!empty($response)) {
-            $data = $response['rowList'][0]['columnDataList'] ?? null;
-            if (null !== $data) {
-                $this->referenceDossier = $data[0] ?? null;
-                $this->sasEtat = $data[1] ?? null;
-                $this->sasDateDecision = $data[2] ?? null;
-                $this->sasCauseRefus = $data[3] ?? null;
-                $this->dossId = $data[4] ?? null;
-                $this->dossNum = $data[5] ?? null;
-                $this->dossObjet = $data[6] ?? null;
-                $this->dossDateCloture = $data[7] ?? null;
-                $this->dossStatutAbr = $data[8] ?? null;
-                $this->dossStatut = $data[9] ?? null;
-                $this->dossEtat = $data[10] ?? null;
-                $this->dossTypeCode = $data[11] ?? null;
-                $this->dossTypeLib = $data[12] ?? null;
+            $columnList = $response['columnList'] ?? null;
+            $rowList = $response['rowList'][0]['columnDataList'] ?? null;
+
+            if (null !== $columnList && null !== $rowList) {
+                if (\count($columnList) !== \count($rowList)) {
+                    $this->errorReason = 'Nombre de colonnes et de données incohérent';
+                } else {
+                    $data = array_combine($columnList, $rowList);
+                    $this->referenceDossier = $data[self::COL_REFERENCE_DOSSIER] ?? null;
+                    $this->sasEtat = $data[self::COL_SAS_ETAT] ?? null;
+                    $this->sasDateDecision = $data[self::COL_SAS_DATE_DECISION] ?? null;
+                    $this->sasCauseRefus = $data[self::COL_SAS_CAUSE_REFUS] ?? null;
+                    $this->dossId = $data[self::COL_SISH_DOSS_ID] ?? null;
+                    $this->dossNum = $data[self::COL_SISH_DOSS_NUM] ?? null;
+                    $this->dossObjet = $data[self::COL_SISH_DOSS_OBJET] ?? null;
+                    $this->dossDateCloture = $data[self::COL_SISH_DOSS_DATE_CLOTURE] ?? null;
+                    $this->dossStatutAbr = $data[self::COL_SISH_DOSS_STATUT_ABR] ?? null;
+                    $this->dossStatut = $data[self::COL_SISH_DOSS_STATUT] ?? null;
+                    $this->dossEtat = $data[self::COL_SISH_DOSS_ETAT] ?? null;
+                    $this->dossTypeCode = $data[self::COL_SISH_DOSS_TYPE_CODE] ?? null;
+                    $this->dossTypeLib = $data[self::COL_SISH_DOSS_TYPE_LIB] ?? null;
+                }
             } else {
                 $this->errorReason = (string) json_encode($response);
             }

--- a/src/Service/Interconnection/Esabora/Response/DossierStateSISHResponse.php
+++ b/src/Service/Interconnection/Esabora/Response/DossierStateSISHResponse.php
@@ -43,13 +43,13 @@ class DossierStateSISHResponse implements DossierResponseInterface
     {
         if (!empty($response)) {
             $columnList = $response['columnList'] ?? null;
-            $rowList = $response['rowList'][0]['columnDataList'] ?? null;
+            $valueList = $response['rowList'][0]['columnDataList'] ?? null;
 
-            if (null !== $columnList && null !== $rowList) {
-                if (\count($columnList) !== \count($rowList)) {
+            if (null !== $columnList && null !== $valueList) {
+                if (\count($columnList) !== \count($valueList)) {
                     $this->errorReason = 'Nombre de colonnes et de données incohérent';
                 } else {
-                    $data = array_combine($columnList, $rowList);
+                    $data = array_combine($columnList, $valueList);
                     $this->referenceDossier = $data[self::COL_REFERENCE_DOSSIER] ?? null;
                     $this->sasEtat = $data[self::COL_SAS_ETAT] ?? null;
                     $this->sasDateDecision = $data[self::COL_SAS_DATE_DECISION] ?? null;

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -109,7 +109,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Status Refuse for agent 38' => [['status' => 'refuse', 'isImported' => 'oui'], 1, 'user-38-01@signal-logement.fr'];
         yield 'Search by all for agent CAF30' => [['isImported' => 'oui'], 3, 'user-partenaire-30@signal-logement.fr'];
         yield 'Search by Partner Ales agglo for agent CAF30' => [['partenaires' => ['86'], 'isImported' => 'oui'], 1, 'user-partenaire-30@signal-logement.fr'];
-        yield 'Search by all for agent Partenaire 13-05' => [['isImported' => 'oui'], 5, 'user-13-05@signal-logement.fr'];
+        yield 'Search by all for agent Partenaire 13-05' => [['isImported' => 'oui'], 6, 'user-13-05@signal-logement.fr'];
         yield 'Search by Partner 13-01 & 13-06 for agent Partenaire 13-05' => [['partenaires' => ['2', '7'], 'isImported' => 'oui'], 2, 'user-13-05@signal-logement.fr'];
     }
 

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -40,7 +40,7 @@ class AffectationRepositoryTest extends KernelTestCase
         }
 
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::COMMUNE_SCHS);
-        $this->assertCount(1, $affectationsSubscribedToEsabora);
+        $this->assertCount(2, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $row) {
             $affectationSubscribedToEsabora = $row['affectation'];
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());

--- a/tests/Unit/Service/Esabora/Response/DossierStateSCHSResponseTest.php
+++ b/tests/Unit/Service/Esabora/Response/DossierStateSCHSResponseTest.php
@@ -42,4 +42,167 @@ class DossierStateSCHSResponseTest extends TestCase
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $dossierResponse->getStatusCode());
         $this->assertNotNull($dossierResponse->getErrorReason());
     }
+
+
+    public function testDossierResponseNominal(): void
+    {
+        $responseEsabora = [
+            'columnList' => [
+                'SAS_Référence',
+                'SAS_Etat',
+                'Doss_ID',
+                'Doss_Numéro',
+                'Doss_Statut_Abrégé',
+                'Doss_Statut',
+                'Doss_Etat',
+                'Doss_Cloture'
+            ],
+            'rowList' => [
+                [
+                    'columnDataList' => [
+                        'REF123',
+                        'Importé',
+                        '12345',
+                        'NUM123',
+                        'AT',
+                        'A traiter',
+                        'en cours',
+                        '2023-12-31'
+                    ]
+                ]
+            ]
+        ];
+
+        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
+        $this->assertEquals('REF123', $dossierResponse->getSasReference());
+        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
+        $this->assertEquals('12345', $dossierResponse->getId());
+        $this->assertEquals('NUM123', $dossierResponse->getNumero());
+        $this->assertEquals('AT', $dossierResponse->getStatutAbrege());
+        $this->assertEquals('A traiter', $dossierResponse->getStatut());
+        $this->assertEquals('en cours', $dossierResponse->getEtat());
+        $this->assertEquals('2023-12-31', $dossierResponse->getDateCloture());
+        $this->assertNull($dossierResponse->getErrorReason());
+    }
+
+    public function testDossierResponseWithoutDossID(): void
+    {
+        $responseEsabora = [
+            'columnList' => [
+                'SAS_Référence',
+                'SAS_Etat',
+                'Doss_Numéro',
+                'Doss_Statut_Abrégé',
+                'Doss_Statut',
+                'Doss_Etat',
+                'Doss_Cloture'
+            ],
+            'rowList' => [
+                [
+                    'columnDataList' => [
+                        'REF123',
+                        'Importé',
+                        'NUM123',
+                        'AT',
+                        'A traiter',
+                        'en cours',
+                        null
+                    ]
+                ]
+            ]
+        ];
+
+        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
+        $this->assertEquals('REF123', $dossierResponse->getSasReference());
+        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
+        $this->assertNull($dossierResponse->getId());
+        $this->assertEquals('NUM123', $dossierResponse->getNumero());
+        $this->assertEquals('AT', $dossierResponse->getStatutAbrege());
+        $this->assertEquals('A traiter', $dossierResponse->getStatut());
+        $this->assertEquals('en cours', $dossierResponse->getEtat());
+        $this->assertNull($dossierResponse->getDateCloture());
+        $this->assertNull($dossierResponse->getErrorReason());
+    }
+
+    public function testDossierResponseDifferentOrder(): void
+    {
+        $responseEsabora = [
+            'columnList' => [
+                'Doss_Statut',
+                'SAS_Référence',
+                'Doss_ID',
+                'SAS_Etat',
+            ],
+            'rowList' => [
+                [
+                    'columnDataList' => [
+                        'A traiter',
+                        'REF123',
+                        '12345',
+                        'Importé',
+                    ]
+                ]
+            ]
+        ];
+
+        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
+        $this->assertEquals('REF123', $dossierResponse->getSasReference());
+        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
+        $this->assertEquals('12345', $dossierResponse->getId());
+        $this->assertEquals('A traiter', $dossierResponse->getStatut());
+        $this->assertNull($dossierResponse->getErrorReason());
+    }
+
+    public function testDossierResponseWithAdditionalColumns(): void
+    {
+        $responseEsabora = [
+            'columnList' => [
+                'SAS_Référence',
+                'SAS_Etat',
+                'Doss_ID',
+                'Doss_Type',
+                'Doss_Problématique'
+            ],
+            'rowList' => [
+                [
+                    'columnDataList' => [
+                        'REF123',
+                        'Importé',
+                        '12345',
+                        "Hygiène de l'habitat",
+                        'Habitabilité'
+                    ]
+                ]
+            ]
+        ];
+
+        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
+        $this->assertEquals('REF123', $dossierResponse->getSasReference());
+        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
+        $this->assertEquals('12345', $dossierResponse->getId());
+        $this->assertNull($dossierResponse->getErrorReason());
+    }
+
+    public function testDossierResponseInvalidColumnCount(): void
+    {
+        $responseEsabora = [
+            'columnList' => [
+                'SAS_Référence',
+                'SAS_Etat',
+            ],
+            'rowList' => [
+                [
+                    'columnDataList' => [
+                        'REF123',
+                        'Importé',
+                        'Extra'
+                    ]
+                ]
+            ]
+        ];
+
+        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
+        $this->assertNull($dossierResponse->getSasReference());
+        $this->assertEquals('Nombre de colonnes et de données incohérent', $dossierResponse->getErrorReason());
+    }
 }

--- a/tests/Unit/Service/Esabora/Response/DossierStateSCHSResponseTest.php
+++ b/tests/Unit/Service/Esabora/Response/DossierStateSCHSResponseTest.php
@@ -43,81 +43,17 @@ class DossierStateSCHSResponseTest extends TestCase
         $this->assertNotNull($dossierResponse->getErrorReason());
     }
 
-
-    public function testDossierResponseNominal(): void
-    {
-        $responseEsabora = [
-            'columnList' => [
-                'SAS_Référence',
-                'SAS_Etat',
-                'Doss_ID',
-                'Doss_Numéro',
-                'Doss_Statut_Abrégé',
-                'Doss_Statut',
-                'Doss_Etat',
-                'Doss_Cloture'
-            ],
-            'rowList' => [
-                [
-                    'columnDataList' => [
-                        'REF123',
-                        'Importé',
-                        '12345',
-                        'NUM123',
-                        'AT',
-                        'A traiter',
-                        'en cours',
-                        '2023-12-31'
-                    ]
-                ]
-            ]
-        ];
-
-        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
-        $this->assertEquals('REF123', $dossierResponse->getSasReference());
-        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
-        $this->assertEquals('12345', $dossierResponse->getId());
-        $this->assertEquals('NUM123', $dossierResponse->getNumero());
-        $this->assertEquals('AT', $dossierResponse->getStatutAbrege());
-        $this->assertEquals('A traiter', $dossierResponse->getStatut());
-        $this->assertEquals('en cours', $dossierResponse->getEtat());
-        $this->assertEquals('2023-12-31', $dossierResponse->getDateCloture());
-        $this->assertNull($dossierResponse->getErrorReason());
-    }
-
     public function testDossierResponseWithoutDossID(): void
     {
-        $responseEsabora = [
-            'columnList' => [
-                'SAS_Référence',
-                'SAS_Etat',
-                'Doss_Numéro',
-                'Doss_Statut_Abrégé',
-                'Doss_Statut',
-                'Doss_Etat',
-                'Doss_Cloture'
-            ],
-            'rowList' => [
-                [
-                    'columnDataList' => [
-                        'REF123',
-                        'Importé',
-                        'NUM123',
-                        'AT',
-                        'A traiter',
-                        'en cours',
-                        null
-                    ]
-                ]
-            ]
-        ];
+        $filepath = __DIR__.'/../../../../../tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe_missing_column.json';
+        $responseEsabora = json_decode((string) file_get_contents($filepath), true);
 
         $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
-        $this->assertEquals('REF123', $dossierResponse->getSasReference());
+        $this->assertEquals('00000000-0000-0000-2022-000000000011', $dossierResponse->getSasReference());
         $this->assertEquals('Importé', $dossierResponse->getSasEtat());
         $this->assertNull($dossierResponse->getId());
-        $this->assertEquals('NUM123', $dossierResponse->getNumero());
-        $this->assertEquals('AT', $dossierResponse->getStatutAbrege());
+        $this->assertEquals('2026DSP-19349-HAB', $dossierResponse->getNumero());
+        $this->assertEquals('A traiter', $dossierResponse->getStatutAbrege());
         $this->assertEquals('A traiter', $dossierResponse->getStatut());
         $this->assertEquals('en cours', $dossierResponse->getEtat());
         $this->assertNull($dossierResponse->getDateCloture());
@@ -140,9 +76,9 @@ class DossierStateSCHSResponseTest extends TestCase
                         'REF123',
                         '12345',
                         'Importé',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
 
         $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
@@ -150,36 +86,6 @@ class DossierStateSCHSResponseTest extends TestCase
         $this->assertEquals('Importé', $dossierResponse->getSasEtat());
         $this->assertEquals('12345', $dossierResponse->getId());
         $this->assertEquals('A traiter', $dossierResponse->getStatut());
-        $this->assertNull($dossierResponse->getErrorReason());
-    }
-
-    public function testDossierResponseWithAdditionalColumns(): void
-    {
-        $responseEsabora = [
-            'columnList' => [
-                'SAS_Référence',
-                'SAS_Etat',
-                'Doss_ID',
-                'Doss_Type',
-                'Doss_Problématique'
-            ],
-            'rowList' => [
-                [
-                    'columnDataList' => [
-                        'REF123',
-                        'Importé',
-                        '12345',
-                        "Hygiène de l'habitat",
-                        'Habitabilité'
-                    ]
-                ]
-            ]
-        ];
-
-        $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);
-        $this->assertEquals('REF123', $dossierResponse->getSasReference());
-        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
-        $this->assertEquals('12345', $dossierResponse->getId());
         $this->assertNull($dossierResponse->getErrorReason());
     }
 
@@ -195,10 +101,10 @@ class DossierStateSCHSResponseTest extends TestCase
                     'columnDataList' => [
                         'REF123',
                         'Importé',
-                        'Extra'
-                    ]
-                ]
-            ]
+                        'Extra',
+                    ],
+                ],
+            ],
         ];
 
         $dossierResponse = new DossierStateSCHSResponse($responseEsabora, 200);

--- a/tools/wiremock/src/Mock/Esabora/EsaboraSCHSMock.php
+++ b/tools/wiremock/src/Mock/Esabora/EsaboraSCHSMock.php
@@ -39,7 +39,7 @@ class EsaboraSCHSMock extends AbstractEsaboraMock
 
         self::createCustomStateDossierMock(
             $wiremock,
-            '00000000-0000-0000-2022-000000000001',
+            '00000000-0000-0000-2022-000000000011',
             'etat_importe_missing_column.json'
         );
 
@@ -66,6 +66,7 @@ class EsaboraSCHSMock extends AbstractEsaboraMock
             '00000000-0000-0000-2022-000000000002',
             '00000000-0000-0000-2022-000000000008',
             '00000000-0000-0000-2023-000000000009',
+            '00000000-0000-0000-2022-000000000011',
             self::SIGNALEMENT_SUBSCRIBED_SISH_SCHS,
         ];
 

--- a/tools/wiremock/src/Mock/Esabora/EsaboraSCHSMock.php
+++ b/tools/wiremock/src/Mock/Esabora/EsaboraSCHSMock.php
@@ -39,6 +39,12 @@ class EsaboraSCHSMock extends AbstractEsaboraMock
 
         self::createCustomStateDossierMock(
             $wiremock,
+            '00000000-0000-0000-2022-000000000001',
+            'etat_importe_missing_column.json'
+        );
+
+        self::createCustomStateDossierMock(
+            $wiremock,
             '00000000-0000-0000-2022-000000000002',
             'etat_non_importe.json'
         );

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_a_traiter.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_a_traiter.json
@@ -22,7 +22,6 @@
         "2022-8",
         null,
         null,
-        null,
         null
       ],
       "keyDataList": [

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_a_traiter.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_a_traiter.json
@@ -8,7 +8,7 @@
     "Doss_Statut_Abrégé",
     "Doss_Statut",
     "Doss_Etat",
-    "DOss_Cloture"
+    "Doss_Cloture"
   ],
   "keyList": [
     "i1.iaff_id"

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe.json
@@ -5,6 +5,7 @@
     "SAS_Référence",
     "SAS_Etat",
     "Doss_ID",
+    "Doss_Numéro",
     "Doss_Statut_Abrégé",
     "Doss_Statut",
     "Doss_Etat",

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe.json
@@ -8,7 +8,7 @@
     "Doss_Statut_Abrégé",
     "Doss_Statut",
     "Doss_Etat",
-    "DOss_Cloture"
+    "Doss_Cloture"
   ],
   "keyList": [
     "i1.iaff_id"

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe_missing_column.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe_missing_column.json
@@ -19,11 +19,11 @@
   "rowList": [
     {
       "columnDataList": [
-        "78915bd0-fd28-418c-9e68-450212c9dd81",
+        "00000000-0000-0000-2022-000000000011",
         "Import\u00e9",
         "2026DSP-19349-HAB",
         "A traiter",
-        "*A traiter",
+        "A traiter",
         "en cours",
         null,
         "Hygi\u00e8ne de l'habitat",

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe_missing_column.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_importe_missing_column.json
@@ -1,0 +1,37 @@
+
+{
+  "searchId": 27155,
+  "nbResults": 1,
+  "columnList": [
+    "SAS_R\u00e9f\u00e9rence",
+    "SAS_Etat",
+    "Doss_Num\u00e9ro",
+    "Doss_Statut_Abr\u00e9g\u00e9",
+    "Doss_Statut",
+    "Doss_Etat",
+    "Doss_Cloture",
+    "Doss_Type",
+    "Doss_Probl\u00e9matique"
+  ],
+  "keyList": [
+    "i1.iaff_id"
+  ],
+  "rowList": [
+    {
+      "columnDataList": [
+        "78915bd0-fd28-418c-9e68-450212c9dd81",
+        "Import\u00e9",
+        "2026DSP-19349-HAB",
+        "A traiter",
+        "*A traiter",
+        "en cours",
+        null,
+        "Hygi\u00e8ne de l'habitat",
+        "Habitabilit\u00e9"
+      ],
+      "keyDataList": [
+        9
+      ]
+    }
+  ]
+}

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_non_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_non_importe.json
@@ -8,7 +8,7 @@
     "Doss_Statut_Abrégé",
     "Doss_Statut",
     "Doss_Etat",
-    "DOss_Cloture"
+    "Doss_Cloture"
   ],
   "keyList": [
     "i1.iaff_id"

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_non_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_non_importe.json
@@ -22,7 +22,6 @@
         null,
         null,
         null,
-        null,
         null
       ],
       "keyDataList": [

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/etat_termine.json
@@ -5,6 +5,7 @@
     "SAS_Référence",
     "SAS_Etat",
     "Doss_ID",
+    "Doss_Numero",
     "Doss_Statut_Abrégé",
     "Doss_Statut",
     "Doss_Etat",

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_rejete.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_rejete.json
@@ -34,9 +34,6 @@
         null,
         null,
         null,
-        null,
-        null,
-        null,
         null
       ],
       "keyDataList": [


### PR DESCRIPTION
## Ticket

#5814    

<img width="574" height="645" alt="image" src="https://github.com/user-attachments/assets/89bc6d84-6466-4a10-87da-7b488f425a78" />

## Description
Bien que JP ait corrigé la version SCHS de Villeurbanne, il est nécessaire de fiabiliser le mapping des champs car se basait sur l'index reste fragile.

De plus le déploiement des correctifs SCHS n'est pas simple à gérer car la solution n'est pas centralisé.

Dernier mail reçu 
> Il y avait effectivement un problème sur la dernière version.
> Nous venons de régler le problème à Villeurbanne.
> La prochaine remontée d’informations devrait fonctionner.
> Il y a d’autres sites potentiellement concernés : Nice, la CABEM, Vénissieux et Sète.
> Nous regardons ce qui peut être fait


## Changements apportés
- Remplacement du mapping par index par un mapping basé sur `columnList`.
- En cas d’incohérence, remonter une erreur au lieu de mapper des données potentiellement décalées.
- Logique appliqué sur SISH

## Pré-requis

```
make mock-restart
``` 

00000000-0000-0000-2022-000000000011 reçoit par wiremock une réponse avec absence de champs (Doss_ID) comme les réponses buggé actuellement mais la mise à jour doit se faire.

## Tests
- [ ] Exécuter `make console app="sync-esabora-schs"` et vérifier les statuts des dossiers remonté dans l'output dont http://localhost:8080/bo/signalements/00000000-0000-0000-2022-000000000011 qui doit passé à accepté
- [ ] Exécuter `make console app="sync-esabora-sish"` et véifier les statuts des dossiers remonté dans l'output
