### PR TITLE
[Tech - Type de suivi] Supprimer ou limiter leur utilisation

### DIFF
--- a/src/Command/Cron/AskFeedbackUsagerCommand.php
+++ b/src/Command/Cron/AskFeedbackUsagerCommand.php
@@ -236,6 +236,7 @@ class AskFeedbackUsagerCommand extends AbstractCronCommand
                 signalement: $signalement,
                 description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation.",
                 category: SuiviCategory::ASK_FEEDBACK_SENT,
+                sendMail: false,
                 flush: false
             );
 

--- a/src/Command/Cron/AskFeedbackUsagerCommand.php
+++ b/src/Command/Cron/AskFeedbackUsagerCommand.php
@@ -235,7 +235,6 @@ class AskFeedbackUsagerCommand extends AbstractCronCommand
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation.",
-                type: Suivi::TYPE_TECHNICAL,
                 category: SuiviCategory::ASK_FEEDBACK_SENT,
                 flush: false
             );

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -69,7 +69,6 @@ class NotifyVisitsCommand extends AbstractCronCommand
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $description,
-                type: Suivi::TYPE_TECHNICAL,
                 category: SuiviCategory::INTERVENTION_PLANNED_REMINDER,
                 isVisibleForUsager: true,
                 context: Suivi::CONTEXT_INTERVENTION,
@@ -123,7 +122,6 @@ class NotifyVisitsCommand extends AbstractCronCommand
                 $suivi = $this->suiviManager->createSuivi(
                     signalement: $affectation->getSignalement(),
                     description: $description,
-                    type: Suivi::TYPE_TECHNICAL,
                     category: SuiviCategory::INTERVENTION_IS_REQUIRED,
                     context: Suivi::CONTEXT_INTERVENTION,
                 );

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -70,6 +70,7 @@ class NotifyVisitsCommand extends AbstractCronCommand
                 signalement: $signalement,
                 description: $description,
                 category: SuiviCategory::INTERVENTION_PLANNED_REMINDER,
+                sendMail: false,
                 isVisibleForUsager: true,
                 context: Suivi::CONTEXT_INTERVENTION,
             );
@@ -123,6 +124,7 @@ class NotifyVisitsCommand extends AbstractCronCommand
                     signalement: $affectation->getSignalement(),
                     description: $description,
                     category: SuiviCategory::INTERVENTION_IS_REQUIRED,
+                    sendMail: false,
                     context: Suivi::CONTEXT_INTERVENTION,
                 );
 

--- a/src/Command/Cron/RemindInjonctionSignalementCommand.php
+++ b/src/Command/Cron/RemindInjonctionSignalementCommand.php
@@ -68,7 +68,6 @@ class RemindInjonctionSignalementCommand extends AbstractCronCommand
                 $this->suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $description,
-                    type: Suivi::TYPE_AUTO,
                     category: SuiviCategory::INJONCTION_BAILLEUR_RAPPEL_REPONSE_BAILLEUR,
                 );
             }
@@ -114,7 +113,6 @@ class RemindInjonctionSignalementCommand extends AbstractCronCommand
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_REMINDER_FOR_USAGER,
                 isVisibleForUsager: true
             );

--- a/src/Command/Cron/ResetInjonctionNoResponseCommand.php
+++ b/src/Command/Cron/ResetInjonctionNoResponseCommand.php
@@ -3,7 +3,6 @@
 namespace App\Command\Cron;
 
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Manager\SuiviManager;
 use App\Manager\UserManager;
 use App\Repository\SignalementRepository;
@@ -62,7 +61,6 @@ class ResetInjonctionNoResponseCommand extends AbstractCronCommand
                 $this->suiviManager->createSuivi(
                     signalement: $signalement,
                     description: 'La procédure d’injonction a expiré pour le bailleur. Le signalement est désormais en attente de validation.',
-                    type: Suivi::TYPE_AUTO,
                     category: SuiviCategory::INJONCTION_BAILLEUR_EXPIREE,
                     user: $this->userManager->getSystemUser(),
                     isVisibleForUsager: true

--- a/src/Command/Cron/SynchronizeIdossCommand.php
+++ b/src/Command/Cron/SynchronizeIdossCommand.php
@@ -5,7 +5,6 @@ namespace App\Command\Cron;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\JobEvent;
 use App\Entity\Partner;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Manager\AffectationManager;
 use App\Manager\SuiviManager;
@@ -150,7 +149,6 @@ class SynchronizeIdossCommand extends AbstractCronCommand
                     $suivi = $this->suiviManager->createSuivi(
                         signalement: $signalement,
                         description: $description,
-                        type: Suivi::TYPE_TECHNICAL,
                         category: SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
                         partner: $affectation->getPartner(),
                         user: $this->adminUser,

--- a/src/Command/Cron/SynchronizeIdossCommand.php
+++ b/src/Command/Cron/SynchronizeIdossCommand.php
@@ -150,6 +150,7 @@ class SynchronizeIdossCommand extends AbstractCronCommand
                         signalement: $signalement,
                         description: $description,
                         category: SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
+                        sendMail: false,
                         partner: $affectation->getPartner(),
                         user: $this->adminUser,
                         flush: false

--- a/src/Controller/Api/SuiviCreateController.php
+++ b/src/Controller/Api/SuiviCreateController.php
@@ -7,7 +7,6 @@ use App\Dto\Api\Response\SuiviResponse;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\File;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Manager\SuiviManager;
 use App\Security\Voter\Api\ApiSignalementPartnerVoter;
@@ -154,7 +153,6 @@ class SuiviCreateController extends AbstractController
         $suivi = $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: Sanitizer::sanitize($suiviRequest->getDescription()),
-            type: Suivi::TYPE_PARTNER,
             category: SuiviCategory::MESSAGE_PARTNER,
             partner: $partner,
             user: $user,

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -87,7 +87,6 @@ class SignalementActionController extends AbstractController
         $suiviManager->createSuivi(
             signalement: $signalement,
             description: Suivi::DESCRIPTION_SIGNALEMENT_VALIDE,
-            type : Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
             partner: $partner,
             user : $user,
@@ -127,7 +126,6 @@ class SignalementActionController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: Suivi::DESCRIPTION_SIGNALEMENT_VALIDE,
-                type : Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
                 partner: $partner,
                 user : $user,
@@ -175,7 +173,6 @@ class SignalementActionController extends AbstractController
         $suiviManager->createSuivi(
             signalement: $signalement,
             description: $description,
-            type : Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_IS_REFUSED,
             partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user : $user,
@@ -221,7 +218,6 @@ class SignalementActionController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $suivi->getDescription(),
-                type: Suivi::TYPE_PARTNER,
                 category: SuiviCategory::MESSAGE_PARTNER,
                 partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                 user: $user,
@@ -357,7 +353,6 @@ class SignalementActionController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Signalement rouvert pour '.$reopenFor,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_IS_REOPENED,
                 partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                 user: $user,

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -16,7 +16,6 @@ use App\Dto\Request\Signalement\SituationFoyerRequest;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Enum\TiersInvitationStatus;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Factory\TiersInvitationFactory;
 use App\Manager\SignalementManager;
@@ -706,7 +705,6 @@ class SignalementEditController extends AbstractController
                 $suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $description,
-                    type: Suivi::TYPE_AUTO,
                     category: SuiviCategory::SIGNALEMENT_EDITED_BO,
                     partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                     user: $user,

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -7,7 +7,6 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\File;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Manager\SuiviManager;
 use App\Messenger\Message\PdfExportMessage;
@@ -208,7 +207,6 @@ class SignalementFileController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::DOCUMENT_DELETED_BY_PARTNER,
                 partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                 user: $user,

--- a/src/Controller/SignalementConfirmEditController.php
+++ b/src/Controller/SignalementConfirmEditController.php
@@ -4,7 +4,6 @@ namespace App\Controller;
 
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Manager\SuiviManager;
 use App\Security\Voter\SignalementFoVoter;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
@@ -30,7 +29,6 @@ class SignalementConfirmEditController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $this->renderView('suivi/front_signalement_confirm_edit_email_occupant.html.twig', ['old' => $old, 'new' => $signalement->getMailOccupant()]),
-                type: Suivi::TYPE_USAGER,
                 category: SuiviCategory::SIGNALEMENT_EDITED_FO,
                 isVisibleForUsager: true,
             );

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -619,14 +619,12 @@ class SignalementController extends AbstractController
                 }
             }
 
-            $suiviType = SignalementStatus::CLOSED === $signalement->getStatut() ? Suivi::TYPE_USAGER_POST_CLOTURE : Suivi::TYPE_USAGER;
             $suiviCategory = SignalementStatus::CLOSED === $signalement->getStatut() ?
                 SuiviCategory::MESSAGE_USAGER_POST_CLOTURE :
                 SuiviCategory::MESSAGE_USAGER;
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $description,
-                type: $suiviType,
                 category: $suiviCategory,
                 user: $signalementUser->getUser(),
                 isVisibleForUsager: true,
@@ -705,7 +703,6 @@ class SignalementController extends AbstractController
                         $suiviManager->createSuivi(
                             signalement: $signalement,
                             description: UserManager::OCCUPANT === $signalementUser->getType() ? 'L\'occupant a ajouté '.$descriptionDetails : 'Le déclarant a ajouté '.$descriptionDetails,
-                            type: Suivi::TYPE_USAGER,
                             category: SuiviCategory::MESSAGE_USAGER,
                             user: $signalementUser->getUser(),
                             isVisibleForUsager: true,
@@ -809,7 +806,6 @@ class SignalementController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: HtmlCleaner::cleanFrontEndEntry($description),
-                type: Suivi::TYPE_USAGER,
                 category: $category,
                 user: $user,
                 isVisibleForUsager: true,
@@ -874,7 +870,6 @@ class SignalementController extends AbstractController
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: HtmlCleaner::cleanFrontEndEntry($description),
-                type: Suivi::TYPE_USAGER,
                 category: SuiviCategory::DEMANDE_POURSUITE_PROCEDURE,
                 user: $user,
                 isVisibleForUsager: true,
@@ -929,7 +924,6 @@ class SignalementController extends AbstractController
                 $suiviManager->createSuivi(
                     signalement: $signalement,
                     description: HtmlCleaner::cleanFrontEndEntry($description),
-                    type: Suivi::TYPE_USAGER,
                     category: SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_USAGER,
                     user: $user,
                     isVisibleForUsager: true,
@@ -1026,7 +1020,6 @@ class SignalementController extends AbstractController
                 $suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $description,
-                    type: Suivi::TYPE_USAGER,
                     category: $category,
                     user: $user,
                     isVisibleForUsager: true,
@@ -1098,7 +1091,6 @@ class SignalementController extends AbstractController
         $suiviManager->createSuivi(
             signalement: $signalement,
             description: $description,
-            type: Suivi::TYPE_USAGER,
             category: SuiviCategory::MESSAGE_USAGER,
             user: $user,
             isVisibleForUsager: true,

--- a/src/Controller/SignalementFileController.php
+++ b/src/Controller/SignalementFileController.php
@@ -4,7 +4,6 @@ namespace App\Controller;
 
 use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Manager\SuiviManager;
 use App\Messenger\Message\PdfExportMessage;
 use App\Repository\FileRepository;
@@ -162,7 +161,6 @@ class SignalementFileController extends AbstractController
                 $suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $description,
-                    type: Suivi::TYPE_AUTO,
                     category: SuiviCategory::DOCUMENT_DELETED_BY_USAGER,
                     user: $signalementUser->getUser(),
                 );

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -5,49 +5,42 @@ suivis:
   created_at: "2022-06-08 17:06:33"
   is_public: 1
   signalement: "2022-8"
-  type: 3
   category: "MESSAGE_PARTNER"
 -
   description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation."
   created_at: "2023-04-18 17:06:33"
   is_public: 0
   signalement: "2022-8"
-  type: 4
   category: "ASK_FEEDBACK_SENT"
 -
   description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation."
   created_at: "2023-05-18 17:06:33"
   is_public: 0
   signalement: "2022-8"
-  type: 4
   category: "ASK_FEEDBACK_SENT"
 -
   description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation."
   created_at: "2023-06-18 17:06:33"
   is_public: 0
   signalement: "2022-8"
-  type: 4
   category: "ASK_FEEDBACK_SENT"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
   description: "Le signalement a été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
   is_public: 1
   signalement: "2022-3"
-  type: 1
   category: "SIGNALEMENT_IS_REFUSED"
 -
   created_by: null
   description: "Bonjour, j'ai toujours le problème, quand vais-je avoir une visite ?"
   is_public: 1
   signalement: "2022-4"
-  type: 2
   category: "MESSAGE_USAGER"
 -
   created_by: admin-01@signal-logement.fr
   description: "Un petit message de rappel afin d'y revenir plus tard"
   is_public: 0
   signalement: "2023-6"
-  type: 1
   category: "MESSAGE_PARTNER"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
@@ -55,14 +48,12 @@ suivis:
   created_at: "2023-04-01 17:06:33"
   is_public: 1
   signalement: "2023-13"
-  type: 3
   category: "MESSAGE_PARTNER"
 -
   description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation."
   created_at: "2023-04-18 17:06:33"
   is_public: 0
   signalement: "2023-14"
-  type: 4
   category: "ASK_FEEDBACK_SENT"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
@@ -70,7 +61,6 @@ suivis:
   created_at: "2023-01-10 17:06:33"
   is_public: 1
   signalement: "2023-15"
-  type: 3
   category: "MESSAGE_PARTNER"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
@@ -78,42 +68,36 @@ suivis:
   created_at: "2023-02-10 17:06:33"
   is_public: 1
   signalement: "2023-15"
-  type: 3
   category: "MESSAGE_PARTNER"
 -
   description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation."
   created_at: "2023-03-18 17:06:33"
   is_public: 0
   signalement: "2023-15"
-  type: 4
   category: "ASK_FEEDBACK_SENT"
 -
   description: "Un message automatique a été envoyé à l'usager pour lui demander de mettre à jour sa situation."
   created_at: "2023-04-18 17:06:33"
   is_public: 0
   signalement: "2023-15"
-  type: 4
   category: "ASK_FEEDBACK_SENT"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
   description: "Signalement Refusé"
   is_public: 1
   signalement: "2023-21"
-  type: 1
   category: "SIGNALEMENT_IS_REFUSED"
 -
   created_by: null
   description: "Je ne comprends pas pourquoi mon signalement a été cloturé, j'ai toujours des soucis ! (suivi de type 5 post-cloture)"
   is_public: 1
   signalement: "2022-2"
-  type: 5
   category: "MESSAGE_USAGER_POST_CLOTURE"
 - 
   created_by: api-02@signal-logement.fr
   description: "Nous vous confirmons la prise en charge de votre signalement."
   is_public: 1
   signalement: "2024-12"
-  type: 3
   category: "MESSAGE_PARTNER"
   force_notifications: 1
 - 
@@ -121,7 +105,6 @@ suivis:
   description: "On avance sur le dossier, est-ce que d'autres action sont en cours ?"
   is_public: 0
   signalement: "2024-12"
-  type: 3
   category: "MESSAGE_PARTNER"
   force_notifications: 1
 - 
@@ -129,7 +112,6 @@ suivis:
   description: "Le signalement a été clôturé pour tous les partenaires avec le motif suivant <br /><strong>Refus de visite</strong><br /><strong>Desc. : </strong>bla bla bla<br />"
   is_public: 1
   signalement: "2025-07"
-  type: 3
   context: signalementClosed
   category: "SIGNALEMENT_IS_CLOSED"
 - 
@@ -137,26 +119,22 @@ suivis:
   description: "Un message sur le 2023-15 qui m'abonne avec participation"
   is_public: 0
   signalement: "2023-13"
-  type: 3
   category: "MESSAGE_PARTNER"
 - 
   created_by: null
   description: "Le bailleur s'engage à résoudre les désordres signalés."
   is_public: 1
   signalement: "00000000-0000-0000-2025-000000000012"
-  type: 1
   category: "INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE"
 - 
   created_by: viens@ramontafrez.com
   description: "Je veux faire les travaux, mais je ne sais pas comment m'y prendre."
   is_public: 0
   signalement: "00000000-0000-0000-2025-000000000012"
-  type: 1
   category: "INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE"
 - 
   created_by: admin-partenaire-13-01@signal-logement.fr
   description: "Un suivi pour abonner l'utilisateur."
   is_public: 0
   signalement: "00000000-0000-0000-2023-000000000026"
-  type: 1
   category: "INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE"

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -42,7 +42,6 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: Suivi::DESCRIPTION_SIGNALEMENT_VALIDE,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
                 partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                 user: $user,
@@ -94,7 +93,6 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
         $suivi = $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: $row['description'],
-            type: $row['type'],
             category: $category,
             partner: $createdBy?->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $createdBy,

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -94,6 +94,7 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             signalement: $signalement,
             description: $row['description'],
             category: $category,
+            sendMail: SuiviCategory::ASK_FEEDBACK_SENT !== $category,
             partner: $createdBy?->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $createdBy,
             isVisibleForUsager: $row['is_public'],

--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -3,6 +3,7 @@
 namespace App\Entity\Enum;
 
 use App\Entity\Behaviour\EnumTrait;
+use App\Entity\Suivi;
 
 enum SuiviCategory: string
 {
@@ -188,5 +189,68 @@ enum SuiviCategory: string
             self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES,
             self::INJONCTION_BAILLEUR_REPONSE_NON,
         ];
+    }
+
+    public static function getSuiviTypeForSuiviCategory(SuiviCategory $category): int
+    {
+        switch ($category) {
+            case self::INJONCTION_BAILLEUR_RAPPEL_REPONSE_BAILLEUR:
+            case self::INJONCTION_BAILLEUR_REMINDER_FOR_USAGER:
+            case self::INJONCTION_BAILLEUR_EXPIREE:
+            case self::DOCUMENT_DELETED_BY_USAGER:
+            case self::SIGNALEMENT_IS_ACTIVE:
+            case self::SIGNALEMENT_IS_REFUSED:
+            case self::SIGNALEMENT_IS_REOPENED:
+            case self::SIGNALEMENT_EDITED_BO:
+            case self::NEW_DOCUMENT:
+            case self::DOCUMENT_DELETED_BY_PARTNER:
+            case self::AFFECTATION_IS_REFUSED:
+            case self::AFFECTATION_IS_ACCEPTED:
+            case self::INTERVENTION_IS_ABORTED:
+            case self::INTERVENTION_IS_CANCELED:
+            case self::INTERVENTION_HAS_CONCLUSION:
+            case self::INTERVENTION_IS_DONE:
+            case self::INTERVENTION_IS_CREATED:
+            case self::INTERVENTION_CONTROLE_IS_DONE:
+            case self::INTERVENTION_CONTROLE_IS_CREATED:
+            case self::INTERVENTION_ARRETE_IS_CREATED:
+            case self::INTERVENTION_HAS_CONCLUSION_EDITED:
+            case self::INTERVENTION_IS_RESCHEDULED:
+            case self::INTERVENTION_CONTROLE_IS_RESCHEDULED:
+            case self::INTERVENTION_ARRETE_IS_RESCHEDULED:
+            case self::SIGNALEMENT_IS_INJONCTION:
+            case self::INJONCTION_BAILLEUR_REPONSE_OUI:
+            case self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE:
+            case self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES:
+            case self::INJONCTION_BAILLEUR_REPONSE_NON:
+            case self::INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE:
+            case self::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR:
+            case self::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR_COMMENTAIRE:
+            case self::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR:
+            case self::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR_COMMENTAIRE:
+            case self::ASK_DOCUMENT:
+                return Suivi::TYPE_AUTO;
+            case self::ASK_FEEDBACK_SENT:
+            case self::INTERVENTION_PLANNED_REMINDER:
+            case self::INTERVENTION_IS_REQUIRED:
+            case self::SIGNALEMENT_STATUS_IS_SYNCHRO:
+                return Suivi::TYPE_TECHNICAL;
+            case self::SIGNALEMENT_EDITED_FO:
+            case self::MESSAGE_USAGER:
+            case self::INJONCTION_BAILLEUR_CLOTURE_PAR_USAGER:
+            case self::DEMANDE_ABANDON_PROCEDURE:
+            case self::DEMANDE_POURSUITE_PROCEDURE:
+            case self::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_USAGER:
+                return Suivi::TYPE_USAGER;
+            case self::MESSAGE_USAGER_POST_CLOTURE:
+                return Suivi::TYPE_USAGER_POST_CLOTURE;
+            case self::MESSAGE_PARTNER:
+            case self::AFFECTATION_IS_CLOSED:
+            case self::SIGNALEMENT_IS_CLOSED:
+            case self::MESSAGE_ESABORA_SCHS:
+                return Suivi::TYPE_PARTNER;
+            default:
+                throw new \LogicException(sprintf('La catégorie de suivi %s n\'a pas de type de suivi défini.', $category->name));
+        }
     }
 }

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -55,7 +55,6 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: SuiviManager::buildDescriptionAnswerAffectation($params),
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::AFFECTATION_IS_REFUSED,
                 partner: $event->getPartner(),
                 user: $user,
@@ -67,7 +66,6 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Signalement rouvert pour '.mb_strtoupper($partner->getNom()),
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_IS_REOPENED,
                 partner: $event->getPartner(),
                 user: $user,
@@ -90,7 +88,6 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
             $this->suiviManager->createSuivi(
                 signalement: $affectation->getSignalement(),
                 description: $this->parameterBag->get('suivi_message')['first_accepted_affectation'],
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::AFFECTATION_IS_ACCEPTED,
                 user: $adminUser,
                 isVisibleForUsager: true,

--- a/src/EventSubscriber/AffectationClosedSubscriber.php
+++ b/src/EventSubscriber/AffectationClosedSubscriber.php
@@ -3,7 +3,6 @@
 namespace App\EventSubscriber;
 
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Event\AffectationClosedEvent;
 use App\Manager\SuiviManager;
 use App\Service\Notification\NotificationAndMailSender;
@@ -37,7 +36,6 @@ readonly class AffectationClosedSubscriber implements EventSubscriberInterface
         $suivi = $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: SuiviManager::buildDescriptionClotureSignalement($params),
-            type: Suivi::TYPE_PARTNER,
             category: SuiviCategory::AFFECTATION_IS_CLOSED,
             partner: $event->getPartner(),
             user: $user,

--- a/src/EventSubscriber/InterventionAbortedSubscriber.php
+++ b/src/EventSubscriber/InterventionAbortedSubscriber.php
@@ -46,7 +46,6 @@ class InterventionAbortedSubscriber implements EventSubscriberInterface
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $intervention->getSignalement(),
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INTERVENTION_IS_ABORTED,
                 partner: $context['createdByPartner'],
                 user: $currentUser,

--- a/src/EventSubscriber/InterventionCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionCanceledSubscriber.php
@@ -47,7 +47,6 @@ class InterventionCanceledSubscriber implements EventSubscriberInterface
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $intervention->getSignalement(),
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INTERVENTION_IS_CANCELED,
                 partner: $context['createdByPartner'],
                 user: $currentUser,

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -59,7 +59,6 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $intervention->getSignalement(),
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INTERVENTION_HAS_CONCLUSION,
                 partner: $context['createdByPartner'],
                 user: $currentUser,

--- a/src/EventSubscriber/InterventionCreatedSubscriber.php
+++ b/src/EventSubscriber/InterventionCreatedSubscriber.php
@@ -60,7 +60,6 @@ readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
         $suivi = $this->suiviManager->createSuivi(
             signalement: $intervention->getSignalement(),
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category : $suiviCategory,
             partner: $event->getPartner(),
             user: $event->getUser(),

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -60,7 +60,6 @@ readonly class InterventionEditedSubscriber implements EventSubscriberInterface
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $intervention->getSignalement(),
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INTERVENTION_HAS_CONCLUSION_EDITED,
                 partner: $event->getPartner(),
                 user: $currentUser,

--- a/src/EventSubscriber/InterventionRescheduledSubscriber.php
+++ b/src/EventSubscriber/InterventionRescheduledSubscriber.php
@@ -48,7 +48,6 @@ class InterventionRescheduledSubscriber implements EventSubscriberInterface
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $intervention->getSignalement(),
                 description: $description,
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INTERVENTION_IS_RESCHEDULED,
                 partner: $event->getPartner(),
                 user: $event->getUser(),

--- a/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
+++ b/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
@@ -50,7 +50,6 @@ readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriber
         $suivi = $this->suiviManager->createSuivi(
             signalement: $intervention->getSignalement(),
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category: $suiviCategory,
             partner: $event->getPartner(),
             user: $event->getUser(),

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -42,7 +42,6 @@ readonly class SignalementClosedSubscriber implements EventSubscriberInterface
                     'motif_suivi' => $signalementAffectationClose->getDescription(),
                 ]
             ),
-            type: Suivi::TYPE_PARTNER,
             category: SuiviCategory::SIGNALEMENT_IS_CLOSED,
             partner: $event->getPartner(),
             user: $user,

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -7,7 +7,6 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
-use App\Entity\Suivi;
 use App\Event\SignalementDraftCompletedEvent;
 use App\Manager\SuiviManager;
 use App\Messenger\Message\NewSignalementCheckFileMessage;
@@ -115,7 +114,6 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Dossier déposé dans le cadre de la démarche accélérée',
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_IS_INJONCTION,
                 user: $this->userRepository->findOneBy(['email' => $this->parameterBag->get('user_system_email')])
             );

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -29,7 +29,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
     {
         $suivi = $event->getSuivi();
 
-        if (Suivi::TYPE_TECHNICAL === $suivi->getType() || !$suivi->getSendMail()) {
+        if (!$suivi->getSendMail()) {
             return;
         }
         if (Suivi::CONTEXT_INTERVENTION === $suivi->getContext()) {

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -29,7 +29,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
     {
         $suivi = $event->getSuivi();
 
-        if (Suivi::TYPE_TECHNICAL === $suivi->getType()) {
+        if (Suivi::TYPE_TECHNICAL === $suivi->getType() || !$suivi->getSendMail()) {
             return;
         }
         if (Suivi::CONTEXT_INTERVENTION === $suivi->getContext()) {
@@ -70,7 +70,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
     private function sendToUsagers(Suivi $suivi): void
     {
-        if ($suivi->getSendMail() && $suivi->getIsVisibleForUsager()) {
+        if ($suivi->getIsVisibleForUsager()) {
             if (SuiviCategory::DEMANDE_ABANDON_PROCEDURE === $suivi->getCategory()) {
                 $this->notificationAndMailSender->sendDemandeAbandonProcedureToUsager($suivi);
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -988,7 +988,6 @@ class SignalementManager
         $suivi = $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: 'Signalement validé',
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
             partner: $partner,
             user: $adminUser,

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -51,7 +51,6 @@ class SuiviManager
     public function createSuivi(
         Signalement $signalement,
         string $description,
-        int $type,
         SuiviCategory $category,
         ?Partner $partner = null,
         ?User $user = null,
@@ -74,7 +73,7 @@ class SuiviManager
             ->setPartner($partner)
             ->setSignalement($signalement)
             ->setDescription($this->htmlSanitizer->sanitize($description))
-            ->setType($type)
+            ->setType(SuiviCategory::getSuiviTypeForSuiviCategory($category))
             ->setIsVisibleForUsager($isVisibleForUsager)
             ->setIsVisibleForBailleur($isVisibleForBailleur)
             ->setContext($context)
@@ -152,7 +151,6 @@ class SuiviManager
             $this->createSuivi(
                 signalement: $signalement,
                 description: $description.$user->getNomComplet(),
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_EDITED_BO,
                 partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                 user: $user,
@@ -181,7 +179,6 @@ class SuiviManager
         $this->createSuivi(
             signalement: $signalement,
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_EDITED_BO,
             partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $user,
@@ -205,7 +202,6 @@ class SuiviManager
         $this->createSuivi(
             signalement: $tiersInvitation->getSignalement(),
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_EDITED_FO,
             user: $this->userManager->getSystemUser(),
         );
@@ -224,7 +220,6 @@ class SuiviManager
         $this->createSuivi(
             signalement: $signalement,
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_EDITED_FO,
             user: $this->userManager->getSystemUser(),
             isVisibleForUsager: true,
@@ -244,7 +239,6 @@ class SuiviManager
         $this->createSuivi(
             signalement: $signalement,
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_EDITED_FO,
             user: $this->userManager->getSystemUser(),
             isVisibleForUsager: true,
@@ -343,7 +337,6 @@ class SuiviManager
         return $this->createSuivi(
             signalement: $signalement,
             description: $description,
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::NEW_DOCUMENT,
             partner: $partner,
             user: $user,
@@ -431,7 +424,6 @@ class SuiviManager
         $this->createSuivi(
             signalement: $signalement,
             description: $description,
-            type: Suivi::TYPE_USAGER,
             category: SuiviCategory::SIGNALEMENT_EDITED_FO,
             user: $user,
             isVisibleForUsager: true,

--- a/src/Messenger/MessageHandler/NewSignalementCheckFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/NewSignalementCheckFileMessageHandler.php
@@ -227,7 +227,6 @@ class NewSignalementCheckFileMessageHandler
         return $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: $this->description,
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::ASK_DOCUMENT,
             user: $userAdmin,
             isVisibleForUsager: true,

--- a/src/Repository/Query/Dashboard/DossiersAvecRelanceSansReponseQuery.php
+++ b/src/Repository/Query/Dashboard/DossiersAvecRelanceSansReponseQuery.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository\Query\Dashboard;
 
+use App\Entity\Suivi;
 use App\Entity\User;
 use App\Service\DashboardTabPanel\TabDossier;
 use App\Service\DashboardTabPanel\TabQueryParameters;
@@ -26,6 +27,7 @@ class DossiersAvecRelanceSansReponseQuery
             $clauseTerritoriesSi3 = ' AND si3.territory_id IN (:territories_ids) ';
             $clauseTerritoriesSi = ' AND si.territory_id IN (:territories_ids) ';
         }
+        $suiviTypeUsager = Suivi::TYPE_USAGER;
 
         return <<<SQL
             FROM (
@@ -66,7 +68,7 @@ class DossiersAvecRelanceSansReponseQuery
                     SELECT 1
                     FROM suivi s2
                     WHERE s2.signalement_id = relances_usager.signalement_id
-                      AND s2.type = 2
+                      AND s2.type = $suiviTypeUsager 
                       AND s2.created_at > relances_usager.first_relance_at
                 )
                 $clauseTerritoriesSi

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -376,7 +376,6 @@ class SignalementImportLoader
                     $suivi = $this->suiviManager->createSuivi(
                         signalement: $signalement,
                         description: $description,
-                        type: Suivi::TYPE_PARTNER,
                         category: SuiviCategory::MESSAGE_PARTNER,
                         user: $this->userSystem,
                     );

--- a/src/Service/InjonctionBailleur/InjonctionBailleurService.php
+++ b/src/Service/InjonctionBailleur/InjonctionBailleurService.php
@@ -10,7 +10,6 @@ use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Manager\AffectationManager;
 use App\Manager\FileManager;
 use App\Manager\SignalementManager;
@@ -57,7 +56,6 @@ class InjonctionBailleurService
                 $this->suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $contenu,
-                    type: Suivi::TYPE_AUTO,
                     category: $category,
                     isVisibleForUsager: true
                 );
@@ -72,7 +70,6 @@ class InjonctionBailleurService
                 $this->suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $contenu,
-                    type: Suivi::TYPE_AUTO,
                     category: $category,
                     isVisibleForUsager: true
                 );
@@ -86,7 +83,6 @@ class InjonctionBailleurService
                 $this->suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $contenu,
-                    type: Suivi::TYPE_AUTO,
                     category: $category,
                     isVisibleForUsager: true
                 );
@@ -99,7 +95,6 @@ class InjonctionBailleurService
                 $this->suiviManager->createSuivi(
                     signalement: $signalement,
                     description: $contenu,
-                    type: Suivi::TYPE_AUTO,
                     category: $category,
                     isVisibleForUsager: true
                 );
@@ -129,7 +124,6 @@ class InjonctionBailleurService
         $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: HtmlCleaner::cleanFrontEndEntry($description),
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE,
         );
     }
@@ -166,7 +160,6 @@ class InjonctionBailleurService
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Le bailleur souhaite arrêter la procédure d\'injonction, le signalement va être pris en charge par les partenaires compétents.',
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR,
                 isVisibleForUsager: true
             );
@@ -174,7 +167,6 @@ class InjonctionBailleurService
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: HtmlCleaner::cleanFrontEndEntry($description),
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR_COMMENTAIRE,
             );
 
@@ -185,7 +177,6 @@ class InjonctionBailleurService
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Votre bailleur souhaite terminer la démarche pour le motif suivant : les travaux ont été réalisés. Veuillez confirmer sur la page d\'accueil de votre dossier.',
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR,
                 isVisibleForUsager: true
             );
@@ -193,7 +184,6 @@ class InjonctionBailleurService
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: HtmlCleaner::cleanFrontEndEntry($description),
-                type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR_COMMENTAIRE,
             );
             $this->entityManager->flush();

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -88,7 +88,7 @@ class EsaboraManager
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Signalement <b>'.$description.'</b>',
-                type: EsaboraStatus::ESABORA_WAIT->value === $dossierResponse->getSasEtat() ? Suivi::TYPE_TECHNICAL : Suivi::TYPE_AUTO,
+                sendMail: EsaboraStatus::ESABORA_WAIT->value === $dossierResponse->getSasEtat() ? false : true,
                 category: SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
                 partner: $affectation->getPartner(),
                 user: $this->adminUser,
@@ -337,7 +337,6 @@ class EsaboraManager
         $suivi = $this->suiviManager->createSuivi(
             signalement: $affectation->getSignalement(),
             description: $description,
-            type: Suivi::TYPE_PARTNER,
             category: SuiviCategory::MESSAGE_ESABORA_SCHS,
             partner: $affectation->getPartner(),
             user: $this->adminUser,

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -824,7 +824,6 @@ class SignalementControllerTest extends WebTestCase
         $suivi = $suiviManager->createSuivi(
             signalement: $signalement,
             description: 'Votre bailleur souhaite terminer la démarche pour le motif suivant : les travaux ont été réalisés. Veuillez confirmer sur la page d\'accueil de votre dossier.',
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR,
             isVisibleForUsager: true,
             flush: true
@@ -901,7 +900,6 @@ class SignalementControllerTest extends WebTestCase
         $suivi = $suiviManager->createSuivi(
             signalement: $signalement,
             description: 'Votre bailleur souhaite terminer la démarche pour le motif suivant : les travaux ont été réalisés. Veuillez confirmer sur la page d\'accueil de votre dossier.',
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR,
             isVisibleForUsager: true,
             flush: true
@@ -969,7 +967,6 @@ class SignalementControllerTest extends WebTestCase
         $suivi = $suiviManager->createSuivi(
             signalement: $signalement,
             description: 'Votre bailleur souhaite terminer la démarche pour le motif suivant : les travaux ont été réalisés. Veuillez confirmer sur la page d\'accueil de votre dossier.',
-            type: Suivi::TYPE_AUTO,
             category: SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR,
             isVisibleForUsager: true,
             flush: true

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -176,7 +176,7 @@ class EsaboraManagerTest extends KernelTestCase
             'etat_importe.json',
             'accepté par Partenaire 13-01 via Esabora',
             AffectationStatus::ACCEPTED,
-            Suivi::TYPE_AUTO,
+            Suivi::TYPE_TECHNICAL,
             true, // suivi mail sent
             SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
         ];
@@ -186,7 +186,7 @@ class EsaboraManagerTest extends KernelTestCase
             'etat_termine.json',
             'clôturé par Partenaire 13-02 via Esabora',
             AffectationStatus::CLOSED,
-            Suivi::TYPE_AUTO,
+            Suivi::TYPE_TECHNICAL,
             true, // suivi mail sent
             SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
         ];
@@ -196,7 +196,7 @@ class EsaboraManagerTest extends KernelTestCase
             'etat_non_importe.json',
             'refusé par Partenaire 01-01 via Esabora',
             AffectationStatus::REFUSED,
-            Suivi::TYPE_AUTO,
+            Suivi::TYPE_TECHNICAL,
             false, // suivi mail not sent cause signalement closed
             SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
         ];
@@ -206,7 +206,7 @@ class EsaboraManagerTest extends KernelTestCase
             '../../sish/ws_etat_dossier_sas/etat_rejete.json',
             'refusé via '.EsaboraSISHService::NAME_SI.' pour motif suivant :',
             AffectationStatus::REFUSED,
-            Suivi::TYPE_AUTO,
+            Suivi::TYPE_TECHNICAL,
             false, // suivi mail not sent cause signalement closed
             SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
         ];
@@ -216,7 +216,7 @@ class EsaboraManagerTest extends KernelTestCase
             '../../sish/ws_etat_dossier_sas/etat_importe.json',
             'accepté par Partenaire 01-01 via '.EsaboraSISHService::NAME_SI.' (Dossier 2023/SISH/0010)',
             AffectationStatus::ACCEPTED,
-            Suivi::TYPE_AUTO,
+            Suivi::TYPE_TECHNICAL,
             false, // suivi mail not sent cause signalement closed
             SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
         ];
@@ -228,7 +228,7 @@ class EsaboraManagerTest extends KernelTestCase
         $filename = '../../sish/ws_etat_dossier_sas/etat_importe.json';
         $suiviDescription = 'accepté par Partenaire 01-01 via '.EsaboraSISHService::NAME_SI.' (Dossier 2023/SISH/0010)';
         $expectedAffectationStatus = AffectationStatus::ACCEPTED;
-        $suiviStatus = Suivi::TYPE_AUTO;
+        $suiviStatus = Suivi::TYPE_TECHNICAL;
         /** @var Signalement $signalement */
         $signalement = $this->entityManager->getRepository(Signalement::class)->findOneBy([
             'reference' => $referenceSignalement,

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -80,7 +80,6 @@ class SuiviManagerTest extends KernelTestCase
         $suivi = $this->suiviManager->createSuivi(
             signalement : $signalement,
             description : SuiviManager::buildDescriptionClotureSignalement($params),
-            type : Suivi::TYPE_PARTNER,
             category: SuiviCategory::SIGNALEMENT_IS_CLOSED,
             partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $user,
@@ -112,7 +111,6 @@ class SuiviManagerTest extends KernelTestCase
         $suivi = $this->suiviManager->createSuivi(
             signalement : $signalement,
             description : $desc,
-            type : Suivi::TYPE_USAGER,
             category: SuiviCategory::MESSAGE_USAGER,
         );
         $this->assertEquals($descSanitized, $suivi->getDescription());
@@ -127,7 +125,6 @@ class SuiviManagerTest extends KernelTestCase
         $suivi = $this->suiviManager->createSuivi(
             signalement : $signalement,
             description : 'prise en charge du signalement',
-            type : Suivi::TYPE_PARTNER,
             category: SuiviCategory::MESSAGE_PARTNER,
             partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user : $user,
@@ -162,7 +159,6 @@ class SuiviManagerTest extends KernelTestCase
         $suivi = $this->suiviManager->createSuivi(
             signalement : $signalement,
             description : SuiviManager::buildDescriptionClotureSignalement($params),
-            type : Suivi::TYPE_PARTNER,
             category: SuiviCategory::SIGNALEMENT_IS_CLOSED,
             partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $user,

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -189,7 +189,7 @@ class SignalementRepositoryTest extends KernelTestCase
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
 
         $signalements = $signalementRepository->findSignalementsLastSuiviByPartnerOlderThan($territory, 10, 0);
-        $this->assertCount(1, $signalements);
+        $this->assertCount(2, $signalements);
     }
 
     public function testfindOnSameAddress(): void

--- a/tests/Unit/Service/InjonctionBailleur/InjonctionBailleurServiceTest.php
+++ b/tests/Unit/Service/InjonctionBailleur/InjonctionBailleurServiceTest.php
@@ -96,13 +96,11 @@ class InjonctionBailleurServiceTest extends KernelTestCase
                 if (0 === $callIndex) {
                     $this->assertInstanceOf(Signalement::class, $args[0]);
                     $this->assertStringContainsString('arrêter la procédure d\'injonction', $args[1]);
-                    $this->assertSame(Suivi::TYPE_AUTO, $args[2]);
-                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR, $args[3]);
+                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR, $args[2]);
                 } elseif (1 === $callIndex) {
                     $this->assertInstanceOf(Signalement::class, $args[0]);
                     $this->assertSame('Le bailleur souhaite repasser en procédure classique.', $args[1]);
-                    $this->assertSame(Suivi::TYPE_AUTO, $args[2]);
-                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR_COMMENTAIRE, $args[3]);
+                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR_COMMENTAIRE, $args[2]);
                 }
                 ++$callIndex;
 
@@ -138,13 +136,11 @@ class InjonctionBailleurServiceTest extends KernelTestCase
                 if (0 === $callIndex) {
                     $this->assertInstanceOf(Signalement::class, $args[0]);
                     $this->assertStringContainsString('Votre bailleur souhaite terminer la démarche pour le motif suivant : les travaux ont été réalisés', $args[1]);
-                    $this->assertSame(Suivi::TYPE_AUTO, $args[2]);
-                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR, $args[3]);
+                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR, $args[2]);
                 } elseif (1 === $callIndex) {
                     $this->assertInstanceOf(Signalement::class, $args[0]);
                     $this->assertSame('Travaux faits.', $args[1]);
-                    $this->assertSame(Suivi::TYPE_AUTO, $args[2]);
-                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR_COMMENTAIRE, $args[3]);
+                    $this->assertSame(SuiviCategory::INJONCTION_BAILLEUR_DEMANDE_CLOTURE_PAR_BAILLEUR_COMMENTAIRE, $args[2]);
                 }
                 ++$callIndex;
 


### PR DESCRIPTION
## Ticket

#5825

## Description
Limitation de l'utilisation des type de suivi : 
- Suppression du paramètre `type` dans la méthode `createSuivi ` du `suiviManager`
- Le type est à présent calculé en fonction de la `category` via la méthode `getSuiviTypeForSuiviCategory`
- Le `TYPE_TECHNICAL` correspondait coté métier a une non notification par mail, j'ai remplacé par un explicite `sendMail:false` (qui existait déjà mais n'était pas utilisé)

Suite à cela la suppression complète des type de suivi est envisageable.

## Pré-requis
`make load-fixtures`

## Tests
- [ ] CI OK
- [ ] Faire quelque actions générant des suivi et vérifier leur cohérence
