### PR TITLE
[FO -Signalement] Enlever le blocage sur le parcours Parc public si bailleur pas prévenu ou prévenu trop récemment

### DIFF
--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -277,8 +277,20 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est recommandé de prévenir votre bailleur. Vous pourrez le faire grâce au modèle de courrier que nous vous enverrons par e-mail dès la fin de votre signalement.",
+          "label": "Avant de déposer un signalement, il est recommandé de prévenir votre bailleur. Vous pourrez le faire grâce au modèle de courrier que nous vous enverrons par e-mail dès la fin de votre signalement ou que vous pouvez télécharger en cliquant sur le bouton ci-dessous.",
           "slug": "info_procedure_bailleur_prevenu_info_non",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "Télécharger le courrier",
+          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
+          "customCss": "fr-btn",
+          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
+          "linktarget": "_blank",
+          "slug": "info_procedure_bailleur_prevenu_info_link",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -437,7 +437,18 @@
         {
           "type": "SignalementFormInfo",
           "label": "Il est fortement recommandé de laisser à votre bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
-          "slug": "prevenir_bailleur_info_text"
+          "slug": "prevenir_bailleur_info_oui_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormInfo",
+          "label": "il est fortement recommandé de contacter votre bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_non_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -280,15 +280,7 @@
           "label": "Avant de déposer un signalement, il est recommandé de prévenir votre bailleur. Vous pourrez le faire grâce au modèle de courrier que nous vous enverrons par e-mail dès la fin de votre signalement.",
           "slug": "info_procedure_bailleur_prevenu_info_non",
           "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non' && formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est obligatoire pour les locataires du parc social de prévenir le bailleur. Vous pourrez le faire grâce au modèle de courrier que vous pourrez télécharger à la page suivante ou en le sollicitant par les canaux de communication habituels.",
-          "slug": "info_procedure_bailleur_prevenu_info_oui",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non' && formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -383,7 +383,7 @@
                 "action": "goto.save:zone_concernee",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "!formStore.shouldInjonctionBailleurSuggested() && ((formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() >= 2) || formStore.data.signalement_concerne_logement_social_autre_tiers === 'non')"
+                  "show": "!formStore.shouldInjonctionBailleurSuggested() &&!formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -393,7 +393,7 @@
                 "action": "goto.save:prevenir_bailleur_info",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "!formStore.shouldInjonctionBailleurSuggested() && ((formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui') && ((formStore.data.info_procedure_bailleur_prevenu === 'non') || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() < 2)))"
+                  "show": "!formStore.shouldInjonctionBailleurSuggested() &&formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -428,76 +428,45 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "Votre signalement ne peut pas être déposé",
+    "label": "Votre signalement peut être déposé, mais...",
     "description": "",
     "slug": "prevenir_bailleur_info",
     "screenCategory": "Adresse et coordonnées",
     "components": {
       "body": [
         {
-          "type": "SignalementFormWarning",
-          "label": "Si le problème représente un danger pour votre sécurité, contactez les services de secours (pompiers, police, gendarmerie) !",
-          "slug": "prevenir_bailleur_info_warning"
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Avant de déposer un signalement sur {{formStore.props.platformName}} vous devez prévenir votre bailleur et lui laisser un délai de 2 mois pour vous répondre.</p><p><strong>Le service {{formStore.props.platformName}} ne peut pour le moment donner suite à votre démarche.</strong>",
-          "slug": "prevenir_bailleur_intro"
-        },
-        {
           "type": "SignalementFormInfo",
-          "label": "Vous devez d'abord prévenir votre bailleur. Il a ensuite 2 mois pour vous répondre. Si vous n'avez pas de réponse de sa part au bout de 2 mois : vous pouvez signaler votre problème sur {{formStore.props.platformName}}.",
-          "slug": "prevenir_bailleur_info_warning_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Prenez contact avec lui directement via les canaux de communications mis à votre disposition dans le cadre de sa gestion locative (ou en téléchargeant le modèle de courrier ci-dessous). Il est fort probable que celui-ci intervienne pour résoudre les problèmes dans les meilleurs délais.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormInfo",
-          "label": "Vous avez prévenu votre bailleur il y a moins de 2 mois. Votre bailleur dispose de 2 mois pour vous répondre <strong>à partir du moment où vous le prévenez</strong>. Une fois le délai passé, nous vous enverrons automatiquement un e-mail pour terminer votre signalement.",
-          "slug": "prevenir_bailleur_info_warning_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Si votre bailleur ne vous répond pas, n'hésitez pas à lui envoyer un courrier recommandé. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormLink",
-          "label": "Télécharger le courrier",
-          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
-          "customCss": "fr-btn",
-          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
-          "linktarget": "_blank",
-          "slug": "prevenir_bailleur_info_link"
+          "label": "Il est fortement recommandé de laisser à votre bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_text"
         }
       ],
       "footer": [
         {
           "type": "SignalementFormSubscreen",
           "slug": "prevenir_bailleur_info_footer",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Continuer",
+                "slug": "prevenir_bailleur_info_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
               {
                 "type": "SignalementFormLink",
                 "link": "/",
                 "label": "Fermer",
                 "slug": "prevenir_bailleur_info_close",
-                "customCss": "fr-btn--icon-left fr-icon-close-line"
+                "customCss": "fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "prevenir_bailleur_info_previous",
+                "action": "goto:info_procedure_bail",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
               }
             ]
           }
@@ -766,11 +735,21 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Précédent",
+                "slug": "zone_concernee_zone_previous_prevenir_bailleur_info",
+                "action": "goto:prevenir_bailleur_info",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+                "conditional": {
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
                 "slug": "zone_concernee_zone_previous_info_procedure",
                 "action": "goto:info_procedure_bail",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "!formStore.shouldInjonctionBailleurSuggested()"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && !formStore.shouldInjonctionBailleurSuggested()"
                 }
               },
               {
@@ -780,7 +759,7 @@
                 "action": "goto:injonction_bailleur",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.shouldInjonctionBailleurSuggested()"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.shouldInjonctionBailleurSuggested()"
                 }
               }
             ]

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -444,7 +444,7 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "il est fortement recommandé de contacter votre bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de contacter votre bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et revenez déposer votre signalement 2 mois après avoir contacté votre bailleur si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_non_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -518,7 +518,7 @@
       "body": [
         {
           "type": "SignalementFormInfo",
-          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à la demande du locataire.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_oui_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
@@ -526,7 +526,7 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à la demande du locataire.<br><br>Cliquez sur le bouton Fermer et revenez déposer votre signalement 2 mois après avoir contacté le bailleur si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_non_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -374,8 +374,20 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur.",
+          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
           "slug": "info_procedure_bailleur_prevenu_info",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "Télécharger le courrier",
+          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
+          "customCss": "fr-btn",
+          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
+          "linktarget": "_blank",
+          "slug": "info_procedure_bailleur_prevenu_info_link",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -475,7 +475,7 @@
                 "action": "goto.save:zone_concernee",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_logement_social_service_secours !== 'oui' || formStore.data.info_procedure_bailleur_prevenu === 'nsp' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() >= 2)"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -485,7 +485,7 @@
                 "action": "goto.save:prevenir_bailleur_info",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'oui' && (formStore.data.info_procedure_bailleur_prevenu === 'non' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() < 2))"
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -510,76 +510,45 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "Votre signalement ne peut pas être déposé",
+    "label": "Votre signalement peut être déposé, mais...",
     "description": "",
     "slug": "prevenir_bailleur_info",
     "screenCategory": "Adresse et coordonnées",
     "components": {
       "body": [
         {
-          "type": "SignalementFormWarning",
-          "label": "Si le problème représente un danger pour la sécurité de l'occupant, contactez les services de secours (pompiers, police, gendarmerie) !",
-          "slug": "prevenir_bailleur_info_warning"
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Avant de déposer un signalement sur {{formStore.props.platformName}} le locataire doit prévenir son bailleur et lui laisser un délai de 2 mois pour lui répondre.</p><p><strong>Le service {{formStore.props.platformName}} ne peut pour le moment donner suite à votre démarche.</strong>",
-          "slug": "prevenir_bailleur_intro"
-        },
-        {
           "type": "SignalementFormInfo",
-          "label": "Vous devez d'abord prévenir le bailleur. Il a ensuite 2 mois pour répondre. Si vous n'avez pas de réponse de sa part au bout de 2 mois : vous pouvez signaler votre problème sur {{formStore.props.platformName}}.",
-          "slug": "prevenir_bailleur_info_warning_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Prenez contact avec lui directement via les canaux de communications mis à votre disposition dans le cadre de sa gestion locative (ou en téléchargeant le modèle de courrier ci-dessous). Il est fort probable que celui-ci intervienne pour résoudre les problèmes dans les meilleurs délais.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormInfo",
-          "label": "Le bailleur a été prévenu il y a moins de 2 mois. Le bailleur dispose de 2 mois pour répondre <strong>à partir du moment où il est prévenu</strong>. Une fois le délai passé, nous vous enverrons automatiquement un e-mail pour terminer votre signalement.",
-          "slug": "prevenir_bailleur_info_warning_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Si le bailleur ne vous répond pas, n'hésitez pas à lui envoyer un courrier recommandé. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormLink",
-          "label": "Télécharger le courrier",
-          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
-          "customCss": "fr-btn",
-          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
-          "linktarget": "_blank",
-          "slug": "prevenir_bailleur_info_link"
+          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_text"
         }
       ],
       "footer": [
         {
           "type": "SignalementFormSubscreen",
           "slug": "prevenir_bailleur_info_footer",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Continuer",
+                "slug": "prevenir_bailleur_info_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
               {
                 "type": "SignalementFormLink",
                 "link": "/",
                 "label": "Fermer",
                 "slug": "prevenir_bailleur_info_close",
-                "customCss": "fr-btn--icon-left fr-icon-close-line"
+                "customCss": "fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "prevenir_bailleur_info_previous",
+                "action": "goto:info_procedure_bail",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
               }
             ]
           }
@@ -711,11 +680,21 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Précédent",
+                "slug": "zone_concernee_zone_previous_prevenir_bailleur_info",
+                "action": "goto:prevenir_bailleur_info",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+                "conditional": {
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
                 "slug": "zone_concernee_zone_previous_info_procedure_bail",
                 "action": "goto:info_procedure_bail",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_profil_occupant !== 'bailleur_occupant'"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.data.signalement_concerne_profil_detail_profil_occupant !== 'bailleur_occupant'"
                 }
               },
               {
@@ -725,7 +704,7 @@
                 "action": "goto:coordonnees_occupant",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_profil_occupant === 'bailleur_occupant'"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.data.signalement_concerne_profil_detail_profil_occupant === 'bailleur_occupant'"
                 }
               }
             ]

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -374,10 +374,10 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est obligatoire pour les locataires du parc social de prévenir le bailleur. Ils peuvent le faire grâce au modèle de courrier que vous pourrez télécharger à la page suivante ou en le sollicitant par les canaux de communication habituels.",
+          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur.",
           "slug": "info_procedure_bailleur_prevenu_info",
           "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non' && formStore.data.signalement_concerne_logement_social_service_secours === 'oui'"
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -519,7 +519,18 @@
         {
           "type": "SignalementFormInfo",
           "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
-          "slug": "prevenir_bailleur_info_text"
+          "slug": "prevenir_bailleur_info_oui_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormInfo",
+          "label": "il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_non_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -383,8 +383,20 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur.",
+          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
           "slug": "info_procedure_bailleur_prevenu_info",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "Télécharger le courrier",
+          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
+          "customCss": "fr-btn",
+          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
+          "linktarget": "_blank",
+          "slug": "info_procedure_bailleur_prevenu_info_link",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -528,7 +528,7 @@
       "body": [
         {
           "type": "SignalementFormInfo",
-          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à la demande du locataire.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_oui_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
@@ -536,7 +536,7 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à la demande du locataire.<br><br>Cliquez sur le bouton Fermer et revenez déposer votre signalement 2 mois après avoir contacté le bailleur si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_non_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -529,7 +529,18 @@
         {
           "type": "SignalementFormInfo",
           "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
-          "slug": "prevenir_bailleur_info_text"
+          "slug": "prevenir_bailleur_info_oui_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormInfo",
+          "label": "il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_non_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -485,7 +485,7 @@
                 "action": "goto.save:zone_concernee",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_logement_social_autre_tiers !== 'oui' || formStore.data.info_procedure_bailleur_prevenu === 'nsp' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() >= 2)"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -495,7 +495,7 @@
                 "action": "goto.save:prevenir_bailleur_info",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui' && (formStore.data.info_procedure_bailleur_prevenu === 'non' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() < 2))"
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -520,76 +520,45 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "Votre signalement ne peut pas être déposé",
+    "label": "Votre signalement peut être déposé, mais...",
     "description": "",
     "slug": "prevenir_bailleur_info",
     "screenCategory": "Adresse et coordonnées",
     "components": {
       "body": [
         {
-          "type": "SignalementFormWarning",
-          "label": "Si le problème représente un danger pour la sécurité de l'occupant, contactez les services de secours (pompiers, police, gendarmerie) !",
-          "slug": "prevenir_bailleur_info_warning"
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Avant de déposer un signalement sur {{formStore.props.platformName}} le locataire doit prévenir son bailleur et lui laisser un délai de 2 mois pour lui répondre.</p><p><strong>Le service {{formStore.props.platformName}} ne peut pour le moment donner suite à votre démarche.</strong>",
-          "slug": "prevenir_bailleur_intro"
-        },
-        {
           "type": "SignalementFormInfo",
-          "label": "Vous devez d'abord prévenir le bailleur. Il a ensuite 2 mois pour répondre. Si vous n'avez pas de réponse de sa part au bout de 2 mois : vous pouvez signaler votre problème sur {{formStore.props.platformName}}.",
-          "slug": "prevenir_bailleur_info_warning_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Prenez contact avec lui directement via les canaux de communications mis à votre disposition dans le cadre de sa gestion locative (ou en téléchargeant le modèle de courrier ci-dessous). Il est fort probable que celui-ci intervienne pour résoudre les problèmes dans les meilleurs délais.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormInfo",
-          "label": "Le bailleur a été prévenu il y a moins de 2 mois. Le bailleur dispose de 2 mois pour répondre <strong>à partir du moment où il est prévenu</strong>. Une fois le délai passé, nous vous enverrons automatiquement un e-mail pour terminer votre signalement.",
-          "slug": "prevenir_bailleur_info_warning_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Si le bailleur ne vous répond pas, n'hésitez pas à lui envoyer un courrier recommandé. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormLink",
-          "label": "Télécharger le courrier",
-          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
-          "customCss": "fr-btn",
-          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
-          "linktarget": "_blank",
-          "slug": "prevenir_bailleur_info_link"
+          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_text"
         }
       ],
       "footer": [
         {
           "type": "SignalementFormSubscreen",
           "slug": "prevenir_bailleur_info_footer",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Continuer",
+                "slug": "prevenir_bailleur_info_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
               {
                 "type": "SignalementFormLink",
                 "link": "/",
                 "label": "Fermer",
                 "slug": "prevenir_bailleur_info_close",
-                "customCss": "fr-btn--icon-left fr-icon-close-line"
+                "customCss": "fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "prevenir_bailleur_info_previous",
+                "action": "goto:info_procedure_bail",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
               }
             ]
           }
@@ -721,11 +690,21 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Précédent",
+                "slug": "zone_concernee_zone_previous_prevenir_bailleur_info",
+                "action": "goto:prevenir_bailleur_info",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+                "conditional": {
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
                 "slug": "zone_concernee_zone_previous_info_procedure_bail",
                 "action": "goto:info_procedure_bail",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_profil_occupant !== 'bailleur_occupant'"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.data.signalement_concerne_profil_detail_profil_occupant !== 'bailleur_occupant'"
                 }
               },
               {
@@ -735,7 +714,7 @@
                 "action": "goto:coordonnees_occupant",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_profil_occupant === 'bailleur_occupant'"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.data.signalement_concerne_profil_detail_profil_occupant === 'bailleur_occupant'"
                 }
               }
             ]

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -383,10 +383,10 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est obligatoire pour les locataires du parc social de prévenir le bailleur. Ils peuvent le faire grâce au modèle de courrier que vous pourrez télécharger à la page suivante ou en le sollicitant par les canaux de communication habituels.",
+          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur.",
           "slug": "info_procedure_bailleur_prevenu_info",
           "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non' && formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -368,10 +368,10 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est obligatoire pour les locataires du parc social de prévenir le bailleur. Ils peuvent le faire grâce au modèle de courrier que vous pourrez télécharger à la page suivante ou en le sollicitant par les canaux de communication habituels.",
+          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur.",
           "slug": "info_procedure_bailleur_prevenu_info",
           "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non' && formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -514,7 +514,18 @@
         {
           "type": "SignalementFormInfo",
           "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
-          "slug": "prevenir_bailleur_info_text"
+          "slug": "prevenir_bailleur_info_oui_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormInfo",
+          "label": "il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_non_text",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -470,7 +470,7 @@
                 "action": "goto.save:zone_concernee",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_logement_social_autre_tiers !== 'oui' || formStore.data.info_procedure_bailleur_prevenu === 'nsp' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() >= 2)"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -480,7 +480,7 @@
                 "action": "goto.save:prevenir_bailleur_info",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui' && (formStore.data.info_procedure_bailleur_prevenu === 'non' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() < 2))"
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
                 }
               },
               {
@@ -505,76 +505,45 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "Votre signalement ne peut pas être déposé",
+    "label": "Votre signalement peut être déposé, mais...",
     "description": "",
     "slug": "prevenir_bailleur_info",
     "screenCategory": "Adresse et coordonnées",
     "components": {
       "body": [
         {
-          "type": "SignalementFormWarning",
-          "label": "Si le problème représente un danger pour la sécurité de l'occupant, contactez les services de secours (pompiers, police, gendarmerie) !",
-          "slug": "prevenir_bailleur_info_warning"
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Avant de déposer un signalement sur {{formStore.props.platformName}} le locataire doit prévenir son bailleur et lui laisser un délai de 2 mois pour lui répondre.</p><p><strong>Le service {{formStore.props.platformName}} ne peut pour le moment donner suite à votre démarche.</strong>",
-          "slug": "prevenir_bailleur_intro"
-        },
-        {
           "type": "SignalementFormInfo",
-          "label": "Vous devez d'abord prévenir le bailleur. Il a ensuite 2 mois pour répondre. Si vous n'avez pas de réponse de sa part au bout de 2 mois : vous pouvez signaler votre problème sur {{formStore.props.platformName}}.",
-          "slug": "prevenir_bailleur_info_warning_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Prenez contact avec lui directement via les canaux de communications mis à votre disposition dans le cadre de sa gestion locative (ou en téléchargeant le modèle de courrier ci-dessous). Il est fort probable que celui-ci intervienne pour résoudre les problèmes dans les meilleurs délais.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_pas_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
-          }
-        },
-        {
-          "type": "SignalementFormInfo",
-          "label": "Le bailleur a été prévenu il y a moins de 2 mois. Le bailleur dispose de 2 mois pour répondre <strong>à partir du moment où il est prévenu</strong>. Une fois le délai passé, nous vous enverrons automatiquement un e-mail pour terminer votre signalement.",
-          "slug": "prevenir_bailleur_info_warning_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormParagraph",
-          "label": "Si le bailleur ne vous répond pas, n'hésitez pas à lui envoyer un courrier recommandé. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
-          "slug": "prevenir_bailleur_info_paragraph_bailleur_contacte",
-          "conditional": {
-            "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
-          }
-        },
-        {
-          "type": "SignalementFormLink",
-          "label": "Télécharger le courrier",
-          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
-          "customCss": "fr-btn",
-          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
-          "linktarget": "_blank",
-          "slug": "prevenir_bailleur_info_link"
+          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "slug": "prevenir_bailleur_info_text"
         }
       ],
       "footer": [
         {
           "type": "SignalementFormSubscreen",
           "slug": "prevenir_bailleur_info_footer",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Continuer",
+                "slug": "prevenir_bailleur_info_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
               {
                 "type": "SignalementFormLink",
                 "link": "/",
                 "label": "Fermer",
                 "slug": "prevenir_bailleur_info_close",
-                "customCss": "fr-btn--icon-left fr-icon-close-line"
+                "customCss": "fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "prevenir_bailleur_info_previous",
+                "action": "goto:info_procedure_bail",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
               }
             ]
           }
@@ -706,11 +675,21 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Précédent",
+                "slug": "zone_concernee_zone_previous_prevenir_bailleur_info",
+                "action": "goto:prevenir_bailleur_info",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+                "conditional": {
+                  "show": "formStore.shouldDisplayPrevenirBailleurInfo()"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
                 "slug": "zone_concernee_zone_previous_info_procedure_bail",
                 "action": "goto:info_procedure_bail",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_profil_occupant !== 'bailleur_occupant'"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.data.signalement_concerne_profil_detail_profil_occupant !== 'bailleur_occupant'"
                 }
               },
               {
@@ -720,7 +699,7 @@
                 "action": "goto:coordonnees_occupant",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_profil_occupant === 'bailleur_occupant'"
+                  "show": "!formStore.shouldDisplayPrevenirBailleurInfo() && formStore.data.signalement_concerne_profil_detail_profil_occupant === 'bailleur_occupant'"
                 }
               }
             ]

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -513,7 +513,7 @@
       "body": [
         {
           "type": "SignalementFormInfo",
-          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de laisser au bailleur un délai de 2 mois avant de déposer un signalement pour qu’il puisse apporter une réponse à la demande du locataire.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_oui_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'oui'"
@@ -521,7 +521,7 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à votre demande.<br><br>Cliquez sur le bouton Fermer et nous vous contacterons par e-mail à l’issue du délai de 2 mois pour vous inviter à finaliser votre signalement si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
+          "label": "Il est fortement recommandé de contacter le bailleur avant de déposer un signalement et de lui laisser un délai de 2 mois pour qu’il puisse apporter une réponse à la demande du locataire.<br><br>Cliquez sur le bouton Fermer et revenez déposer votre signalement 2 mois après avoir contacté le bailleur si vous le jugez toujours nécessaire.<br><br>Si vous souhaitez, au regard de l’urgence de la situation et d’éventuels risques encourus déposer un signalement sans attendre, cliquez sur le bouton Continuer.",
           "slug": "prevenir_bailleur_info_non_text",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -368,8 +368,20 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur.",
+          "label": "Avant de déposer un signalement, il est fortement recommandé de prévenir le bailleur. Vous pouvez télécharger un modèle de courrier à remplir en cliquant sur le bouton ci-dessous.",
           "slug": "info_procedure_bailleur_prevenu_info",
+          "conditional": {
+            "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "Télécharger le courrier",
+          "description": "Télécharger le modèle de courrier à envoyer au bailleur",
+          "customCss": "fr-btn",
+          "link": "/build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf",
+          "linktarget": "_blank",
+          "slug": "info_procedure_bailleur_prevenu_info_link",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu === 'non'"
           }

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -242,6 +242,32 @@ const formStore: FormStore = reactive({
     
     return dateToday.getMonth() - dateBailleurPrevenu.getMonth() + (12 * (dateToday.getFullYear() - dateBailleurPrevenu.getFullYear()))
   },
+  shouldDisplayPrevenirBailleurInfo (): boolean {
+    if (formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'bailleur') {
+      return false
+    }
+    if ((formStore.data.profil === 'tiers_pro' || formStore.data.profil === 'tiers_particulier') && formStore.data.signalement_concerne_logement_social_autre_tiers !== 'oui') {
+      return false
+    }
+    if (formStore.data.profil === 'service_secours' && formStore.data.signalement_concerne_logement_social_service_secours !== 'oui') {
+      return false
+    }
+    if (formStore.data.profil === 'locataire') {
+      if (this.shouldInjonctionBailleurSuggested() || formStore.data.signalement_concerne_logement_social_autre_tiers !== 'oui') {
+        return false
+      }
+    }
+    if (formStore.data.info_procedure_bailleur_prevenu === 'nsp') {
+        return false
+    }
+    if (formStore.data.info_procedure_bailleur_prevenu === 'oui') {
+      const monthsSinceBailleurPrevenu = this.countMonthsSinceBailleurPrevenu()
+      if (monthsSinceBailleurPrevenu === undefined || monthsSinceBailleurPrevenu >= 2) {
+        return false
+      }
+    }
+    return true;
+  },
   shouldInjonctionBailleurSuggested(): boolean {
       if (!this.props.featureInjonctionBailleur) {
         return false


### PR DESCRIPTION
## Ticket

#5760   

## Description
Modification du parcours bloquant sur le parc social. Ne plus bloquer l'usager si le délai est inférieur à 2 mois ou s'il n'a pas prévenur son bailleur, en ajoutant un bouton `Continuer` et en changeant le texte.

## Changements apportés
* Changement des textes dans les 4 json concernés
* Ajout des boutons `Continuer` et `Précédent` dans le footer de l'écran `prevenir_bailleur_info`
* Ajout d'un bouton Précédent revenant sur cet écran`prevenir_bailleur_info`  sur l'écran suivant `zone_concernee`
* Création d'une fonction `shouldDisplayPrevenirBailleurInfo()` pour faciliter l'affichage des boutons de navigation entre les différents écrans

## Pré-requis

## Tests
- [ ] Vérifier le parcours jusqu'à l'écran  `zone_concernee` et retours dans les différents profils, en choisissant occupant locataire ou propriétaire, en choisissant parc public ou parc privé, et en choisissant les différentes réponses possibles pour "avez-vous prévenu le propriétaire". (ce qui fait une cinquantaine d'allers-retours :laughing: )
- [ ] Vérifier qu'on peut aller jusqu'au bout de l'enregistrement du signalement, et vérifier sa présence sur le BO
- [ ] Refaire un signalement, mais choisir de fermer. En base, changer la date du bailleur prévenu pour la mettre il y a 3 mois. Lancer la console `make console app="remind-pending-drafts-bailleur-prevenu"` et vérifier qu'un mail est envoyé
