### PR TITLE
[Accessibilité] Utilisateurs API

### DIFF
--- a/src/Controller/Back/UserApiPermissionController.php
+++ b/src/Controller/Back/UserApiPermissionController.php
@@ -69,7 +69,7 @@ final class UserApiPermissionController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/permission/{id}/create', name: 'back_api_user_permission_create', methods: ['GET', 'POST'])]
+    #[Route(path: '/permission/{id}/creer', name: 'back_api_user_permission_create', methods: ['GET', 'POST'])]
     public function permissionCreate(User $user, Request $request, EntityManagerInterface $entityManager): Response
     {
         if (!$user->isApiUser()) {
@@ -95,7 +95,7 @@ final class UserApiPermissionController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/permission/{id}/edit', name: 'back_api_user_permission_edit', methods: ['GET', 'POST'])]
+    #[Route(path: '/permission/{id}/editer', name: 'back_api_user_permission_edit', methods: ['GET', 'POST'])]
     public function edit(UserApiPermission $userApiPermission, Request $request, EntityManagerInterface $entityManager): Response
     {
         $form = $this->createForm(UserApiPermissionType::class, $userApiPermission);
@@ -114,7 +114,7 @@ final class UserApiPermissionController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/permission/{id}/delete', name: 'back_api_user_permission_delete', methods: ['POST'])]
+    #[Route(path: '/permission/{id}/supprimer', name: 'back_api_user_permission_delete', methods: ['POST'])]
     public function delete(UserApiPermission $userApiPermission, Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
         if ($this->isCsrfTokenValid('user_api_permission_delete', (string) $request->request->get('_token'))) {
@@ -145,7 +145,7 @@ final class UserApiPermissionController extends AbstractController
         return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages]);
     }
 
-    #[Route(path: '/add', name: 'back_api_user_add', methods: ['GET', 'POST'])]
+    #[Route(path: '/ajouter', name: 'back_api_user_add', methods: ['GET', 'POST'])]
     public function add(
         Request $request,
         EntityManagerInterface $entityManager,

--- a/src/Form/UserApiType.php
+++ b/src/Form/UserApiType.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class UserApiType extends AbstractType
 {
@@ -20,6 +21,11 @@ class UserApiType extends AbstractType
             ->add('email', TextType::class, [
                 'label' => 'Adresse e-mail',
                 'required' => false,
+                'help' => 'Format attendu : exemple@domaine.com',
+                'constraints' => new Assert\NotBlank([
+                    'message' => 'Veuillez saisir une adresse e-mail.',
+                    'groups' => ['registration'],
+                ]),
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Enregistrer',

--- a/templates/back/user_api_permission/_form.html.twig
+++ b/templates/back/user_api_permission/_form.html.twig
@@ -1,29 +1,34 @@
-<div class="fr-container--fluid">
-	<div class="fr-grid-row fr-grid-row--gutters fr-text--center fr-mb-5w fr-mt-5w">
-		<div class="fr-col-5">
-			<strong>Sélectionner un partenaire spécifique</strong>
-		</div>
-		<div class="fr-col-2">
-			<strong>OU</strong>
-		</div>
-		<div class="fr-col-5">
-			<strong>Sélectionner un groupe de partenaires</strong>
-		</div>
-	</div>
+<section class="fr-grid-row fr-pt-4v">
+	<div class="fr-col-12">
 	{{ form_start(form) }}
 	{{ form_errors(form) }}
-	<div class="fr-grid-row fr-grid-row--gutters">
-		<div class="fr-col-5">
+	<div class="fr-grid-row fr-grid-row--gutters fr-mt-5w">
+		<div class="fr-col-12 fr-col-md-5">
+			<p class="fr-text--center fr-mb-2w"><strong>Sélectionner un partenaire spécifique</strong></p>
 			{{ form_row(form.territoryFilter) }}
 			{{ form_row(form.partner) }}
 		</div>
-		<div class="fr-col-2">
+		<div class="fr-col-12 fr-col-md-2 fr-text--center">
+			<strong>OU</strong>
 		</div>
-		<div class="fr-col-5">
+		<div class="fr-col-12 fr-col-md-5">
+			<p class="fr-text--center fr-mb-2w"><strong>Sélectionner un groupe de partenaires</strong></p>
 			{{ form_row(form.territory) }}
 			{{ form_row(form.partnerType) }}
-            {{ form_row(form.save) }}
+		</div>
+	</div>
+	<div class="fr-grid-row fr-grid-row--gutters">
+		<div class="fr-col-12">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+				<li>
+					{{ form_row(form.save) }}
+				</li>
+				<li>
+					<a href="{{path('back_api_user_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+				</li>
+			</ul>
 		</div>
 	</div>
 	{{ form_end(form) }}
-</div>
+	</div>
+</section>

--- a/templates/back/user_api_permission/add-user.html.twig
+++ b/templates/back/user_api_permission/add-user.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Ajouter un utilisateur API{% endblock %}
 
 {% block content %}
-    <section class="fr-pt-4v">
+    <section class="fr-pt-4v fr-mb-4v">
         {% include 'back/breadcrumb_bo.html.twig' with {
             'level2Title': 'Outils SA',
             'level2Link': '',
@@ -20,18 +20,35 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12">
                     <h1 class="fr-mb-0">Ajouter un utilisateur API</h1>
+                    <br>
+                    <span>Le champ est obligatoire.</span>
                 </div>
             </div>
         </header>
 
     </section>
 
-<div class="fr-container--fluid">
-	<div class="fr-grid-row fr-grid-row--gutters">
-		<div class="fr-col-6">
-            {{ form(form) }}
+    <section class="fr-pt-4v fr-grid-row">
+        <div class="fr-col-12">
+            {{ form_start(form, {'attr': {'id': 'form-add-zone'}}) }}
+            {{ form_errors(form) }}
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    {{ form_row(form.email) }}
+                </div>
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            {{ form_row(form.save) }}
+                        </li>
+                        <li>
+                            <a href="{{path('back_api_user_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            {{ form_end(form) }}
         </div>
-    </div>
-</div>
+    </section>
 
 {% endblock %}

--- a/templates/back/user_api_permission/create.html.twig
+++ b/templates/back/user_api_permission/create.html.twig
@@ -21,7 +21,7 @@
                 <div class="fr-col-12">
                     <h1 class="fr-mb-0">Ajouter une permission pour {{ user.email }}</h1>
                     <br>
-                    <span>Sélectionnez un partenaire spécifique (les deux champs sont obligatoires) <strong>ou</strong> définissez un groupe de partenaires en sélectionnant un territoire, un type de partenaire, ou les deux.</span>
+                    <span>Sélectionnez un partenaire spécifique <strong>ou</strong> définissez un groupe de partenaires en sélectionnant un territoire, un type de partenaire, ou les deux.</span>
                 </div>
             </div>
         </header>

--- a/templates/back/user_api_permission/create.html.twig
+++ b/templates/back/user_api_permission/create.html.twig
@@ -20,6 +20,8 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12">
                     <h1 class="fr-mb-0">Ajouter une permission pour {{ user.email }}</h1>
+                    <br>
+                    <span>Sélectionnez un partenaire spécifique (les deux champs sont obligatoires) <strong>ou</strong> définissez un groupe de partenaires en sélectionnant un territoire, un type de partenaire, ou les deux.</span>
                 </div>
             </div>
         </header>

--- a/templates/back/user_api_permission/edit.html.twig
+++ b/templates/back/user_api_permission/edit.html.twig
@@ -21,7 +21,7 @@
                 <div class="fr-col-12">
                     <h1 class="fr-mb-0">Modifier une permission pour {{ user.email }}</h1>
                     <br>
-                    <span>Sélectionnez un partenaire spécifique (les deux champs sont obligatoires) <strong>ou</strong> définissez un groupe de partenaires en sélectionnant un territoire, un type de partenaire, ou les deux.</span>
+                    <span>Sélectionnez un partenaire spécifique <strong>ou</strong> définissez un groupe de partenaires en sélectionnant un territoire, un type de partenaire, ou les deux.</span>
                 </div>
             </div>
         </header>

--- a/templates/back/user_api_permission/edit.html.twig
+++ b/templates/back/user_api_permission/edit.html.twig
@@ -20,6 +20,8 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12">
                     <h1 class="fr-mb-0">Modifier une permission pour {{ user.email }}</h1>
+                    <br>
+                    <span>Sélectionnez un partenaire spécifique (les deux champs sont obligatoires) <strong>ou</strong> définissez un groupe de partenaires en sélectionnant un territoire, un type de partenaire, ou les deux.</span>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
## Ticket

#5775   

## Description

- Ajout utilisateur API http://localhost:8080/bo/api-user/add
Préciser que le champ est obligatoire
Harmoniser la mise en page avec toutes les autres pages (
Ajouter un bouton Annuler (attention à l'ordre du DOM)
Gérer l'erreur si on valide sans mettre d'adresse e-mail

- Edition permission API http://localhost:8080/bo/api-user/permission/8/edit
Ajouter un texte pour préciser qu'un choix est obligatoire entre les deux possibilités
Ajouter un bouton Annuler (attention à l'ordre du DOM)
Gérer l'affichage mobile

- Ajout permission API http://localhost:8080/bo/api-user/permission/1/create
Ajouter un texte pour préciser qu'un choix est obligatoire entre les deux possibilités
Ajouter un bouton Annuler (attention à l'ordre du DOM)
Gérer l'affichage mobile

## Changements apportés
* Changement des twigs, ajout d'une contrainte sur le formType

## Pré-requis

## Tests
- [ ]  Tester l'ajout d'un utilisateur API
- [ ] Tester l'ajout et l'édition des permissions sur un utilisateur API
- [ ] Vérifier les points ci-dessus, et vérifier que tout fonctionne toujours
