### PR TITLE
[Accessibilité] Ajout et édition d'événements

### DIFF
--- a/src/Entity/ClubEvent.php
+++ b/src/Entity/ClubEvent.php
@@ -34,7 +34,6 @@ class ClubEvent implements EntityHistoryInterface
     private ?string $url = null;
 
     #[ORM\Column]
-    #[Assert\NotBlank()]
     private array $userRoles = [];
 
     /**

--- a/src/Entity/ClubEvent.php
+++ b/src/Entity/ClubEvent.php
@@ -34,6 +34,7 @@ class ClubEvent implements EntityHistoryInterface
     private ?string $url = null;
 
     #[ORM\Column]
+    #[Assert\NotBlank()]
     private array $userRoles = [];
 
     /**
@@ -58,7 +59,7 @@ class ClubEvent implements EntityHistoryInterface
         return $this->dateEvent;
     }
 
-    public function setDateEvent(\DateTimeImmutable $dateEvent): static
+    public function setDateEvent(?\DateTimeImmutable $dateEvent): static
     {
         $this->dateEvent = $dateEvent;
 
@@ -70,7 +71,7 @@ class ClubEvent implements EntityHistoryInterface
         return $this->name;
     }
 
-    public function setName(string $name): static
+    public function setName(?string $name): static
     {
         $this->name = $name;
 
@@ -82,7 +83,7 @@ class ClubEvent implements EntityHistoryInterface
         return $this->url;
     }
 
-    public function setUrl(string $url): static
+    public function setUrl(?string $url): static
     {
         $this->url = $url;
 

--- a/src/Form/ClubEventType.php
+++ b/src/Form/ClubEventType.php
@@ -46,6 +46,8 @@ class ClubEventType extends AbstractType
             },
             'setter' => static function (ClubEvent $clubEvent, ?\DateTimeInterface $date) use ($timezoneProvider): void {
                 if (null === $date) {
+                    $clubEvent->setDateEvent(null);
+
                     return;
                 }
                 $utcDate = new \DateTimeImmutable(

--- a/src/Form/ClubEventType.php
+++ b/src/Form/ClubEventType.php
@@ -59,7 +59,7 @@ class ClubEventType extends AbstractType
             },
         ]);
         $builder->add('userRoles', ChoiceType::class, [
-            'label' => 'Utilisateurs concernés',
+            'label' => 'Utilisateurs concernés (facultatif)',
             'required' => false,
             'multiple' => true,
             'expanded' => true,

--- a/templates/back/config_club_event/add.html.twig
+++ b/templates/back/config_club_event/add.html.twig
@@ -17,14 +17,48 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
                     <h1 class="fr-mb-0">Ajouter un événement</h1>
+                    <span>Remplissez le formulaire ci-dessous pour créer un événement.</span><br>
+                    <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
                 </div>
             </div>
         </header>
     </section>
 
-    <section class="fr-grid-row fr-pt-4v">
-        <div class="fr-col-12 fr-col-lg-6">
-            {{ form(form) }}
+    <section class="fr-grid-row fr-pt-4v">        
+        <div class="fr-col-12">
+            {{ form_start(form, {'attr': {'id': 'form-add-zone'}}) }}
+            {{ form_errors(form) }}
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    {{ form_row(form.name) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.url) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.dateEvent) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.userRoles) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.partnerTypes) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.partnerCompetences) }}
+                </div>
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            {{ form_row(form.submit) }}
+                        </li>
+                        <li>
+                            <a href="{{path('back_config_club_event_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            {{ form_end(form) }}
         </div>
     </section>
 

--- a/templates/back/config_club_event/edit.html.twig
+++ b/templates/back/config_club_event/edit.html.twig
@@ -17,14 +17,48 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
                     <h1 class="fr-mb-0">Événement {{clubEvent.name}}</h1>
+                    <span>Remplissez le formulaire ci-dessous pour créer un événement.</span><br>
+                    <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
                 </div>
             </div>
         </header>
     </section>
 
     <section class="fr-grid-row fr-pt-4v">
-        <div class="fr-col-12 fr-col-lg-6">
-            {{ form(form) }}
+        <div class="fr-col-12">
+            {{ form_start(form, {'attr': {'id': 'form-add-zone'}}) }}
+            {{ form_errors(form) }}
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    {{ form_row(form.name) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.url) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.dateEvent) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.userRoles) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.partnerTypes) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.partnerCompetences) }}
+                </div>
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            {{ form_row(form.submit) }}
+                        </li>
+                        <li>
+                            <a href="{{path('back_config_club_event_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            {{ form_end(form) }}
         </div>
     </section>
 


### PR DESCRIPTION
## Ticket

#5773   

## Description
- Ajout événement http://localhost:8080/bo/config-club-utilisateur/ajouter
Préciser que tous les champs sont obligatoires sauf mention contraire
Harmoniser la mise en page avec toutes les autres pages 
Ajouter un bouton Annuler (attention à l'ordre du DOM)
Pas d'erreur gérée sur les utilisateurs concernés

- Edition événement http://localhost:8080/bo/config-club-utilisateur/editer/1
Préciser que tous les champs sont obligatoires sauf mention contraire
Idem mise en page que la page d'ajout (mise en page, bouton annuler)
Erreur pas gérée si on supprime tous les champs et qu'on valide :

## Changements apportés
* Changement des twigs, de l'entité et formType

## Pré-requis

## Tests
- [ ] Tester l'ajout et l'édition d'un événement
- [ ] Vérifier les points ci-dessus, et vérifier que tout fonctionne toujours
