### PR TITLE
[FO - Signalement] Ajout liserets dans les différentes parties du récapitulatif de signalement

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -5,10 +5,10 @@
       <h3 class="fr-h4">Récapitulatif</h3>
 
       <!-- ADRESSE DU LOGEMENT -->
-      <div>
+      <div class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Adresse du logement</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Adresse du logement</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -23,10 +23,10 @@
       </div>
 
       <!-- VOS COORDONNES SI OCCUPANT -->
-      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
+      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Vos coordonnées</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Vos coordonnées</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -40,10 +40,10 @@
       </div>
 
       <!-- VOS COORDONNEES SI TIERS -->
-      <div v-else>
+      <div v-else class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Vos coordonnées</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Vos coordonnées</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -57,10 +57,10 @@
       </div>
 
       <!-- LES COORDONNEES DU BAILLEUR -->
-      <div v-if="formStore.shouldDisplaySignalementInfoBailleur()">
+      <div v-if="formStore.shouldDisplaySignalementInfoBailleur()" class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Les coordonnées du bailleur</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Les coordonnées du bailleur</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -74,10 +74,10 @@
       </div>
 
       <!-- LES COORDONNEES DU FOYER -->
-      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire'">
+      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire'" class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Les coordonnées du foyer</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Les coordonnées du foyer</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -90,10 +90,10 @@
       </div>
 
       <!-- TYPE ET COMPOSITION DU LOGEMENT -->
-      <div>
+      <div class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Type et composition du logement</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Type et composition du logement</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -118,11 +118,11 @@
       </div>
 
       <!-- SITUATION OCCUPANT -->
-      <div v-if="formStore.data.profil !== 'service_secours'">
+      <div v-if="formStore.data.profil !== 'service_secours'" class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v" v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">Votre situation</h4>
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v" v-else>La situation du foyer</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france" v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">Votre situation</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france" v-else>La situation du foyer</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -147,10 +147,10 @@
       </div>
 
       <!-- LES DESORDRES -->
-      <div>
+      <div class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">Les désordres</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Les désordres</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -173,10 +173,10 @@
       </div>
 
       <!-- LA PROCEDURE  -->
-      <div>
+      <div class="signalement-group-data-card">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-12 fr-col-md-8">
-            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v">La procédure</h4>
+            <h4 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">La procédure</h4>
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
@@ -196,11 +196,11 @@
       </div>
 
       <!-- INFORMATIONS COMPLEMENTAIRES  -->
-      <div v-if="formStore.data.profil !== 'service_secours'">
+      <div v-if="formStore.data.profil !== 'service_secours'" class="signalement-group-data-card">
         <div v-if="hasInformationsComplementaires()">
           <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
             <div class="fr-col-12 fr-col-md-8">
-              <h3 class="fr-h6 fr-mb-0 fr-mb-md-8v">Informations complémentaires</h3>
+              <h3 class="fr-h6 fr-mb-0 fr-mb-md-8v title-blue-france">Informations complémentaires</h3>
             </div>
             <div class="fr-col-12 fr-col-md-4 fr-text--right">
               <button
@@ -213,7 +213,7 @@
           <p v-html="getFormDataInformationsComplementaires()"></p>
         </div>
         <div v-else>
-          <h3 class="fr-h4">Informations complémentaires</h3>
+          <h3 class="fr-h4 title-blue-france">Informations complémentaires</h3>
           <p>
             Plus nous avons d'informations sur la situation,
             mieux nous pouvons vous accompagner.

--- a/src/Service/Mailer/ContextDateTimeNormalizer.php
+++ b/src/Service/Mailer/ContextDateTimeNormalizer.php
@@ -46,6 +46,8 @@ class ContextDateTimeNormalizer
 
     /**
      * Checks if an array represents a serialized DateTime object.
+     *
+     * @param array<mixed> $value
      */
     private function isSerializedDateTime(array $value): bool
     {

--- a/templates/front/dossier_bailleur/dossier_bailleur.html.twig
+++ b/templates/front/dossier_bailleur/dossier_bailleur.html.twig
@@ -91,7 +91,7 @@
 				</div>	
 			</div>
 
-			<div class="fr-mb-4w">
+			<div class="fr-mb-4w signalement-group-data-card">
 				<h2 class="title-blue-france fr-mb-1w">Déclaration</h2>
 				{% if signalement.debutDesordres is not null %}
 					<ul>
@@ -118,7 +118,7 @@
 				{% endif %}
 			</div>
 
-			<div class="fr-mb-4w">
+			<div class="fr-mb-4w signalement-group-data-card">
 				<h2 class="title-blue-france fr-mb-1w">Les photos et documents du dossier</h2>
 				{% set photos = signalement.files|filter(photo => photo.documentType == enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION and photo.isTypeImage) %}
 				{% set docs = signalement.files|filter(photo => photo.documentType == enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION and photo.isTypeDocument and not photo.isSuspicious) %}
@@ -173,11 +173,8 @@
 		</div>
 
 		<div class="fr-col-12 fr-col-md-6">
-			<div class="fr-mb-4w">
-				<h2 class="title-blue-france fr-mb-1w">Coordonnées</h2>
-				<div class="fr-mb-1w">
-					<strong>Vos Coordonnées (bailleur)</strong>
-				</div>
+			<div class="fr-mb-4w signalement-group-data-card">
+				<h2 class="title-blue-france fr-mb-1w">Vos coordonnées</h2>
 				{{signalement.nomProprio}}
 				{% if signalement.prenomProprio %}
 					{{ signalement.prenomProprio }}


### PR DESCRIPTION
## Ticket

#5858   

## Description
- Formulaire de signalement usager : Ajout liserets dans les différentes parties du récapitulatif
- Page suivi bailleur : Ajout liserets pour séparer les différentes parties des données

## Pré-requis
`make npm-watch`

## Tests
- [ ] Faire des signalements avec différents profils et vérifier l'affichage des données dans le récapitulatif
- [ ] Aller voir une page de suivi bailleur pour vérifier l'affichage
