### PR TITLE
[Accessibilité] Service secours, bailleurs, communes

### DIFF
--- a/src/Entity/Bailleur.php
+++ b/src/Entity/Bailleur.php
@@ -68,7 +68,7 @@ class Bailleur
         return $this->name;
     }
 
-    public function setName(string $name): self
+    public function setName(?string $name): self
     {
         $this->name = $name;
 

--- a/src/Entity/Commune.php
+++ b/src/Entity/Commune.php
@@ -47,10 +47,10 @@ class Commune implements EntityHistoryInterface
             return $this->nom;
         }
 
-        return ImportCommune::sanitizeCommuneWithArrondissement($this->nom);
+        return $this->nom ? ImportCommune::sanitizeCommuneWithArrondissement($this->nom) : null;
     }
 
-    public function setNom(string $nom): self
+    public function setNom(?string $nom): self
     {
         $this->nom = $nom;
 
@@ -74,7 +74,7 @@ class Commune implements EntityHistoryInterface
         return $this->codeInsee;
     }
 
-    public function setCodeInsee(string $codeInsee): self
+    public function setCodeInsee(?string $codeInsee): self
     {
         $this->codeInsee = $codeInsee;
 

--- a/src/Form/BailleurType.php
+++ b/src/Form/BailleurType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class BailleurType extends AbstractType
 {
@@ -30,11 +31,15 @@ class BailleurType extends AbstractType
         $builder
             ->add('name', null, [
                 'label' => 'Nom',
+                'required' => false,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Veuillez fournir le nom du bailleur.'),
+                ],
             ])
             ->add('bailleurTerritories', SearchCheckboxType::class, [
                 'class' => Territory::class,
                 'choice_label' => 'zipAndName',
-                'label' => 'Territoires associés',
+                'label' => 'Territoires associés (facultatif)',
                 'noselectionlabel' => 'Sélectionnez un ou plusieurs territoires à associer',
                 'nochoiceslabel' => 'Aucun territoire associable disponible',
                 'mapped' => false,

--- a/src/Form/CommuneType.php
+++ b/src/Form/CommuneType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class CommuneType extends AbstractType
 {
@@ -28,6 +29,10 @@ class CommuneType extends AbstractType
             ])
             ->add('nom', null, [
                 'label' => 'Nom',
+                'required' => false,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Veuillez fournir le nom de la commune.'),
+                ],
             ])
             ->add('epci', EntityType::class, [
                 'class' => Epci::class,
@@ -35,7 +40,7 @@ class CommuneType extends AbstractType
                     return $er->createQueryBuilder('e')->orderBy('e.nom', 'ASC');
                 },
                 'choice_label' => 'nom',
-                'label' => 'EPCI',
+                'label' => 'EPCI (facultatif)',
                 'required' => false,
             ])
             ->add('codePostal', null, [
@@ -44,6 +49,10 @@ class CommuneType extends AbstractType
             ])
             ->add('codeInsee', null, [
                 'label' => 'Code INSEE',
+                'required' => false,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Veuillez fournir le code INSEE de la commune.'),
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Valider',

--- a/templates/back/bailleur/edit.html.twig
+++ b/templates/back/bailleur/edit.html.twig
@@ -16,7 +16,9 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
-                    <h1 class="fr-mb-0">Bailleur {{bailleur.name}}</h1>
+                    <h1 class="fr-mb-0">Bailleur {{bailleur.name}}</h1><br>
+                    <span>Remplissez le formulaire ci-dessous pour modifier le bailleur.</span><br>
+                    <span>Le champ nom est obligatoire.</span>
                 </div>
             </div>
         </header>
@@ -24,8 +26,28 @@
 
     <section class="fr-grid-row fr-pt-4v">
         <div class="fr-col-12">
-            {{form(form, {'attr': {'id': 'form-edit-bailleur'}} )}}
+            {{ form_start(form, {'attr': {'id': 'form-edit-bailleur'}}) }}
+            {{ form_errors(form) }}
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    {{ form_row(form.name) }}
+                </div>
+                <div class="fr-col-12">
+                    {{ form_row(form.bailleurTerritories) }}
+                </div>
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            {{ form_row(form.submit) }}
+                        </li>
+                        <li>
+                            <a href="{{path('back_bailleur_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </div>
+        {{ form_end(form) }}
     </section>
 
 {% endblock %}

--- a/templates/back/bailleur/edit.html.twig
+++ b/templates/back/bailleur/edit.html.twig
@@ -16,9 +16,11 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
-                    <h1 class="fr-mb-0">Bailleur {{bailleur.name}}</h1><br>
-                    <span>Remplissez le formulaire ci-dessous pour modifier le bailleur.</span><br>
-                    <span>Le champ nom est obligatoire.</span>
+                    <h1>Bailleur {{bailleur.name}}</h1>                    
+                    <p>
+                        <span>Remplissez le formulaire ci-dessous pour modifier le bailleur.</span><br>
+                        <span>Le champ nom est obligatoire.</span>
+                    </p>
                 </div>
             </div>
         </header>

--- a/templates/back/commune/edit.html.twig
+++ b/templates/back/commune/edit.html.twig
@@ -16,7 +16,9 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
-                    <h1 class="fr-mb-0">Commune {{commune.nom}}</h1>
+                    <h1 class="fr-mb-0">Commune {{commune.nom}}</h1><br>
+                    <span>Remplissez le formulaire ci-dessous pour modifier la commune.</span><br>
+                    <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
                 </div>
             </div>
         </header>
@@ -32,11 +34,15 @@
             {{ form_row(form.codePostal) }}
             {{ form_row(form.codeInsee) }}
             <div class="fr-grid-row">
-                <div class="fr-col-6">
-                    <a href="{{ path('back_commune_index') }}" class="fr-btn fr-btn--secondary">Annuler</a>
-                </div>
-                <div class="fr-col-6 fr-text--right">
-                    {{ form_row(form.submit) }}
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            {{ form_row(form.submit) }}
+                        </li>
+                        <li>
+                            <a href="{{path('back_commune_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+                        </li>
+                    </ul>
                 </div>
             </div>
             {{ form_end(form) }}

--- a/templates/back/commune/edit.html.twig
+++ b/templates/back/commune/edit.html.twig
@@ -16,9 +16,11 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
-                    <h1 class="fr-mb-0">Commune {{commune.nom}}</h1><br>
-                    <span>Remplissez le formulaire ci-dessous pour modifier la commune.</span><br>
-                    <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
+                    <h1>Commune {{commune.nom}}</h1>
+                    <p>
+                        <span>Remplissez le formulaire ci-dessous pour modifier la commune.</span><br>
+                        <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
+                    </p>
                 </div>
             </div>
         </header>

--- a/templates/back/config-service-secours-route/_form.html.twig
+++ b/templates/back/config-service-secours-route/_form.html.twig
@@ -1,1 +1,27 @@
-{{ form(form) }}
+{{ form_start(form, {'attr': {'id': 'form-config-service-secours-route'}}) }}
+{{ form_errors(form) }}
+<div class="fr-grid-row fr-grid-row--gutters">
+    <div class="fr-col-12">
+        {{ form_row(form.territory) }}
+    </div>
+    <div class="fr-col-12">
+        {{ form_row(form.name) }}
+    </div>
+    <div class="fr-col-12">
+        {{ form_row(form.email) }}
+    </div>
+    <div class="fr-col-12">
+        {{ form_row(form.phone) }}
+    </div>
+    <div class="fr-col-12">
+        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+            <li>
+                {{ form_row(form.submit) }}
+            </li>
+            <li>
+                <a href="{{path('back_config_service_secours_route_index')}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line" type="button">Annuler</a>
+            </li>
+        </ul>
+    </div>
+</div>
+{{ form_end(form) }}

--- a/templates/back/config-service-secours-route/edit.html.twig
+++ b/templates/back/config-service-secours-route/edit.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Route service secours{% endblock %}
+{% block title %}Ajouter une route service secours{% endblock %}
 
 {% block content %}
     <section class="fr-col-12 fr-pt-4v">

--- a/templates/back/config-service-secours-route/edit.html.twig
+++ b/templates/back/config-service-secours-route/edit.html.twig
@@ -1,6 +1,12 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Ajouter une route service secours{% endblock %}
+{% block title %}
+    {% if create %}
+        Ajouter une route service secours
+    {% else %}
+        Modifier la route service secours {{ serviceSecoursRoute.name }}
+    {% endif %}
+{% endblock %}
 
 {% block content %}
     <section class="fr-col-12 fr-pt-4v">


### PR DESCRIPTION
## Ticket

#5776   

## Description
- Ajout route service secours http://localhost:8080/bo/config-service-secours/ajout
Ajouter un bouton Annuler (attention à l'ordre du DOM)
Changer le titre pour "Ajouter une route service secours  - Signal Logement"

- Edition bailleur http://localhost:8080/bo/bailleur/editer/17
Préciser que le champ nom est obligatoire, 
Gérer les messages d'erreurs, s'interroger sur le fait que les territoires sont facultatifs :
Ajouter un bouton Annuler (en faisant attention à l'ordre du DOM)

- Edition commune http://localhost:8080/bo/commune/editer/2676
Précisier les champs obligatoires et facultatifs, gérer les erreurs
Inverser le bouton `Valider` et `annuler` dans le DOM (si c'est bien ce qu'on a décidé partout ailleurs) pour la navigation au clavier 

## Changements apportés
* Modification twigs, formType et entités

## Pré-requis

## Tests 

- [ ] Tester l'ajout d'une route service secours
- [ ] Tester l'édition des dun bailleur
- [ ] Tester l'édition d'une commune
- [ ] Vérifier les points ci-dessus, et vérifier que tout fonctionne toujours
