### PR TITLE
[QA] Correction de conversion array to string pour renvoi de mail

### DIFF
--- a/src/Command/Cron/RetryFailedEmailsCommand.php
+++ b/src/Command/Cron/RetryFailedEmailsCommand.php
@@ -38,6 +38,38 @@ class RetryFailedEmailsCommand extends AbstractCronCommand
         parent::__construct($this->parameterBag);
     }
 
+    /**
+     * Normalizes the context by converting serialized DateTime arrays back to DateTime objects.
+     *
+     * @param array<mixed> $context
+     *
+     * @return array<mixed>
+     */
+    private function normalizeContext(array $context): array
+    {
+        foreach ($context as $key => $value) {
+            if (\is_array($value)) {
+                // Check if this is a serialized DateTime
+                if (isset($value['date'], $value['timezone'])
+                    && \is_string($value['date'])
+                    && \is_string($value['timezone'])
+                ) {
+                    try {
+                        $context[$key] = new \DateTime($value['date'], new \DateTimeZone($value['timezone']));
+                    } catch (\Exception) {
+                        // If conversion fails, recurse into the array
+                        $context[$key] = $this->normalizeContext($value);
+                    }
+                } else {
+                    // Recurse into nested arrays
+                    $context[$key] = $this->normalizeContext($value);
+                }
+            }
+        }
+
+        return $context;
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
@@ -48,9 +80,11 @@ class RetryFailedEmailsCommand extends AbstractCronCommand
         $failedEmails = $this->failedEmailRepository->findEmailToResend();
 
         foreach ($failedEmails as $failedEmail) {
+            $context = $this->normalizeContext($failedEmail->getContext());
+
             $emailMessage = (new TemplatedEmail())
                 ->htmlTemplate('emails/'.$failedEmail->getContext()['template'].'.html.twig')
-                ->context($failedEmail->getContext())
+                ->context($context)
                 ->replyTo($failedEmail->getReplyTo())
                 ->subject($failedEmail->getSubject())
                 ->from(

--- a/src/Command/Cron/RetryFailedEmailsCommand.php
+++ b/src/Command/Cron/RetryFailedEmailsCommand.php
@@ -4,6 +4,7 @@ namespace App\Command\Cron;
 
 use App\Entity\FailedEmail;
 use App\Repository\FailedEmailRepository;
+use App\Service\Mailer\ContextDateTimeNormalizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -34,40 +35,9 @@ class RetryFailedEmailsCommand extends AbstractCronCommand
         private readonly FailedEmailRepository $failedEmailRepository,
         private readonly MailerInterface $mailer,
         private readonly ParameterBagInterface $parameterBag,
+        private readonly ContextDateTimeNormalizer $contextDateTimeNormalizer,
     ) {
         parent::__construct($this->parameterBag);
-    }
-
-    /**
-     * Normalizes the context by converting serialized DateTime arrays back to DateTime objects.
-     *
-     * @param array<mixed> $context
-     *
-     * @return array<mixed>
-     */
-    private function normalizeContext(array $context): array
-    {
-        foreach ($context as $key => $value) {
-            if (\is_array($value)) {
-                // Check if this is a serialized DateTime
-                if (isset($value['date'], $value['timezone'])
-                    && \is_string($value['date'])
-                    && \is_string($value['timezone'])
-                ) {
-                    try {
-                        $context[$key] = new \DateTime($value['date'], new \DateTimeZone($value['timezone']));
-                    } catch (\Exception) {
-                        // If conversion fails, recurse into the array
-                        $context[$key] = $this->normalizeContext($value);
-                    }
-                } else {
-                    // Recurse into nested arrays
-                    $context[$key] = $this->normalizeContext($value);
-                }
-            }
-        }
-
-        return $context;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -80,7 +50,7 @@ class RetryFailedEmailsCommand extends AbstractCronCommand
         $failedEmails = $this->failedEmailRepository->findEmailToResend();
 
         foreach ($failedEmails as $failedEmail) {
-            $context = $this->normalizeContext($failedEmail->getContext());
+            $context = $this->contextDateTimeNormalizer->normalize($failedEmail->getContext());
 
             $emailMessage = (new TemplatedEmail())
                 ->htmlTemplate('emails/'.$failedEmail->getContext()['template'].'.html.twig')

--- a/src/Service/Mailer/ContextDateTimeNormalizer.php
+++ b/src/Service/Mailer/ContextDateTimeNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Service\Mailer;
+
+/**
+ * Service to normalize context arrays by converting serialized DateTime arrays back to DateTime objects.
+ *
+ * When DateTime objects are stored in JSON (e.g., in database), they are serialized as arrays with keys:
+ * - date: the datetime string
+ * - timezone: the timezone string
+ * - timezone_type: the timezone type (usually 3)
+ *
+ * This service recursively traverses context arrays and converts these serialized DateTime arrays
+ * back into proper DateTime objects.
+ */
+class ContextDateTimeNormalizer
+{
+    /**
+     * Normalizes a context array by converting serialized DateTime arrays back to DateTime objects.
+     *
+     * @param array<mixed> $context
+     *
+     * @return array<mixed>
+     */
+    public function normalize(array $context): array
+    {
+        foreach ($context as $key => $value) {
+            if (\is_array($value)) {
+                // Check if this is a serialized DateTime
+                if ($this->isSerializedDateTime($value)) {
+                    try {
+                        $context[$key] = new \DateTime($value['date'], new \DateTimeZone($value['timezone']));
+                    } catch (\Exception) {
+                        // If conversion fails, recurse into the array
+                        $context[$key] = $this->normalize($value);
+                    }
+                } else {
+                    // Recurse into nested arrays
+                    $context[$key] = $this->normalize($value);
+                }
+            }
+        }
+
+        return $context;
+    }
+
+    /**
+     * Checks if an array represents a serialized DateTime object.
+     */
+    private function isSerializedDateTime(array $value): bool
+    {
+        return isset($value['date'], $value['timezone'])
+            && \is_string($value['date'])
+            && \is_string($value['timezone']);
+    }
+}

--- a/tests/Unit/Service/Mailer/ContextDateTimeNormalizerTest.php
+++ b/tests/Unit/Service/Mailer/ContextDateTimeNormalizerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Tests\Unit\Service\Mailer;
+
+use App\Service\Mailer\ContextDateTimeNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class ContextDateTimeNormalizerTest extends TestCase
+{
+    private ContextDateTimeNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ContextDateTimeNormalizer();
+    }
+
+    public function testNormalizeSimpleDateTime(): void
+    {
+        $context = [
+            'date' => [
+                'date' => '2026-05-19 12:00:00.000000',
+                'timezone' => 'UTC',
+                'timezone_type' => 3,
+            ],
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertInstanceOf(\DateTime::class, $result['date']);
+        $this->assertEquals('2026-05-19 12:00:00', $result['date']->format('Y-m-d H:i:s'));
+        $this->assertEquals('UTC', $result['date']->getTimezone()->getName());
+    }
+
+    public function testNormalizeNestedDateTime(): void
+    {
+        $context = [
+            'params' => [
+                'date' => [
+                    'date' => '2026-05-19 12:00:00.000000',
+                    'timezone' => 'Europe/Paris',
+                    'timezone_type' => 3,
+                ],
+                'name' => 'Test Event',
+            ],
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertIsArray($result['params']);
+        $this->assertInstanceOf(\DateTime::class, $result['params']['date']);
+        $this->assertEquals('2026-05-19 12:00:00', $result['params']['date']->format('Y-m-d H:i:s'));
+        $this->assertEquals('Europe/Paris', $result['params']['date']->getTimezone()->getName());
+        $this->assertEquals('Test Event', $result['params']['name']);
+    }
+
+    public function testNormalizeMultipleDateTimes(): void
+    {
+        $context = [
+            'date' => [
+                'date' => '2026-05-19 12:00:00.000000',
+                'timezone' => 'UTC',
+                'timezone_type' => 3,
+            ],
+            'params' => [
+                'date' => [
+                    'date' => '2026-05-20 14:30:00.000000',
+                    'timezone' => 'Europe/Paris',
+                    'timezone_type' => 3,
+                ],
+            ],
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertInstanceOf(\DateTime::class, $result['date']);
+        $this->assertEquals('2026-05-19 12:00:00', $result['date']->format('Y-m-d H:i:s'));
+
+        $this->assertInstanceOf(\DateTime::class, $result['params']['date']);
+        $this->assertEquals('2026-05-20 14:30:00', $result['params']['date']->format('Y-m-d H:i:s'));
+    }
+
+    public function testNormalizeWithNonDateTimeArrays(): void
+    {
+        $context = [
+            'name' => 'Test Event',
+            'url' => 'https://example.com',
+            'tags' => ['tag1', 'tag2'],
+            'metadata' => [
+                'type' => 'club_event',
+                'priority' => 'high',
+            ],
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertEquals($context, $result);
+    }
+
+    public function testNormalizeMixedContext(): void
+    {
+        $context = [
+            'name' => 'Club Event',
+            'date' => [
+                'date' => '2026-05-19 12:00:00.000000',
+                'timezone' => 'UTC',
+                'timezone_type' => 3,
+            ],
+            'url' => 'https://example.com',
+            'params' => [
+                'timezone' => 'Europe/Paris',
+                'date' => [
+                    'date' => '2026-05-19 12:00:00.000000',
+                    'timezone' => 'UTC',
+                    'timezone_type' => 3,
+                ],
+            ],
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertEquals('Club Event', $result['name']);
+        $this->assertEquals('https://example.com', $result['url']);
+        $this->assertInstanceOf(\DateTime::class, $result['date']);
+        $this->assertInstanceOf(\DateTime::class, $result['params']['date']);
+        $this->assertEquals('Europe/Paris', $result['params']['timezone']);
+    }
+
+    public function testNormalizeEmptyArray(): void
+    {
+        $context = [];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testNormalizeInvalidDateTime(): void
+    {
+        $context = [
+            'date' => [
+                'date' => 'invalid-date-format',
+                'timezone' => 'Invalid/Timezone',
+                'timezone_type' => 3,
+            ],
+            'name' => 'Test',
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        // Should keep the original array structure if conversion fails
+        $this->assertIsArray($result['date']);
+        $this->assertEquals('Test', $result['name']);
+    }
+
+    public function testNormalizeRealClubEventContext(): void
+    {
+        // Real-world example from the failed_email table
+        $context = [
+            'raw' => false,
+            'url' => 'https://app.livestorm.co/mte/club-partenaires-communes',
+            'date' => [
+                'date' => '2026-05-19 12:00:00.000000',
+                'timezone' => 'UTC',
+                'timezone_type' => 3,
+            ],
+            'name' => 'Club Partenaires - Communes/SCHS/EPCI/CCAS',
+            'params' => [
+                'url' => 'https://app.livestorm.co/mte/club-partenaires-communes',
+                'date' => [
+                    'date' => '2026-05-19 12:00:00.000000',
+                    'timezone' => 'UTC',
+                    'timezone_type' => 3,
+                ],
+                'name' => 'Club Partenaires - Communes/SCHS/EPCI/CCAS',
+                'timezone' => 'Europe/Paris',
+            ],
+            'template' => 'club_event_email',
+            'timezone' => 'Europe/Paris',
+            'tagHeader' => 'Pro Club Event',
+        ];
+
+        $result = $this->normalizer->normalize($context);
+
+        $this->assertInstanceOf(\DateTime::class, $result['date']);
+        $this->assertInstanceOf(\DateTime::class, $result['params']['date']);
+        $this->assertEquals('Club Partenaires - Communes/SCHS/EPCI/CCAS', $result['name']);
+        $this->assertEquals('Europe/Paris', $result['timezone']);
+        $this->assertEquals('club_event_email', $result['template']);
+    }
+}


### PR DESCRIPTION
## Ticket

#5852   

## Description
Quand on a un échec d'envoi de mail pour un événement de club, il y a une date enregistrée au format date.
Elle était mal interprétée lors du renvoi dans la commande.

## Changements apportés
* Création d'un normalizer pour prendre en compte le format date correctement

## Pré-requis
Insérer le failed_email problématique (que j'ai anonymisé)

```
INSERT INTO failed_email (id, type, to_email, from_email, from_fullname, reply_to, subject, context, notify_usager, error_message, created_at, is_resend_successful, retry_count, last_attempt_at, is_recipient_visible)
VALUES (
    2353,
    'TYPE_CLUB_EVENT',
    '["coucou@test.fr"]',
    'notifications@signal-logement.beta.gouv.fr',
    'SIGNAL-LOGEMENT - ALERTE',
    'ne-pas-repondre@signal-logement.beta.gouv.fr',
    'SIGNAL-LOGEMENT ALERTE - Evènement à venir Club Partenaires - Communes/SCHS/EPCI/CCAS',
    '{"raw": false, "url": "https://app.livestorm.co", "date": {"date": "2026-05-19 12:00:00.000000", "timezone": "UTC", "timezone_type": 3}, "name": "Club Partenaires - Communes/SCHS/EPCI/CCAS", "params": {"url": "https://app.livestorm.co", "date": {"date": "2026-05-19 12:00:00.000000", "timezone": "UTC", "timezone_type": 3}, "name": "Club Partenaires - Communes/SCHS/EPCI/CCAS", "timezone": "Europe/Paris"}, "btntext": null, "content": "", "subject": "Evènement à venir Club Partenaires - Communes/SCHS/EPCI/CCAS", "markdown": false, "template": "club_event_email", "timezone": "Europe/Paris", "exception": false, "tagHeader": "Pro Club Event", "action_url": null, "importance": null, "action_text": null, "footer_text": null, "template_id": null}',
    0,
    'An exception has been thrown during the rendering of a template ("DateTime::__construct(): Argument #1 ($datetime) must be of type string, array given") in "emails/club_event_email.html.twig" at line 6.',
    '2026-05-12 05:51:22',
    0,
    5,
    '2026-05-12 10:30:11',
    1
);
```

## Tests
- [ ] Si besoin, vérifier l'échec d'envoi sans la correction `make console app="retry-failed-emails"`
- [ ] Vérifier qu'il s'envoie bien avec la commande `make console app="retry-failed-emails"`
