### PR TITLE
[Tech] Remplacer phpspreadsheets partout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "nelmio/cors-bundle": "^2.2",
         "openspout/openspout": "^5",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "phpoffice/phpspreadsheet": "^5",
         "phpstan/phpdoc-parser": "^1.2",
         "scheb/2fa-bundle": "^7.6",
         "scheb/2fa-email": "^7.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46410acbae66cb4178d6ce289c6239c4",
+    "content-hash": "3fc7357956cbc4280b8f95950cd3c06c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -390,85 +390,6 @@
                 }
             ],
             "time": "2021-09-13T08:41:34+00:00"
-        },
-        {
-            "name": "composer/pcre",
-            "version": "3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<1.11.10"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
-            },
-            "type": "library",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Pcre\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
-            "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-11-12T16:29:46+00:00"
         },
         {
             "name": "cron/cron",
@@ -3557,113 +3478,6 @@
             "time": "2026-04-11T18:38:28+00:00"
         },
         {
-            "name": "markbaker/complex",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/MarkBaker/PHPComplex.git",
-                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
-                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-                "squizlabs/php_codesniffer": "^3.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Complex\\": "classes/src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mark Baker",
-                    "email": "mark@lange.demon.co.uk"
-                }
-            ],
-            "description": "PHP Class for working with complex numbers",
-            "homepage": "https://github.com/MarkBaker/PHPComplex",
-            "keywords": [
-                "complex",
-                "mathematics"
-            ],
-            "support": {
-                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
-                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.2"
-            },
-            "time": "2022-12-06T16:21:08+00:00"
-        },
-        {
-            "name": "markbaker/matrix",
-            "version": "3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/MarkBaker/PHPMatrix.git",
-                "reference": "728434227fe21be27ff6d86621a1b13107a2562c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/728434227fe21be27ff6d86621a1b13107a2562c",
-                "reference": "728434227fe21be27ff6d86621a1b13107a2562c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpdocumentor/phpdocumentor": "2.*",
-                "phploc/phploc": "^4.0",
-                "phpmd/phpmd": "2.*",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-                "sebastian/phpcpd": "^4.0",
-                "squizlabs/php_codesniffer": "^3.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Matrix\\": "classes/src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mark Baker",
-                    "email": "mark@demon-angel.eu"
-                }
-            ],
-            "description": "PHP Class for working with matrices",
-            "homepage": "https://github.com/MarkBaker/PHPMatrix",
-            "keywords": [
-                "mathematics",
-                "matrix",
-                "vector"
-            ],
-            "support": {
-                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
-                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
-            },
-            "time": "2022-12-02T22:17:43+00:00"
-        },
-        {
             "name": "masterminds/html5",
             "version": "2.10.0",
             "source": {
@@ -4533,115 +4347,6 @@
             "time": "2025-11-21T15:09:14+00:00"
         },
         {
-            "name": "phpoffice/phpspreadsheet",
-            "version": "5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
-                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
-                "shasum": ""
-            },
-            "require": {
-                "composer/pcre": "^1||^2||^3",
-                "ext-ctype": "*",
-                "ext-dom": "*",
-                "ext-fileinfo": "*",
-                "ext-filter": "*",
-                "ext-gd": "*",
-                "ext-iconv": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-simplexml": "*",
-                "ext-xml": "*",
-                "ext-xmlreader": "*",
-                "ext-xmlwriter": "*",
-                "ext-zip": "*",
-                "ext-zlib": "*",
-                "maennchen/zipstream-php": "^2.1 || ^3.0",
-                "markbaker/complex": "^3.0",
-                "markbaker/matrix": "^3.0",
-                "php": "^8.1",
-                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
-                "dompdf/dompdf": "^2.0 || ^3.0",
-                "ext-intl": "*",
-                "friendsofphp/php-cs-fixer": "^3.2",
-                "mitoteam/jpgraph": "^10.5",
-                "mpdf/mpdf": "^8.1.1",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpstan/phpstan": "^1.1 || ^2.0",
-                "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
-                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
-                "phpunit/phpunit": "^10.5",
-                "squizlabs/php_codesniffer": "^3.7",
-                "tecnickcom/tcpdf": "^6.5"
-            },
-            "suggest": {
-                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
-                "ext-intl": "PHP Internationalization Functions, required for NumberFormat Wizard and StringHelper::setLocale()",
-                "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
-                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
-                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Maarten Balliauw",
-                    "homepage": "https://blog.maartenballiauw.be"
-                },
-                {
-                    "name": "Mark Baker",
-                    "homepage": "https://markbakeruk.net"
-                },
-                {
-                    "name": "Franck Lefevre",
-                    "homepage": "https://rootslabs.net"
-                },
-                {
-                    "name": "Erik Tilt"
-                },
-                {
-                    "name": "Adrien Crivelli"
-                },
-                {
-                    "name": "Owen Leibman"
-                }
-            ],
-            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
-            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
-            "keywords": [
-                "OpenXML",
-                "excel",
-                "gnumeric",
-                "ods",
-                "php",
-                "spreadsheet",
-                "xls",
-                "xlsx"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.7.0"
-            },
-            "time": "2026-04-20T02:42:17+00:00"
-        },
-        {
             "name": "phpseclib/phpseclib",
             "version": "3.0.52",
             "source": {
@@ -5263,57 +4968,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -16254,7 +15908,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -16262,6 +15916,6 @@
         "ext-imagick": "*",
         "ext-sodium": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Controller/Back/AnnuaireController.php
+++ b/src/Controller/Back/AnnuaireController.php
@@ -4,16 +4,21 @@ namespace App\Controller\Back;
 
 use App\Entity\User;
 use App\Form\SearchAnnuaireAgentType;
+use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserPartnerRepository;
 use App\Service\ListFilters\SearchAnnuaireAgent;
-use PhpOffice\PhpSpreadsheet\Cell\DataType;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Writer\Csv;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use App\Service\Signalement\Export\SignalementExportHeader;
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Cell\StringCell;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Writer\CSV\Options as CsvOptions;
+use OpenSpout\Writer\CSV\Writer as CsvWriter;
+use OpenSpout\Writer\XLSX\Writer as XlsxWriter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/annuaire')]
@@ -57,61 +62,51 @@ class AnnuaireController extends AbstractController
         if ('POST' === $originalMethod) {
             /** @var string $format */
             $format = $request->request->get('file-format');
-            if (!in_array($format, ['csv', 'xlsx'])) {
+            if (!in_array($format, [ListExportMessage::FORMAT_CSV, ListExportMessage::FORMAT_XLSX])) {
                 $this->addFlash('error', 'Merci de sélectionner le format de l\'export.');
 
                 return $this->redirectToRoute('back_annuaire_export', $search->getUrlParams());
             }
-
-            $spreadsheet = new Spreadsheet();
-            $activeWorksheet = $spreadsheet->getActiveSheet();
-
-            $activeWorksheet->setCellValue('A1', 'Nom complet de l\'agent');
-            $activeWorksheet->setCellValue('B1', 'Nom du partenaire');
-            $activeWorksheet->setCellValue('C1', 'Email de l\'agent');
-            $activeWorksheet->setCellValue('D1', 'Téléphone de l\'agent');
-            $activeWorksheet->setCellValue('E1', 'Fonction de l\'agent');
-            if ($isMultiTerritory) {
-                $activeWorksheet->setCellValue('F1', 'Territoire');
-            }
-
-            $row = 2;
-            foreach ($userPartners as $userPartner) {
-                $partner = $userPartner->getPartner();
-                $user = $userPartner->getUser();
-                $activeWorksheet->setCellValue('A'.$row, $user->getNomComplet());
-                $activeWorksheet->setCellValue('B'.$row, $partner->getNom());
-                $activeWorksheet->setCellValue('C'.$row, $user->getEmail());
-                $activeWorksheet->setCellValueExplicit('D'.$row, $user->getPhoneDecoded(), DataType::TYPE_STRING);
-                $activeWorksheet->setCellValue('E'.$row, $user->getFonction());
-                if ($isMultiTerritory) {
-                    $territory = $partner->getTerritory();
-                    $territoryName = $territory ? $territory->getZipAndName() : '';
-                    $activeWorksheet->setCellValue('F'.$row, $territoryName);
-                }
-                ++$row;
-            }
-
-            if ('csv' === $format) {
-                $writer = new Csv($spreadsheet);
-            } elseif ('xlsx' === $format) {
-                $writer = new Xlsx($spreadsheet);
+            if (ListExportMessage::FORMAT_CSV === $format) {
+                $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+            } elseif (ListExportMessage::FORMAT_XLSX === $format) {
+                $writer = new XlsxWriter();
             } else {
                 throw new \Exception('Invalid format "'.$format.'"');
             }
+
             $filename = 'annuaire_'.date('Y-m-d_H-i-s').'.'.$format;
 
-            ob_start();
-            $writer->save('php://output');
-            $content = ob_get_clean();
+            $contentType = ListExportMessage::FORMAT_CSV === $format
+                ? 'text/csv'
+                : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
-            if (!$content) {
-                throw new \RuntimeException('Erreur lors de la génération du contenu CSV.');
-            }
-            $response = new Response($content);
-            $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+            $response = new StreamedResponse(static function () use ($writer, $isMultiTerritory, $userPartners) {
+                $writer->openToFile('php://output');
+                $writer->addRow(Row::fromValues([
+                    'Nom complet de l\'agent',
+                    'Nom du partenaire',
+                    'Email de l\'agent',
+                    'Téléphone de l\'agent',
+                    'Fonction de l\'agent',
+                    $isMultiTerritory ? 'Territoire' : null,
+                ]));
+                foreach ($userPartners as $userPartner) {
+                    $partner = $userPartner->getPartner();
+                    $user = $userPartner->getUser();
+                    $writer->addRow(new Row([
+                        Cell::fromValue($user->getNomComplet()),
+                        Cell::fromValue($partner->getNom()),
+                        Cell::fromValue($user->getEmail()),
+                        new StringCell($user->getPhoneDecoded() ?? '', null),
+                        Cell::fromValue($user->getFonction()),
+                        Cell::fromValue($isMultiTerritory ? ($partner->getTerritory()?->getZipAndName() ?? '') : null),
+                    ]));
+                }
+                $writer->close();
+            });
+            $response->headers->set('Content-Type', $contentType);
             $response->headers->set('Content-Disposition', 'attachment; filename="'.$filename.'"');
-            $response->headers->set('Content-Length', (string) strlen($content));
 
             return $response;
         }

--- a/src/Controller/Back/AnnuaireController.php
+++ b/src/Controller/Back/AnnuaireController.php
@@ -4,10 +4,9 @@ namespace App\Controller\Back;
 
 use App\Entity\User;
 use App\Form\SearchAnnuaireAgentType;
-use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserPartnerRepository;
 use App\Service\ListFilters\SearchAnnuaireAgent;
-use App\Service\Signalement\Export\SignalementExportHeader;
+use App\Utils\ExportFormat;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Row;
@@ -62,14 +61,14 @@ class AnnuaireController extends AbstractController
         if ('POST' === $originalMethod) {
             /** @var string $format */
             $format = $request->request->get('file-format');
-            if (!in_array($format, [ListExportMessage::FORMAT_CSV, ListExportMessage::FORMAT_XLSX])) {
+            if (!in_array($format, [ExportFormat::FORMAT_CSV, ExportFormat::FORMAT_XLSX])) {
                 $this->addFlash('error', 'Merci de sélectionner le format de l\'export.');
 
                 return $this->redirectToRoute('back_annuaire_export', $search->getUrlParams());
             }
-            if (ListExportMessage::FORMAT_CSV === $format) {
-                $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
-            } elseif (ListExportMessage::FORMAT_XLSX === $format) {
+            if (ExportFormat::FORMAT_CSV === $format) {
+                $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: ExportFormat::CSV_SEPARATOR));
+            } elseif (ExportFormat::FORMAT_XLSX === $format) {
                 $writer = new XlsxWriter();
             } else {
                 throw new \Exception('Invalid format "'.$format.'"');
@@ -77,7 +76,7 @@ class AnnuaireController extends AbstractController
 
             $filename = 'annuaire_'.date('Y-m-d_H-i-s').'.'.$format;
 
-            $contentType = ListExportMessage::FORMAT_CSV === $format
+            $contentType = ExportFormat::FORMAT_CSV === $format
                 ? 'text/csv'
                 : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 

--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -10,6 +10,7 @@ use App\Service\RequestDataExtractor;
 use App\Service\Signalement\Export\SignalementExportFiltersDisplay;
 use App\Service\Signalement\Export\SignalementExportSelectableColumns;
 use App\Service\Signalement\SearchFilter;
+use App\Utils\ExportFormat;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -59,7 +60,7 @@ class ExportSignalementController extends AbstractController
         $selectedColumns = RequestDataExtractor::getArray($requestData, 'cols');
         $request->getSession()->set('selectedCols', $selectedColumns);
 
-        if (!in_array($format, ['csv', 'xlsx'])) {
+        if (!in_array($format, [ExportFormat::FORMAT_CSV, ExportFormat::FORMAT_XLSX])) {
             $this->addFlash('error', "Veuillez sélectionner un format pour l'export.");
 
             return $this->redirectToRoute('back_signalement_list_export');

--- a/src/Controller/Back/UserController.php
+++ b/src/Controller/Back/UserController.php
@@ -12,6 +12,7 @@ use App\Security\Voter\UserVoter;
 use App\Service\EmailAlert\EmailAlertChecker;
 use App\Service\Export\UserExportLoader;
 use App\Service\ListFilters\SearchUser;
+use App\Utils\ExportFormat;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -61,7 +62,7 @@ class UserController extends AbstractController
         if ('POST' === $originalMethod) {
             /** @var string $format */
             $format = $request->request->get('file-format');
-            if (!in_array($format, ['csv', 'xlsx'])) {
+            if (!in_array($format, [ExportFormat::FORMAT_CSV, ExportFormat::FORMAT_XLSX])) {
                 $this->addFlash('error', 'Veuillez sélectionner un format pour l\'export.');
 
                 return $this->redirectToRoute('back_user_export', $searchUser->getUrlParams());
@@ -109,7 +110,7 @@ class UserController extends AbstractController
         if ('POST' === $request->getMethod()) {
             /** @var string $format */
             $format = $request->request->get('file-format');
-            if (!in_array($format, ['csv', 'xlsx'])) {
+            if (!in_array($format, [ExportFormat::FORMAT_CSV, ExportFormat::FORMAT_XLSX])) {
                 $this->addFlash('error', 'Veuillez sélectionner un format pour l\'export.');
 
                 return $this->redirectToRoute('back_user_export_inactive_accounts');

--- a/src/Messenger/Message/ListExportMessage.php
+++ b/src/Messenger/Message/ListExportMessage.php
@@ -4,9 +4,6 @@ namespace App\Messenger\Message;
 
 class ListExportMessage
 {
-    public const string FORMAT_CSV = 'csv';
-    public const string FORMAT_XLSX = 'xlsx';
-
     private int $userId;
     private string $format;
     /**

--- a/src/Messenger/MessageHandler/InactiveUserExportMessageHandler.php
+++ b/src/Messenger/MessageHandler/InactiveUserExportMessageHandler.php
@@ -9,8 +9,6 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\TimezoneProvider;
-use PhpOffice\PhpSpreadsheet\Writer\Csv;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -32,19 +30,11 @@ class InactiveUserExportMessageHandler
         try {
             $user = $this->userRepository->find($exportMessage->getUserId());
             $format = $exportMessage->getFormat();
-            $spreadsheet = $this->inactiveUserExportLoader->load($user);
-            if ('csv' === $format) {
-                $writer = new Csv($spreadsheet);
-            } elseif ('xlsx' === $format) {
-                $writer = new Xlsx($spreadsheet);
-            } else {
-                throw new \Exception('Invalid format "'.$format.'"');
-            }
             $timezone = $user->getFirstTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
             $datetimeStr = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone($timezone))->format('dmY-Hi');
             $filename = 'utilisateurs-inactifs-'.$user->getId().'-'.$datetimeStr.'.'.$format;
             $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
-            $writer->save($tmpFilepath);
+            $this->inactiveUserExportLoader->load($user, $format, $tmpFilepath);
 
             $this->notificationMailerRegistry->send(
                 new NotificationMail(

--- a/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
+++ b/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
@@ -9,9 +9,11 @@ use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
+use App\Service\Signalement\Export\SignalementExportHeader;
 use App\Utils\HtmlCleaner;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Writer\Csv;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Writer\CSV\Options as CsvOptions;
+use OpenSpout\Writer\CSV\Writer as CsvWriter;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -39,13 +41,11 @@ class SuiviSummariesMessageHandler
     {
         try {
             $user = $this->userRepository->find($suiviSummariesMessage->getUserId());
-            $spreadsheet = $this->buildSpreadsheet($suiviSummariesMessage);
 
-            $writer = new Csv($spreadsheet);
             $datetimeStr = (new \DateTimeImmutable())->format('dmY-Hi');
             $filename = 'resumes-suivis-'.$user->getId().'-'.$datetimeStr.'.csv';
             $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
-            $writer->save($tmpFilepath);
+            $this->buildSpreadsheet($suiviSummariesMessage, $tmpFilepath);
 
             $this->notificationMailerRegistry->send(
                 new NotificationMail(
@@ -67,12 +67,12 @@ class SuiviSummariesMessageHandler
     /**
      * TODO : move to an export service.
      */
-    private function buildSpreadsheet(SuiviSummariesMessage $suiviSummariesMessage): Spreadsheet
+    private function buildSpreadsheet(SuiviSummariesMessage $suiviSummariesMessage, string $outputFilePath): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        $writer->openToFile($outputFilePath);
         $headers = ['Référence du signalement', 'Lien vers le signalement', 'Date du dernier suivi', 'Auteur du dernier suivi', 'Résumé du dernier suivi', 'Contenu du dernier suivi'];
-        $sheetData = [$headers];
+        $writer->addRow(Row::fromValues($headers));
         $territory = $this->territoryRepository->find($suiviSummariesMessage->getTerritoryId());
         $list = [];
         switch ($suiviSummariesMessage->getQuerySignalement()) {
@@ -115,12 +115,10 @@ class SuiviSummariesMessageHandler
                 $this->getSummaryFromSignalement($cleanLastSuiviDescription, $suiviSummariesMessage),
                 $cleanLastSuiviDescription,
             ];
-            $sheetData[] = $rowArray;
+            $writer->addRow(Row::fromValues($rowArray));
         }
 
-        $sheet->fromArray($sheetData);
-
-        return $spreadsheet;
+        $writer->close();
     }
 
     /**

--- a/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
+++ b/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
@@ -9,7 +9,7 @@ use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
-use App\Service\Signalement\Export\SignalementExportHeader;
+use App\Utils\ExportFormat;
 use App\Utils\HtmlCleaner;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Writer\CSV\Options as CsvOptions;
@@ -69,7 +69,7 @@ class SuiviSummariesMessageHandler
      */
     private function buildSpreadsheet(SuiviSummariesMessage $suiviSummariesMessage, string $outputFilePath): void
     {
-        $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: ExportFormat::CSV_SEPARATOR));
         $writer->openToFile($outputFilePath);
         $headers = ['Référence du signalement', 'Lien vers le signalement', 'Date du dernier suivi', 'Auteur du dernier suivi', 'Résumé du dernier suivi', 'Contenu du dernier suivi'];
         $writer->addRow(Row::fromValues($headers));

--- a/src/Messenger/MessageHandler/UserExportMessageHandler.php
+++ b/src/Messenger/MessageHandler/UserExportMessageHandler.php
@@ -9,8 +9,6 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\TimezoneProvider;
-use PhpOffice\PhpSpreadsheet\Writer\Csv;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -32,19 +30,11 @@ class UserExportMessageHandler
         try {
             $user = $this->userRepository->find($listExportMessage->getSearchUser()->getUser()->getId());
             $format = $listExportMessage->getFormat();
-            $spreadsheet = $this->userExportLoader->load($listExportMessage->getSearchUser());
-            if ('csv' === $format) {
-                $writer = new Csv($spreadsheet);
-            } elseif ('xlsx' === $format) {
-                $writer = new Xlsx($spreadsheet);
-            } else {
-                throw new \Exception('Invalid format "'.$format.'"');
-            }
             $timezone = $user->getFirstTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
             $datetimeStr = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone($timezone))->format('dmY-Hi');
             $filename = 'utilisateurs-histologe-'.$user->getId().'-'.$datetimeStr.'.'.$format;
             $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
-            $writer->save($tmpFilepath);
+            $this->userExportLoader->load($listExportMessage->getSearchUser(), $format, $tmpFilepath);
 
             $this->notificationMailerRegistry->send(
                 new NotificationMail(

--- a/src/Service/Export/InactiveUserExportLoader.php
+++ b/src/Service/Export/InactiveUserExportLoader.php
@@ -3,8 +3,13 @@
 namespace App\Service\Export;
 
 use App\Entity\User;
+use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserRepository;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use App\Service\Signalement\Export\SignalementExportHeader;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Writer\CSV\Options as CsvOptions;
+use OpenSpout\Writer\CSV\Writer as CsvWriter;
+use OpenSpout\Writer\XLSX\Writer as XlsxWriter;
 
 readonly class InactiveUserExportLoader
 {
@@ -13,12 +18,17 @@ readonly class InactiveUserExportLoader
     ) {
     }
 
-    public function load(User $user): Spreadsheet
+    public function load(User $user, string $format, string $outputFilePath): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        if (ListExportMessage::FORMAT_CSV === $format) {
+            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        } else {
+            $writer = new XlsxWriter();
+        }
+        $writer->openToFile($outputFilePath);
+
         $headers = ['ID', 'Nom', 'Prénom', 'Email', 'Partenaire', 'Date de création', 'Dernière connexion', 'Date d\'archivage prévue'];
-        $sheetData = [$headers];
+        $writer->addRow(Row::fromValues($headers));
         /** @var array<int, User> $list */
         $list = $this->userRepository->findUsersPendingToArchive($user);
         foreach ($list as $item) {
@@ -41,10 +51,9 @@ readonly class InactiveUserExportLoader
                 $item->getLastLoginAt() ? $item->getLastLoginAt()->format('d/m/Y') : '',
                 $item->getArchivingScheduledAt() ? $item->getArchivingScheduledAt()->format('d/m/Y') : '',
             ];
-            $sheetData[] = $rowArray;
+            $writer->addRow(Row::fromValues($rowArray));
         }
-        $sheet->fromArray($sheetData);
 
-        return $spreadsheet;
+        $writer->close();
     }
 }

--- a/src/Service/Export/InactiveUserExportLoader.php
+++ b/src/Service/Export/InactiveUserExportLoader.php
@@ -3,9 +3,8 @@
 namespace App\Service\Export;
 
 use App\Entity\User;
-use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserRepository;
-use App\Service\Signalement\Export\SignalementExportHeader;
+use App\Utils\ExportFormat;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Writer\CSV\Options as CsvOptions;
 use OpenSpout\Writer\CSV\Writer as CsvWriter;
@@ -20,8 +19,8 @@ readonly class InactiveUserExportLoader
 
     public function load(User $user, string $format, string $outputFilePath): void
     {
-        if (ListExportMessage::FORMAT_CSV === $format) {
-            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        if (ExportFormat::FORMAT_CSV === $format) {
+            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: ExportFormat::CSV_SEPARATOR));
         } else {
             $writer = new XlsxWriter();
         }

--- a/src/Service/Export/UserExportLoader.php
+++ b/src/Service/Export/UserExportLoader.php
@@ -4,10 +4,9 @@ namespace App\Service\Export;
 
 use App\Entity\Enum\UserStatus;
 use App\Entity\User;
-use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserRepository;
 use App\Service\ListFilters\SearchUser;
-use App\Service\Signalement\Export\SignalementExportHeader;
+use App\Utils\ExportFormat;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Writer\CSV\Options as CsvOptions;
 use OpenSpout\Writer\CSV\Writer as CsvWriter;
@@ -38,8 +37,8 @@ readonly class UserExportLoader
 
     public function load(SearchUser $searchUser, string $format, string $outputFilePath): void
     {
-        if (ListExportMessage::FORMAT_CSV === $format) {
-            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        if (ExportFormat::FORMAT_CSV === $format) {
+            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: ExportFormat::CSV_SEPARATOR));
         } else {
             $writer = new XlsxWriter();
         }

--- a/src/Service/Export/UserExportLoader.php
+++ b/src/Service/Export/UserExportLoader.php
@@ -4,9 +4,14 @@ namespace App\Service\Export;
 
 use App\Entity\Enum\UserStatus;
 use App\Entity\User;
+use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserRepository;
 use App\Service\ListFilters\SearchUser;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use App\Service\Signalement\Export\SignalementExportHeader;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Writer\CSV\Options as CsvOptions;
+use OpenSpout\Writer\CSV\Writer as CsvWriter;
+use OpenSpout\Writer\XLSX\Writer as XlsxWriter;
 
 readonly class UserExportLoader
 {
@@ -31,57 +36,52 @@ readonly class UserExportLoader
     ) {
     }
 
-    public function load(SearchUser $searchUser): Spreadsheet
+    public function load(SearchUser $searchUser, string $format, string $outputFilePath): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
-        $headers = array_map(static fn ($column) => $column['label'], self::getColumnForUser($searchUser->getUser()));
-        $sheetData = [$headers];
+        if (ListExportMessage::FORMAT_CSV === $format) {
+            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        } else {
+            $writer = new XlsxWriter();
+        }
+        $writer->openToFile($outputFilePath);
+
+        $columns = self::getColumnForUser($searchUser->getUser());
+        $headers = array_map(static fn ($column) => $column['label'], $columns);
+        $writer->addRow(Row::fromValues(array_values($headers)));
         /** @var array<int, User> $list */
         $list = $this->userRepository->findFiltered($searchUser);
         foreach ($list as $user) {
-            $rowArray = [];
-            foreach ($headers as $key => $unused) {
-                $territories = '';
-                foreach ($user->getPartnersTerritories() as $territory) {
-                    $territories .= $territory->getZipAndName().', ';
-                }
-                $territories = substr($territories, 0, -2);
-                $partners = '';
-                $partnerTypes = '';
-                foreach ($user->getPartners() as $partner) {
-                    $partners .= $partner->getNom().', ';
-                    if ($partner->getType()) {
-                        $partnerTypes .= $partner->getType()->label().', ';
-                    } else {
-                        $partnerTypes .= 'N/A, ';
-                    }
-                }
-                $partners = substr($partners, 0, -2);
-                $partnerTypes = substr($partnerTypes, 0, -2);
-                $rowArray[] = match ($key) {
-                    'id' => $user->getId(),
-                    'territory' => $territories,
-                    'email' => $user->getEmail(),
-                    'nom' => $user->getNom(),
-                    'prenom' => $user->getPrenom(),
-                    'fonction' => $user->getFonction(),
-                    'partner' => $partners,
-                    'partnerType' => $partnerTypes,
-                    'createdAt' => $user->getCreatedAt()->format('d/m/Y'),
-                    'statut' => UserStatus::ACTIVE === $user->getStatut() ? 'Activé' : 'Non activé',
-                    'lastLoginAt' => $user->getLastLoginAt() ? $user->getLastLoginAt()->format('d/m/Y') : '',
-                    'role' => $user->getRoleLabel(),
-                    'permissionAffectation' => $user->isSuperAdmin() || $user->isTerritoryAdmin() || $user->hasPermissionAffectation() ? 'oui' : 'non',
-                    default => '',
-                };
-            }
-            $sheetData[] = $rowArray;
+            $territories = implode(', ', array_map(
+                static fn ($t) => $t->getZipAndName(),
+                $user->getPartnersTerritories()
+            ));
+            $partners = implode(', ', array_map(
+                static fn ($p) => $p->getNom(),
+                $user->getPartners()->toArray()
+            ));
+            $partnerTypes = implode(', ', array_map(
+                static fn ($p) => $p->getType() ? $p->getType()->label() : 'N/A',
+                $user->getPartners()->toArray()
+            ));
+            $rowArray = array_map(static fn ($key) => match ($key) {
+                'id' => $user->getId(),
+                'territory' => $territories,
+                'email' => $user->getEmail(),
+                'nom' => $user->getNom(),
+                'prenom' => $user->getPrenom(),
+                'fonction' => $user->getFonction(),
+                'partner' => $partners,
+                'partnerType' => $partnerTypes,
+                'createdAt' => $user->getCreatedAt()->format('d/m/Y'),
+                'statut' => UserStatus::ACTIVE === $user->getStatut() ? 'Activé' : 'Non activé',
+                'lastLoginAt' => $user->getLastLoginAt() ? $user->getLastLoginAt()->format('d/m/Y') : '',
+                'role' => $user->getRoleLabel(),
+                'permissionAffectation' => $user->isSuperAdmin() || $user->isTerritoryAdmin() || $user->hasPermissionAffectation() ? 'oui' : 'non',
+                default => '',
+            }, array_keys($columns));
+            $writer->addRow(Row::fromValues($rowArray));
         }
-
-        $sheet->fromArray($sheetData);
-
-        return $spreadsheet;
+        $writer->close();
     }
 
     /**

--- a/src/Service/Signalement/Export/SignalementExporter.php
+++ b/src/Service/Signalement/Export/SignalementExporter.php
@@ -4,7 +4,7 @@ namespace App\Service\Signalement\Export;
 
 use App\Entity\User;
 use App\Manager\SignalementManager;
-use App\Messenger\Message\ListExportMessage;
+use App\Utils\ExportFormat;
 use Doctrine\DBAL\Exception;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
@@ -30,8 +30,8 @@ readonly class SignalementExporter
      */
     public function write(User $user, string $format, string $outputFilePath, ?array $filters, ?array $selectedColumns = null): void
     {
-        if (ListExportMessage::FORMAT_CSV === $format) {
-            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        if (ExportFormat::FORMAT_CSV === $format) {
+            $writer = new CsvWriter(new CsvOptions(FIELD_DELIMITER: ExportFormat::CSV_SEPARATOR));
         } else {
             $writer = new XlsxWriter();
         }
@@ -59,7 +59,7 @@ readonly class SignalementExporter
 
             $cells = [];
             foreach ($rowArray as $key => $value) {
-                if (ListExportMessage::FORMAT_XLSX === $format && \in_array($key, self::DATE_COLUMNS, true) && !empty($value)) {
+                if (ExportFormat::FORMAT_XLSX === $format && \in_array($key, self::DATE_COLUMNS, true) && !empty($value)) {
                     $dateTime = \DateTimeImmutable::createFromFormat('d/m/Y', $value);
                     if ($dateTime) {
                         $cells[] = Cell::fromValue($dateTime, $dateStyle);

--- a/src/Utils/ExportFormat.php
+++ b/src/Utils/ExportFormat.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Utils;
+
+final class ExportFormat
+{
+    public const FORMAT_CSV = 'csv';
+    public const FORMAT_XLSX = 'xlsx';
+    public const CSV_SEPARATOR = ';';
+}

--- a/tests/Functional/Messenger/MessageHandler/InactiveUserExportMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/InactiveUserExportMessageHandlerTest.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use App\Messenger\Message\InactiveUserExportMessage;
 use App\Messenger\MessageHandler\InactiveUserExportMessageHandler;
 use App\Repository\UserRepository;
+use App\Utils\ExportFormat;
 use Symfony\Bridge\Twig\Mime\NotificationEmail;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -22,7 +23,7 @@ class InactiveUserExportMessageHandlerTest extends WebTestCase
         $userRepository = static::getContainer()->get(UserRepository::class);
         /** @var User $user */
         $user = $userRepository->findOneBy(['email' => $userEmail]);
-        $message = new InactiveUserExportMessage($user->getId(), 'xlsx');
+        $message = new InactiveUserExportMessage($user->getId(), ExportFormat::FORMAT_XLSX);
         $messageBus->dispatch($message);
         $transport = $container->get('messenger.transport.async_priority_high');
         $envelopes = $transport->get();

--- a/tests/Functional/Messenger/MessageHandler/ListExportMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/ListExportMessageHandlerTest.php
@@ -10,6 +10,7 @@ use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Signalement\Export\SignalementExporter;
 use App\Service\UploadHandlerService;
+use App\Utils\ExportFormat;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\NotificationEmail;
@@ -39,7 +40,7 @@ class ListExportMessageHandlerTest extends WebTestCase
         $user = $this->userRepository->findOneBy(['email' => $userEmail]);
         $message = (new ListExportMessage())
             ->setUserId($user->getId())
-            ->setFormat('csv')
+            ->setFormat(ExportFormat::FORMAT_CSV)
             ->setFilters([])
             ->setSelectedColumns([]);
 
@@ -79,7 +80,7 @@ class ListExportMessageHandlerTest extends WebTestCase
         $user = $this->userRepository->findOneBy(['email' => $userEmail]);
         $message = (new ListExportMessage())
             ->setUserId($user->getId())
-            ->setFormat('xlsx')
+            ->setFormat(ExportFormat::FORMAT_XLSX)
             ->setFilters([])
             ->setSelectedColumns(['INSEE']);
 

--- a/tests/Functional/Messenger/MessageHandler/UserExportMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/UserExportMessageHandlerTest.php
@@ -7,6 +7,7 @@ use App\Messenger\Message\UserExportMessage;
 use App\Messenger\MessageHandler\UserExportMessageHandler;
 use App\Repository\UserRepository;
 use App\Service\ListFilters\SearchUser;
+use App\Utils\ExportFormat;
 use Symfony\Bridge\Twig\Mime\NotificationEmail;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -24,7 +25,7 @@ class UserExportMessageHandlerTest extends WebTestCase
         /** @var User $user */
         $user = $userRepository->findOneBy(['email' => $userEmail]);
         $searchUser = new SearchUser($user);
-        $message = new UserExportMessage($searchUser, 'csv');
+        $message = new UserExportMessage($searchUser, ExportFormat::FORMAT_CSV);
         $messageBus->dispatch($message);
         $transport = $container->get('messenger.transport.async_priority_high');
         $envelopes = $transport->get();
@@ -52,7 +53,7 @@ class UserExportMessageHandlerTest extends WebTestCase
         /** @var User $user */
         $user = $userRepository->findOneBy(['email' => $userEmail]);
         $searchUser = new SearchUser($user);
-        $message = new UserExportMessage($searchUser, 'xlsx');
+        $message = new UserExportMessage($searchUser, ExportFormat::FORMAT_XLSX);
         $messageBus->dispatch($message);
         $transport = $container->get('messenger.transport.async_priority_high');
         $envelopes = $transport->get();

--- a/tests/Unit/Service/Signalement/Export/SignalementExporterTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExporterTest.php
@@ -6,8 +6,8 @@ use App\Dto\SignalementExport;
 use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Service\Signalement\Export\SignalementExporter;
-use App\Service\Signalement\Export\SignalementExportHeader;
 use App\Tests\UserHelper;
+use App\Utils\ExportFormat;
 use OpenSpout\Reader\CSV\Options as CsvReaderOptions;
 use OpenSpout\Reader\CSV\Reader as CsvReader;
 use OpenSpout\Reader\XLSX\Reader as XlsxReader;
@@ -50,7 +50,7 @@ class SignalementExporterTest extends TestCase
         $this->assertEquals('Déposé le', $rows[0][1]);
         $this->assertEquals('2023-01', $rows[1][0]);
 
-        if ('xlsx' === $format) {
+        if (ExportFormat::FORMAT_XLSX === $format) {
             $this->assertInstanceOf(\DateTimeInterface::class, $rows[1][1]);
         } else {
             $this->assertEquals('31/03/2023', $rows[1][1]);
@@ -59,8 +59,8 @@ class SignalementExporterTest extends TestCase
 
     public static function provideFileFormat(): \Generator
     {
-        yield 'export with xlsx' => ['xlsx'];
-        yield 'export with csv' => ['csv'];
+        yield 'export with xlsx' => [ExportFormat::FORMAT_XLSX];
+        yield 'export with csv' => [ExportFormat::FORMAT_CSV];
     }
 
     /**
@@ -70,8 +70,8 @@ class SignalementExporterTest extends TestCase
     {
         $rows = [];
 
-        if ('csv' === $format) {
-            $reader = new CsvReader(new CsvReaderOptions(FIELD_DELIMITER: SignalementExportHeader::SEPARATOR));
+        if (ExportFormat::FORMAT_CSV === $format) {
+            $reader = new CsvReader(new CsvReaderOptions(FIELD_DELIMITER: ExportFormat::CSV_SEPARATOR));
         } else {
             $reader = new XlsxReader();
         }


### PR DESCRIPTION
## Ticket

#5804   

## Description
Remplacement de phpspreadsheets par openspout partout, c'est-à-dire : 

- export de l'annuaire
- export de la liste des utilisateurs sur le point d'être archivés
- export des résumés de suivis par Albert
- export de la liste des utilisateurs

## Changements apportés
* Remplacement de la dépendance
* Création d'une classe ExportFormat pour le délimiteur et les 2 formats d'export

## Pré-requis
`make composer`

## Tests
- [ ] C/I OK
- [ ] Tester l'export de l'annuaire dans les 2 formats, vérifier les données obtenues
- [ ] Tester l'export de la liste des utilisateurs sur le point d'être archivés dans les 2 formats, vérifier les données obtenues
- [ ] Tester l'export des résumés de suivis (plus facile sur base de prod), vérifier les données obtenues
- [ ] Tester l'export de la liste des utilisateurs dans les 2 formats, vérifier les données obtenues
