### PR TITLE
[FO / BO] Diverses modifications de contenu

### DIFF
--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -525,7 +525,7 @@
         {
           "type": "SignalementFormParagraphList",
           "values": [
-            "<strong>Engagement à réaliser les travaux :</strong> votre propriétaire reconnaît sa responsabilité et s'engage à réaliser les travaux.<br>L'avancement du dossier sera alors régulièrement suivi jusqu'à ce que le problème soit résolu.",
+            "<strong>Engagement à réaliser les travaux :</strong> votre propriétaire reconnaît sa responsabilité et s'engage à réaliser les travaux.<br>Vous et votre propriétaire serez régulièrement sollicités pour nous informer de l'avancement du dossier. Il n'y aura pas d'intervention des services tant que la démarche à l'amiable est en cours.",
             "<strong>Contestation du signalement :</strong> votre propriétaire conteste le signalement et les désordres signalés. Votre dossier sera pris en charge par les services compétents.",
             "<strong>Pas de réponse du propriétaire :</strong> votre dossier sera pris en charge par les services compétents."
           ],

--- a/src/Form/MessageBailleurType.php
+++ b/src/Form/MessageBailleurType.php
@@ -10,6 +10,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * @extends AbstractType<mixed>
+ */
 class MessageBailleurType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -70,7 +70,7 @@
 				{% elseif signalement.statut.name == 'ARCHIVED' %}
 					{% set errorMessage = 'Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.' %}
 				{% elseif signalement.isLogementVacant %}
-					{% set errorMessage = 'Votre logement a été marqué comme vacant, vous ne pouvez plus envoyer de messages.' %}
+					{% set errorMessage = 'Les services en charge du dossier ont indiqué que vous avez quitté votre logement. Par conséquent, vous ne pouvez plus envoyer de messages.' %}
 				{% else %}
 					{% set errorMessage = 'Vous ne pouvez plus envoyer de messages.' %}
 				{% endif %}

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -147,7 +147,12 @@
                 {% elseif current_step == 'step3' %}
                     <h2 class="fr-h5">Coordonnées de l'occupant</h2>
                     {{ form_row(form.step3.profilOccupant, {display_mode: 'block'}) }}
+
+                    <div class="fr-alert fr-alert--info fr-alert--sm fr-mb-2w">
+                        <p>Bien qu'il soit facultatif, le nom de l'occupant permet de faciliter le traitement du dossier par la suite.</p>
+                    </div>
                     {{ form_row(form.step3.nomOccupant) }}
+
                     {{ form_row(form.step3.prenomOccupant) }}
                     {{ form_row(form.step3.mailOccupant) }}
                     {{ form_row(form.step3.telOccupant) }}


### PR DESCRIPTION
## Ticket

#5856
#5859
#5860

## Description
- Formulaire de signalement : modification du texte qui indique que le dossier sera suivi pour la démarche accélérée
- Page de suivi usager : modification de la phrase qui indique à l'usager que son logement est vacant
- Formulaire de secours : ajout d'un encouragement à saisir le nom de l'occupant

## Tests
- [ ] Faire un signalement qui est éligible à la démarche accélérée et vérifier le texte de présentation
- [ ] Passer un logement en vacant et vérifier la phrase affichée dans la page de suivi usager
- [ ] Utiliser le formulaire de secours et vérifier l'affichage au-dessus du champ du nom de l'occupant
