### PR TITLE
[FO - Signalement] Enregistrement du nom du travailleur social

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1498,24 +1498,32 @@
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_nom_referent",
           "label": "Nom de famille du référent qui accompagne le foyer (facultatif)",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
           },
+          "maxlength": 255,
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le nom de famille du référent qui accompagne le foyer."
+            "required": false
+          },
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_prenom_referent",
           "label": "Prénom du référent qui accompagne le foyer (facultatif)",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
           },
+          "maxlength": 255,
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le prénom du référent qui accompagne le foyer."
+            "required": false
+          },
+          "accessibility": {
+            "name": "firstName"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1493,6 +1493,30 @@
             "required": false,
             "message": "Veuillez indiquer le nom de la structure qui accompagne le foyer."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_referent",
+          "label": "Nom de famille du référent qui accompagne le foyer (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de famille du référent qui accompagne le foyer."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_prenom_referent",
+          "label": "Prénom du référent qui accompagne le foyer (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le prénom du référent qui accompagne le foyer."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1342,15 +1342,36 @@
           }
         },
         {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers",
+          "label": "Est-ce que vous souhaitez inviter ce référent pour le suivi du dossier ?",
+          "description": "Ce référent recevra une invitation par e-mail pour suivre le dossier. Si elle accepte, cette personne recevra les mêmes informations que vous et pourra envoyer des informations aux services compétents.",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            }
+          ],
+          "validate": {
+            "message": "Veuillez indiquer si vous souhaitez inviter ce référent pour le suivi du dossier."
+          }
+        },
+        {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_nom_referent",
           "label": "Nom de famille du référent qui vous accompagne (facultatif)",
           "conditional": {
-            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'non'"
           },
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+            "required": false
           }
         },
         {
@@ -1358,11 +1379,44 @@
           "slug": "travailleur_social_accompagnement_prenom_referent",
           "label": "Prénom du référent qui vous accompagne (facultatif)",
           "conditional": {
-            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'non'"
           },
           "validate": {
-            "required": false,
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_nom",
+          "label": "Nom de famille du référent qui vous accompagne",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom",
+          "label": "Prénom du référent qui vous accompagne",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
+          },
+          "validate": {
             "message": "Veuillez indiquer le prénom du référent qui vous accompagne."
+          }
+        },
+        {
+          "type": "SignalementFormEmailfield",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_email",
+          "label": "Adresse e-mail du référent à inviter",
+          "description": "Format attendu : nom@domaine.fr",
+          "validate": {
+            "patternMessage": "Veuillez renseigner une adresse e-mail valide."
+          },
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1372,6 +1372,9 @@
           },
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
@@ -1383,28 +1386,41 @@
           },
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "firstName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_nom",
           "label": "Nom de famille du référent qui vous accompagne",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
           },
           "validate": {
             "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+          },
+          "maxlength": 255,
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom",
           "label": "Prénom du référent qui vous accompagne",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
           },
           "validate": {
             "message": "Veuillez indiquer le prénom du référent qui vous accompagne."
+          },
+          "maxlength": 255,
+          "accessibility": {
+            "name": "firstName"
           }
         },
         {
@@ -1417,6 +1433,9 @@
           },
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
+          },
+          "accessibility": {
+            "name": "mail"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1340,6 +1340,30 @@
             "required": false,
             "message": "Veuillez indiquer le nom de la structure qui vous accompagne."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_referent",
+          "label": "Nom de famille du référent qui vous accompagne (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_prenom_referent",
+          "label": "Prénom du référent qui vous accompagne (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le prénom du référent qui vous accompagne."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -2023,6 +2023,9 @@
           },
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
@@ -2034,28 +2037,41 @@
           },
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "firstName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_nom",
           "label": "Nom de famille du référent qui vous accompagne",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
           },
           "validate": {
             "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+          },
+          "maxlength": 255,
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom",
           "label": "Prénom du référent qui vous accompagne",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
           },
           "validate": {
             "message": "Veuillez indiquer le prénom du référent qui vous accompagne."
+          },
+          "maxlength": 255,
+          "accessibility": {
+            "name": "firstName"
           }
         },
         {
@@ -2068,6 +2084,9 @@
           },
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
+          },
+          "accessibility": {
+            "name": "mail"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1991,6 +1991,30 @@
             "required": false,
             "message": "Veuillez indiquer le nom de la structure qui vous accompagne."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_referent",
+          "label": "Nom de famille du référent qui vous accompagne (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_prenom_referent",
+          "label": "Prénom du référent qui vous accompagne (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le prénom du référent qui vous accompagne."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1993,15 +1993,36 @@
           }
         },
         {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers",
+          "label": "Est-ce que vous souhaitez inviter ce référent pour le suivi du dossier ?",
+          "description": "Ce référent recevra une invitation par e-mail pour suivre le dossier. Si elle accepte, cette personne recevra les mêmes informations que vous et pourra envoyer des informations aux services compétents.",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            }
+          ],
+          "validate": {
+            "message": "Veuillez indiquer si vous souhaitez inviter ce référent pour le suivi du dossier."
+          }
+        },
+        {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_nom_referent",
           "label": "Nom de famille du référent qui vous accompagne (facultatif)",
           "conditional": {
-            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'non'"
           },
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+            "required": false
           }
         },
         {
@@ -2009,11 +2030,44 @@
           "slug": "travailleur_social_accompagnement_prenom_referent",
           "label": "Prénom du référent qui vous accompagne (facultatif)",
           "conditional": {
-            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'non'"
           },
           "validate": {
-            "required": false,
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_nom",
+          "label": "Nom de famille du référent qui vous accompagne",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer le nom de famille du référent qui vous accompagne."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom",
+          "label": "Prénom du référent qui vous accompagne",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
+          },
+          "validate": {
             "message": "Veuillez indiquer le prénom du référent qui vous accompagne."
+          }
+        },
+        {
+          "type": "SignalementFormEmailfield",
+          "slug": "travailleur_social_accompagnement_inviter_referent_comme_tiers_email",
+          "label": "Adresse e-mail du référent à inviter",
+          "description": "Format attendu : nom@domaine.fr",
+          "validate": {
+            "patternMessage": "Veuillez renseigner une adresse e-mail valide."
+          },
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui'"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1903,6 +1903,30 @@
             "required": false,
             "message": "Veuillez indiquer le nom de la structure qui accompagne le foyer."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_referent",
+          "label": "Nom de famille du référent qui accompagne le foyer (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de famille du référent qui accompagne le foyer."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_prenom_referent",
+          "label": "Prénom du référent qui accompagne le foyer (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le prénom du référent qui accompagne le foyer."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1921,7 +1921,7 @@
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_prenom_referent",
-          "description": "Format attendu : 255 caractères maximum",
+          "label": "Prénom du référent qui accompagne le foyer (facultatif)",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
           },

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1912,20 +1912,24 @@
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
           },
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le nom de famille du référent qui accompagne le foyer."
+            "required": false
+          },
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_prenom_referent",
-          "label": "Prénom du référent qui accompagne le foyer (facultatif)",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
           },
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le prénom du référent qui accompagne le foyer."
+            "required": false
+          },
+          "accessibility": {
+            "name": "firstName"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1899,6 +1899,30 @@
             "required": false,
             "message": "Veuillez indiquer le nom de la structure qui accompagne le foyer."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_referent",
+          "label": "Nom de famille du référent qui accompagne le foyer (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_declarant !== 1"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de famille du référent qui accompagne le foyer."
+          }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_prenom_referent",
+          "label": "Prénom du référent qui accompagne le foyer (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_declarant !== 1"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le prénom du référent qui accompagne le foyer."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1908,20 +1908,24 @@
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_declarant !== 1"
           },
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le nom de famille du référent qui accompagne le foyer."
+            "required": false
+          },
+          "accessibility": {
+            "name": "lastName"
           }
         },
         {
           "type": "SignalementFormTextfield",
           "slug": "travailleur_social_accompagnement_prenom_referent",
-          "label": "Prénom du référent qui accompagne le foyer (facultatif)",
+          "description": "Format attendu : 255 caractères maximum",
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_declarant !== 1"
           },
           "validate": {
-            "required": false,
-            "message": "Veuillez indiquer le prénom du référent qui accompagne le foyer."
+            "required": false
+          },
+          "accessibility": {
+            "name": "firstName"
           }
         }
       ],

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -796,6 +796,8 @@ function initBoFormSignalementSituation() {
   ]);
   initRefreshFromRadio('situation', 'signalement_draft_situation_accompagnementTravailleurSocial', [
     '#signalement_draft_situation_accompagnementTravailleurSocialNomStructure',
+    '#signalement_draft_situation_accompagnementTravailleurSocialNomReferent',
+    '#signalement_draft_situation_accompagnementTravailleurSocialPrenomReferent',
   ]);
   window.dispatchEvent(new Event('refreshUploadButtonEvent'));
 

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -403,6 +403,12 @@ export default defineComponent({
       if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
         result += this.addLineIfNeeded('travailleur_social_accompagnement_nom_structure', 'Nom de la structure : ')
       }
+      if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
+        result += this.addLineIfNeeded('travailleur_social_accompagnement_nom_referent', 'Nom du référent : ')
+      }
+      if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
+        result += this.addLineIfNeeded('travailleur_social_accompagnement_prenom_referent', 'Prénom du référent : ')
+      }
       return result
     },
     getFormDataInfosDesordres (): string {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -402,12 +402,15 @@ export default defineComponent({
       result += this.addLineIfNeeded('travailleur_social_accompagnement', 'Accompagnement par un ou une travailleuse sociale ? ')
       if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
         result += this.addLineIfNeeded('travailleur_social_accompagnement_nom_structure', 'Nom de la structure : ')
-      }
-      if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
-        result += this.addLineIfNeeded('travailleur_social_accompagnement_nom_referent', 'Nom du référent : ')
-      }
-      if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
-        result += this.addLineIfNeeded('travailleur_social_accompagnement_prenom_referent', 'Prénom du référent : ')
+        result += this.addLineIfNeeded('travailleur_social_accompagnement_inviter_referent_comme_tiers', 'Inviter un référent à suivre le dossier : ')
+        if (this.formStore.data.travailleur_social_accompagnement_inviter_referent_comme_tiers === 'oui') {
+          result += this.addLineIfNeeded('travailleur_social_accompagnement_inviter_referent_comme_tiers_nom', 'Nom du référent : ')
+          result += this.addLineIfNeeded('travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom', 'Prénom du référent : ')
+          result += this.addLineIfNeeded('travailleur_social_accompagnement_inviter_referent_comme_tiers_email', 'E-mail du référent : ')
+        } else {
+          result += this.addLineIfNeeded('travailleur_social_accompagnement_nom_referent', 'Nom du référent : ')
+          result += this.addLineIfNeeded('travailleur_social_accompagnement_prenom_referent', 'Prénom du référent : ')
+        }
       }
       return result
     },

--- a/assets/scripts/vue/components/signalement-form/services/variableReplacer.ts
+++ b/assets/scripts/vue/components/signalement-form/services/variableReplacer.ts
@@ -3,7 +3,7 @@ import dictionaryStore from '../dictionary-store'
 
 export const variablesReplacer = {
   replace (textToReplace: string | undefined): string {
-    if (textToReplace === undefined) {
+    if (textToReplace === undefined || textToReplace === null) {
       return ''
     }
     const descriptionWithValues = textToReplace.replace(/\{\{([\w.:]+)\}\}/g, (match, expression) => {

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -3,6 +3,11 @@ nelmio_api_doc:
         info:
             title: '%platform_name%'
             description:  |
+             ## CHANGELOG 1.3.3 - 2026-05
+             Cette version introduit deux nouvelles données pour les signalements.
+             ### AJOUTS
+             - Ajout du prénom et du nom du travailleur social qui accompagne le foyer `accompagnementTravailleurSocialNomReferent` et `accompagnementTravailleurSocialPrenomReferent`.
+
              ## CHANGELOG 1.3.2 - 2026-03
              Cette version introduit de nouvelles données pour les signalements et les visites.
              ### AJOUTS
@@ -10,6 +15,7 @@ nelmio_api_doc:
              - Ajout du champ Autre situation de vulnérabilité à mentionner `autreSituationVulnerabilite` sur `GET /api/signalements/{uuid}` et `POST /api/signalements`.
              - Ajout du matricule du déclarant `matriculeDeclarant` conditionné au profils déclarants `TIERS_PRO` et `SERVICE_SECOURS` sur `GET /api/signalements/{uuid}` et `POST /api/signalements`.
              - Ajout des informations de syndic `denominationSyndic`, `nomSyndic`, `mailSyndic`, `telSyndic` et `telSyndicSecondaire` sur `GET /api/signalements/{uuid}` et `POST /api/signalements`.
+             
              ## CHANGELOG 1.3.1 - 2026-02
              Cette version introduit un nouveau filtre pour la liste des signalements.
              ### AJOUTS
@@ -17,6 +23,7 @@ nelmio_api_doc:
              
              *Exemple*
              `GET /api/signalements?codeInsee=13201`
+             
              ## CHANGELOG 1.3.0 - 2026-01
              Cette version introduit un nouvel endpoint permettant la création de signalement.
              ### AJOUTS

--- a/migrations/Version20260512153353.php
+++ b/migrations/Version20260512153353.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260512153353 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'migrate signalement.situationFoyer.travailleurSocialAccompagnementNomStructure to existing signalement.structureReferentSocial';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE signalement SET structure_referent_social = JSON_UNQUOTE(JSON_EXTRACT(situation_foyer, "$.travailleurSocialAccompagnementNomStructure")) WHERE JSON_EXTRACT(situation_foyer, "$.travailleurSocialAccompagnementNomStructure") IS NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20260512153353.php
+++ b/migrations/Version20260512153353.php
@@ -11,15 +11,28 @@ final class Version20260512153353 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'migrate signalement.situationFoyer.travailleurSocialAccompagnementNomStructure to existing signalement.structureReferentSocial';
+        return 'migrate signalement.structureReferentSocial to json field signalement.situationFoyer.travailleur_social_accompagnement_nom_structure';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('UPDATE signalement SET structure_referent_social = JSON_UNQUOTE(JSON_EXTRACT(situation_foyer, "$.travailleurSocialAccompagnementNomStructure")) WHERE JSON_EXTRACT(situation_foyer, "$.travailleurSocialAccompagnementNomStructure") IS NOT NULL');
+        // Copy data from structureReferentSocial in travailleur_social_accompagnement_nom_structure in json field situationFoyer
+        $this->addSql('UPDATE signalement s SET s.situation_foyer = JSON_SET(COALESCE(s.situation_foyer, \'{}\'), \'$.travailleur_social_accompagnement_nom_structure\', s.structure_referent_social) WHERE s.structure_referent_social IS NOT NULL');
+        // Copy data from nomReferentSocial in travailleur_social_accompagnement_nom_referent in json field situationFoyer
+        $this->addSql('UPDATE signalement s SET s.situation_foyer = JSON_SET(COALESCE(s.situation_foyer, \'{}\'), \'$.travailleur_social_accompagnement_nom_referent\', s.nom_referent_social) WHERE s.nom_referent_social IS NOT NULL');
+        // Remove columns structureReferentSocial and nomReferentSocial
+        $this->addSql('ALTER TABLE signalement DROP structure_referent_social');
+        $this->addSql('ALTER TABLE signalement DROP nom_referent_social');
     }
 
     public function down(Schema $schema): void
     {
+        // add columns structureReferentSocial and nomReferentSocial
+        $this->addSql('ALTER TABLE signalement ADD structure_referent_social VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement ADD nom_referent_social VARCHAR(255) DEFAULT NULL');
+        // Copy data from travailleur_social_accompagnement_nom_structure in json field situationFoyer to structureReferentSocial
+        $this->addSql('UPDATE signalement s SET s.structure_referent_social = JSON_UNQUOTE(JSON_EXTRACT(s.situation_foyer, \'$.travailleur_social_accompagnement_nom_structure\')) WHERE JSON_EXTRACT(s.situation_foyer, \'$.travailleur_social_accompagnement_nom_structure\') IS NOT NULL');
+        // Copy data from travailleur_social_accompagnement_nom_referent in json field situationFoyer to nomReferentSocial
+        $this->addSql('UPDATE signalement s SET s.nom_referent_social = JSON_UNQUOTE(JSON_EXTRACT(s.situation_foyer, \'$.travailleur_social_accompagnement_nom_referent\')) WHERE JSON_EXTRACT(s.situation_foyer, \'$.travailleur_social_accompagnement_nom_referent\') IS NOT NULL');
     }
 }

--- a/src/Controller/Api/SignalementCreateController.php
+++ b/src/Controller/Api/SignalementCreateController.php
@@ -114,6 +114,8 @@ class SignalementCreateController extends AbstractController
                             'montantAllocation' => 250.75,
                             'isAccompagnementTravailleurSocial' => true,
                             'accompagnementTravailleurSocialNomStructure' => 'CCAS de Montpellier',
+                            'accompagnementTravailleurSocialPrenomReferent' => 'Marie',
+                            'accompagnementTravailleurSocialNomReferent' => 'Dubois',
                             'isBeneficiaireRsa' => false,
                             'isBeneficiaireFsl' => false,
                             'isBailleurAverti' => true,

--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -329,11 +329,11 @@ class SignalementEditController extends AbstractController
                 $signalement->setDateNaissanceOccupant(new \DateTimeImmutable($form->get('dateNaissanceAllocataire')->getData()->format('Y-m-d')));
             }
             $signalement->setMontantAllocation((int) $form->get('montantAllocation')->getData());
+            $signalement->setStructureReferentSocial($form->get('accompagnementTravailleurSocialNomStructure')->getData());
             $situationFoyer->setLogementSocialMontantAllocation($form->get('montantAllocation')->getData())
                 ->setTravailleurSocialQuitteLogement($form->get('souhaiteQuitterLogement')->getData())
                 ->setTravailleurSocialPreavisDepart($form->get('preavisDepartDepose')->getData())
-                ->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData())
-                ->setTravailleurSocialAccompagnementNomStructure($form->get('accompagnementTravailleurSocialNomStructure')->getData());
+                ->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData());
             $informationComplementaire->setInformationsComplementairesSituationOccupantsTypeAllocation($form->get('typeAllocation')->getData())
                 ->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($form->get('beneficiaireRSA')->getData())
                 ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($form->get('beneficiaireFSL')->getData())

--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -329,11 +329,13 @@ class SignalementEditController extends AbstractController
                 $signalement->setDateNaissanceOccupant(new \DateTimeImmutable($form->get('dateNaissanceAllocataire')->getData()->format('Y-m-d')));
             }
             $signalement->setMontantAllocation((int) $form->get('montantAllocation')->getData());
-            $signalement->setStructureReferentSocial($form->get('accompagnementTravailleurSocialNomStructure')->getData());
             $situationFoyer->setLogementSocialMontantAllocation($form->get('montantAllocation')->getData())
                 ->setTravailleurSocialQuitteLogement($form->get('souhaiteQuitterLogement')->getData())
                 ->setTravailleurSocialPreavisDepart($form->get('preavisDepartDepose')->getData())
-                ->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData());
+                ->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData())
+                ->setTravailleurSocialAccompagnementNomStructure($form->get('accompagnementTravailleurSocialNomStructure')->getData())
+                ->setTravailleurSocialAccompagnementNomReferent($form->get('accompagnementTravailleurSocialNomReferent')->getData())
+                ->setTravailleurSocialAccompagnementPrenomReferent($form->get('accompagnementTravailleurSocialPrenomReferent')->getData());
             $informationComplementaire->setInformationsComplementairesSituationOccupantsTypeAllocation($form->get('typeAllocation')->getData())
                 ->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($form->get('beneficiaireRSA')->getData())
                 ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($form->get('beneficiaireFSL')->getData())

--- a/src/Dto/Api/Request/SignalementRequest.php
+++ b/src/Dto/Api/Request/SignalementRequest.php
@@ -451,6 +451,20 @@ class SignalementRequest implements RequestInterface
     public ?string $accompagnementTravailleurSocialNomStructure = null;
 
     #[OA\Property(
+        description: 'Nom de famille du travailleur social accompagnant.
+                     <br>⚠️Pris en compte uniquement dans le cas où isAccompagnementTravailleurSocial = true.',
+        example: 'Dupont',
+    )]
+    public ?string $accompagnementTravailleurSocialNomReferent = null;
+
+    #[OA\Property(
+        description: 'Prénom du travailleur social accompagnant.
+                     <br>⚠️Pris en compte uniquement dans le cas où isAccompagnementTravailleurSocial = true.',
+        example: 'Dominique',
+    )]
+    public ?string $accompagnementTravailleurSocialPrenomReferent = null;
+
+    #[OA\Property(
         description: 'L\'occupant est-il bénéficiaire du RSA ?',
         example: false,
     )]

--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -446,6 +446,20 @@ class SignalementResponse
     public ?string $nomStructureAccompagnement;
 
     #[OA\Property(
+        description: 'Nom du référent social accompagnant l\'occupant.',
+        example: 'Dupont',
+        nullable: true
+    )]
+    public ?string $nomReferentSocial;
+
+    #[OA\Property(
+        description: 'Prénom du référent social accompagnant l\'occupant.',
+        example: 'Dominique',
+        nullable: true
+    )]
+    public ?string $prenomReferentSocial;
+
+    #[OA\Property(
         description: "Indique si le propriétaire a été averti d'une situation concernant le logement.",
         type: 'boolean',
         example: true,

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -77,6 +77,8 @@ readonly class SituationFoyerRequest implements RequestInterface
         #[Assert\Length(max: 50)]
         private ?string $travailleurSocialAccompagnementDeclarant = null,
         private ?string $travailleurSocialAccompagnementNomStructure = null,
+        private ?string $travailleurSocialAccompagnementNomReferent = null,
+        private ?string $travailleurSocialAccompagnementPrenomReferent = null,
         #[Assert\Choice(
             choices: ['oui', 'non'],
             message: 'Le champ "Bénéficiaire du RSA" est incorrect.',
@@ -151,6 +153,16 @@ readonly class SituationFoyerRequest implements RequestInterface
     public function getTravailleurSocialAccompagnementNomStructure(): ?string
     {
         return $this->travailleurSocialAccompagnementNomStructure;
+    }
+
+    public function getTravailleurSocialAccompagnementNomReferent(): ?string
+    {
+        return $this->travailleurSocialAccompagnementNomReferent;
+    }
+
+    public function getTravailleurSocialAccompagnementPrenomReferent(): ?string
+    {
+        return $this->travailleurSocialAccompagnementPrenomReferent;
     }
 
     public function getBeneficiaireRsa(): ?string

--- a/src/Entity/Model/SituationFoyer.php
+++ b/src/Entity/Model/SituationFoyer.php
@@ -15,7 +15,6 @@ class SituationFoyer
         private ?string $travailleurSocialPreavisDepart = null,
         private ?string $travailleurSocialAccompagnement = null,
         private ?string $travailleurSocialAccompagnementDeclarant = null,
-        private ?string $travailleurSocialAccompagnementNomStructure = null,
     ) {
     }
 
@@ -147,18 +146,6 @@ class SituationFoyer
         return $this;
     }
 
-    public function getTravailleurSocialAccompagnementNomStructure(): ?string
-    {
-        return $this->travailleurSocialAccompagnementNomStructure;
-    }
-
-    public function setTravailleurSocialAccompagnementNomStructure(?string $travailleurSocialAccompagnementNomStructure): self
-    {
-        $this->travailleurSocialAccompagnementNomStructure = $travailleurSocialAccompagnementNomStructure;
-
-        return $this;
-    }
-
     /** @return array<string, mixed> */
     public function toArray(): array
     {
@@ -173,7 +160,6 @@ class SituationFoyer
             'travailleur_social_preavis_depart' => $this->travailleurSocialPreavisDepart,
             'travailleur_social_accompagnement' => $this->travailleurSocialAccompagnement,
             'travailleur_social_accompagnement_declarant' => $this->travailleurSocialAccompagnementDeclarant,
-            'travailleur_social_accompagnement_nom_structure' => $this->travailleurSocialAccompagnementNomStructure,
         ];
     }
 }

--- a/src/Entity/Model/SituationFoyer.php
+++ b/src/Entity/Model/SituationFoyer.php
@@ -15,6 +15,9 @@ class SituationFoyer
         private ?string $travailleurSocialPreavisDepart = null,
         private ?string $travailleurSocialAccompagnement = null,
         private ?string $travailleurSocialAccompagnementDeclarant = null,
+        private ?string $travailleurSocialAccompagnementNomStructure = null,
+        private ?string $travailleurSocialAccompagnementNomReferent = null,
+        private ?string $travailleurSocialAccompagnementPrenomReferent = null,
     ) {
     }
 
@@ -146,6 +149,42 @@ class SituationFoyer
         return $this;
     }
 
+    public function getTravailleurSocialAccompagnementNomStructure(): ?string
+    {
+        return $this->travailleurSocialAccompagnementNomStructure;
+    }
+
+    public function setTravailleurSocialAccompagnementNomStructure(?string $travailleurSocialAccompagnementNomStructure): self
+    {
+        $this->travailleurSocialAccompagnementNomStructure = $travailleurSocialAccompagnementNomStructure;
+
+        return $this;
+    }
+
+    public function getTravailleurSocialAccompagnementNomReferent(): ?string
+    {
+        return $this->travailleurSocialAccompagnementNomReferent;
+    }
+
+    public function setTravailleurSocialAccompagnementNomReferent(?string $travailleurSocialAccompagnementNomReferent): self
+    {
+        $this->travailleurSocialAccompagnementNomReferent = $travailleurSocialAccompagnementNomReferent;
+
+        return $this;
+    }
+
+    public function getTravailleurSocialAccompagnementPrenomReferent(): ?string
+    {
+        return $this->travailleurSocialAccompagnementPrenomReferent;
+    }
+
+    public function setTravailleurSocialAccompagnementPrenomReferent(?string $travailleurSocialAccompagnementPrenomReferent): self
+    {
+        $this->travailleurSocialAccompagnementPrenomReferent = $travailleurSocialAccompagnementPrenomReferent;
+
+        return $this;
+    }
+
     /** @return array<string, mixed> */
     public function toArray(): array
     {
@@ -160,6 +199,9 @@ class SituationFoyer
             'travailleur_social_preavis_depart' => $this->travailleurSocialPreavisDepart,
             'travailleur_social_accompagnement' => $this->travailleurSocialAccompagnement,
             'travailleur_social_accompagnement_declarant' => $this->travailleurSocialAccompagnementDeclarant,
+            'travailleur_social_accompagnement_nom_structure' => $this->travailleurSocialAccompagnementNomStructure,
+            'travailleur_social_accompagnement_nom_referent' => $this->travailleurSocialAccompagnementNomReferent,
+            'travailleur_social_accompagnement_prenom_referent' => $this->travailleurSocialAccompagnementPrenomReferent,
         ];
     }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -419,12 +419,6 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?\DateTimeImmutable $proprioAvertiAt = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    private ?string $nomReferentSocial = null;
-
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    private ?string $structureReferentSocial = null;
-
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Assert\Length(max: 12, maxMessage: 'L\'invariant fiscal ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $numeroInvariant = null;
 
@@ -2050,30 +2044,6 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function setProprioAvertiAt(?\DateTimeImmutable $proprioAvertiAt): static
     {
         $this->proprioAvertiAt = $proprioAvertiAt;
-
-        return $this;
-    }
-
-    public function getNomReferentSocial(): ?string
-    {
-        return $this->nomReferentSocial;
-    }
-
-    public function setNomReferentSocial(?string $nomReferentSocial): static
-    {
-        $this->nomReferentSocial = $nomReferentSocial;
-
-        return $this;
-    }
-
-    public function getStructureReferentSocial(): ?string
-    {
-        return $this->structureReferentSocial;
-    }
-
-    public function setStructureReferentSocial(?string $structureReferentSocial): static
-    {
-        $this->structureReferentSocial = $structureReferentSocial;
 
         return $this;
     }

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -113,6 +113,8 @@ class SignalementUpdatedListener
                 'situationFoyer.travailleur_social_preavis_depart' => 'Préavis de départ déposé',
                 'situationFoyer.travailleur_social_accompagnement' => 'Accompagnement travailleur social',
                 'situationFoyer.travailleur_social_accompagnement_nom_structure' => 'Nom de la structure d\'accompagnement',
+                'situationFoyer.travailleur_social_accompagnement_nom_referent' => 'Nom du référent de la structure d\'accompagnement',
+                'situationFoyer.travailleur_social_accompagnement_prenom_referent' => 'Prénom du référent de la structure d\'accompagnement',
                 'informationComplementaire.informations_complementaires_situation_occupants_beneficiaire_rsa' => 'Bénéficiaire du RSA',
                 'informationComplementaire.informations_complementaires_situation_occupants_beneficiaire_fsl' => 'Bénéficiaire du FSL',
                 'informationComplementaire.informations_complementaires_situation_occupants_revenu_fiscal' => 'Revenu fiscal de référence',

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -8,6 +8,7 @@ use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
 use App\Event\SignalementDraftCompletedEvent;
+use App\Factory\TiersInvitationFactory;
 use App\Manager\SuiviManager;
 use App\Messenger\Message\NewSignalementCheckFileMessage;
 use App\Messenger\Message\SignalementDraftProcessMessage;
@@ -37,6 +38,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
         private readonly ParameterBagInterface $parameterBag,
         private readonly SuiviManager $suiviManager,
         private readonly UserRepository $userRepository,
+        private readonly TiersInvitationFactory $tiersInvitationFactory,
     ) {
     }
 
@@ -73,6 +75,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                     $signalement->getTerritory()->getName()
                 ));
                 $this->sendNotifications($signalement);
+                $this->sendTiersInvitation($signalementDraft, $signalement);
                 $this->createFirstSuivi($signalement);
                 $this->dispatchDraftProcessing($signalementDraft, $signalement);
                 $this->dispatchCheckFiles($signalement);
@@ -106,6 +109,38 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                 )
             );
         }
+    }
+
+    private function sendTiersInvitation(SignalementDraft $signalementDraft, Signalement $signalement): void
+    {
+        $payload = $signalementDraft->getPayload();
+
+        $referentEmail = $payload['travailleur_social_accompagnement_inviter_referent_comme_tiers_email'] ?? null;
+        $referentNom = $payload['travailleur_social_accompagnement_inviter_referent_comme_tiers_nom'] ?? null;
+        $referentPrenom = $payload['travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom'] ?? null;
+
+        if (null === $referentEmail || null === $referentNom || null === $referentPrenom) {
+            return;
+        }
+
+        $invitation = $this->tiersInvitationFactory->createInstanceFrom(
+            $signalement,
+            $referentNom,
+            $referentPrenom,
+            $referentEmail,
+        );
+
+        $this->entityManager->persist($invitation);
+        $this->entityManager->flush();
+
+        $this->notificationMailerRegistry->send(
+            new NotificationMail(
+                type: NotificationMailerType::TYPE_INVITE_TIERS,
+                to: $referentEmail,
+                signalement: $signalement,
+                tiersInvitation: $invitation,
+            )
+        );
     }
 
     private function createFirstSuivi(Signalement $signalement): void

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -119,7 +119,9 @@ readonly class SignalementResponseFactory
         $signalementResponse->souhaiteQuitterLogement = $this->stringToBool($signalement->getSituationFoyer()?->getTravailleurSocialQuitteLogement());
         $signalementResponse->souhaiteQuitterLogementApresTravaux = $this->stringToBool($signalement->getInformationProcedure()?->getInfoProcedureDepartApresTravaux());
         $signalementResponse->suiviParTravailleurSocial = $this->stringToBool($signalement->getSituationFoyer()?->getTravailleurSocialAccompagnement());
-        $signalementResponse->nomStructureAccompagnement = $signalement->getStructureReferentSocial();
+        $signalementResponse->nomStructureAccompagnement = $signalement->getSituationFoyer()?->getTravailleurSocialAccompagnementNomStructure();
+        $signalementResponse->nomReferentSocial = $signalement->getSituationFoyer()?->getTravailleurSocialAccompagnementNomReferent();
+        $signalementResponse->prenomReferentSocial = $signalement->getSituationFoyer()?->getTravailleurSocialAccompagnementPrenomReferent();
         $signalementResponse->proprietaireAverti = $signalement->getIsProprioAverti();
         $signalementResponse->moyenInformationProprietaire = $signalement->getInformationProcedure()?->getInfoProcedureBailMoyen();
         $signalementResponse->dateInformationProprietaire = $signalement->getProprioAvertiAt()?->format('m/Y');

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -119,7 +119,7 @@ readonly class SignalementResponseFactory
         $signalementResponse->souhaiteQuitterLogement = $this->stringToBool($signalement->getSituationFoyer()?->getTravailleurSocialQuitteLogement());
         $signalementResponse->souhaiteQuitterLogementApresTravaux = $this->stringToBool($signalement->getInformationProcedure()?->getInfoProcedureDepartApresTravaux());
         $signalementResponse->suiviParTravailleurSocial = $this->stringToBool($signalement->getSituationFoyer()?->getTravailleurSocialAccompagnement());
-        $signalementResponse->nomStructureAccompagnement = $signalement->getSituationFoyer()?->getTravailleurSocialAccompagnementNomStructure();
+        $signalementResponse->nomStructureAccompagnement = $signalement->getStructureReferentSocial();
         $signalementResponse->proprietaireAverti = $signalement->getIsProprioAverti();
         $signalementResponse->moyenInformationProprietaire = $signalement->getInformationProcedure()?->getInfoProcedureBailMoyen();
         $signalementResponse->dateInformationProprietaire = $signalement->getProprioAvertiAt()?->format('m/Y');

--- a/src/Factory/Signalement/SituationFoyerFactory.php
+++ b/src/Factory/Signalement/SituationFoyerFactory.php
@@ -42,7 +42,6 @@ class SituationFoyerFactory
             travailleurSocialPreavisDepart: $data['travailleur_social_preavis_depart'] ?? null,
             travailleurSocialAccompagnement: $data['travailleur_social_accompagnement'] ?? null,
             travailleurSocialAccompagnementDeclarant: $data['travailleur_social_accompagnement_declarant'] ?? null,
-            travailleurSocialAccompagnementNomStructure: $data['travailleur_social_accompagnement_nom_structure'] ?? null,
         );
     }
 }

--- a/src/Factory/Signalement/SituationFoyerFactory.php
+++ b/src/Factory/Signalement/SituationFoyerFactory.php
@@ -42,6 +42,9 @@ class SituationFoyerFactory
             travailleurSocialPreavisDepart: $data['travailleur_social_preavis_depart'] ?? null,
             travailleurSocialAccompagnement: $data['travailleur_social_accompagnement'] ?? null,
             travailleurSocialAccompagnementDeclarant: $data['travailleur_social_accompagnement_declarant'] ?? null,
+            travailleurSocialAccompagnementNomStructure: $data['travailleur_social_accompagnement_nom_structure'] ?? null,
+            travailleurSocialAccompagnementNomReferent: $data['travailleur_social_accompagnement_nom_referent'] ?? null,
+            travailleurSocialAccompagnementPrenomReferent: $data['travailleur_social_accompagnement_prenom_referent'] ?? null,
         );
     }
 }

--- a/src/Factory/Signalement/SituationFoyerFactory.php
+++ b/src/Factory/Signalement/SituationFoyerFactory.php
@@ -43,8 +43,8 @@ class SituationFoyerFactory
             travailleurSocialAccompagnement: $data['travailleur_social_accompagnement'] ?? null,
             travailleurSocialAccompagnementDeclarant: $data['travailleur_social_accompagnement_declarant'] ?? null,
             travailleurSocialAccompagnementNomStructure: $data['travailleur_social_accompagnement_nom_structure'] ?? null,
-            travailleurSocialAccompagnementNomReferent: $data['travailleur_social_accompagnement_nom_referent'] ?? null,
-            travailleurSocialAccompagnementPrenomReferent: $data['travailleur_social_accompagnement_prenom_referent'] ?? null,
+            travailleurSocialAccompagnementNomReferent: $data['travailleur_social_accompagnement_nom_referent'] ?? $data['travailleur_social_accompagnement_inviter_referent_comme_tiers_nom'] ?? null,
+            travailleurSocialAccompagnementPrenomReferent: $data['travailleur_social_accompagnement_prenom_referent'] ?? $data['travailleur_social_accompagnement_inviter_referent_comme_tiers_prenom'] ?? null,
         );
     }
 }

--- a/src/Factory/SignalementImportFactory.php
+++ b/src/Factory/SignalementImportFactory.php
@@ -88,8 +88,6 @@ class SignalementImportFactory
             ->setIsConstructionAvant1949((bool) $data['isConstructionAvant1949'])
             ->setIsRisqueSurOccupation((bool) $data['isRisqueSurOccupation'])
             ->setProprioAvertiAt($data['prorioAvertiAt'])
-            ->setNomReferentSocial($data['nomReferentSocial'])
-            ->setStructureReferentSocial($data['StructureReferentSocial'])
             ->setNumeroInvariant($data['numeroInvariant'])
             ->setNbPiecesLogement((int) $data['nbPiecesLogement'])
             ->setNbChambresLogement((int) $data['nbChambresLogement'])

--- a/src/Form/SignalementDraftSituationType.php
+++ b/src/Form/SignalementDraftSituationType.php
@@ -45,7 +45,9 @@ class SignalementDraftSituationType extends AbstractType
         $typeAllocation = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsTypeAllocation() : '';
         $montantAllocation = $signalement->getMontantAllocation();
         $accompagnementTravailleurSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnement() : '';
-        $accompagnementTravailleurSocialNomStructure = $signalement->getStructureReferentSocial();
+        $accompagnementTravailleurSocialNomStructure = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomStructure() : '';
+        $accompagnementTravailleurSocialNom = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomReferent() : '';
+        $accompagnementTravailleurSocialPrenom = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementPrenomReferent() : '';
         $beneficiaireRSA = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireRsa() : '';
         $beneficiaireFSL = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireFsl() : '';
         $dateProprietaireAverti = $signalement->getProprioAvertiAt();
@@ -246,6 +248,18 @@ class SignalementDraftSituationType extends AbstractType
                 'required' => false,
                 'mapped' => false,
                 'data' => $accompagnementTravailleurSocialNomStructure,
+            ])
+            ->add('accompagnementTravailleurSocialNomReferent', TextType::class, [
+                'label' => 'Nom du référent social',
+                'required' => false,
+                'mapped' => false,
+                'data' => $accompagnementTravailleurSocialNom,
+            ])
+            ->add('accompagnementTravailleurSocialPrenomReferent', TextType::class, [
+                'label' => 'Prénom du référent social',
+                'required' => false,
+                'mapped' => false,
+                'data' => $accompagnementTravailleurSocialPrenom,
             ])
             ->add('beneficiaireRSA', ChoiceType::class, [
                 'label' => 'Bénéficiaire RSA',

--- a/src/Form/SignalementDraftSituationType.php
+++ b/src/Form/SignalementDraftSituationType.php
@@ -45,7 +45,7 @@ class SignalementDraftSituationType extends AbstractType
         $typeAllocation = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsTypeAllocation() : '';
         $montantAllocation = $signalement->getMontantAllocation();
         $accompagnementTravailleurSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnement() : '';
-        $accompagnementTravailleurSocialNomStructure = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomStructure() : '';
+        $accompagnementTravailleurSocialNomStructure = $signalement->getStructureReferentSocial();
         $beneficiaireRSA = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireRsa() : '';
         $beneficiaireFSL = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireFsl() : '';
         $dateProprietaireAverti = $signalement->getProprioAvertiAt();

--- a/src/Form/SignalementeEditFO/UsagerSituationFoyerType.php
+++ b/src/Form/SignalementeEditFO/UsagerSituationFoyerType.php
@@ -55,7 +55,9 @@ class UsagerSituationFoyerType extends AbstractType
         $souhaiteQuitterLogement = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialQuitteLogement() : '';
         $preavisDepartDepose = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialPreavisDepart() : '';
         $accompagnementTravailleurSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnement() : '';
-        $accompagnementTravailleurSocialNomStructure = $signalement->getStructureReferentSocial();
+        $structureReferentSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomStructure() : '';
+        $nomReferentSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomReferent() : '';
+        $prenomReferentSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementPrenomReferent() : '';
 
         $beneficiaireRSA = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireRsa() : '';
         $beneficiaireFSL = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireFsl() : '';
@@ -214,11 +216,37 @@ class UsagerSituationFoyerType extends AbstractType
                 'help' => 'Format attendu : 255 caractères maximum',
                 'required' => false,
                 'mapped' => false,
-                'data' => $accompagnementTravailleurSocialNomStructure,
+                'data' => $structureReferentSocial,
                 'constraints' => [
                     new Assert\Length(
                         max: 255,
                         maxMessage: 'Le nom de la structure d\'accompagnement doit comporter au maximum {{ limit }} caractères.',
+                    ),
+                ],
+            ])
+            ->add('accompagnementTravailleurSocialNomReferent', TextType::class, [
+                'label' => 'Nom du référent social (facultatif)',
+                'help' => 'Format attendu : 255 caractères maximum',
+                'required' => false,
+                'mapped' => false,
+                'data' => $nomReferentSocial,
+                'constraints' => [
+                    new Assert\Length(
+                        max: 255,
+                        maxMessage: 'Le nom du référent social doit comporter au maximum {{ limit }} caractères.',
+                    ),
+                ],
+            ])
+            ->add('accompagnementTravailleurSocialPrenomReferent', TextType::class, [
+                'label' => 'Prénom du référent social (facultatif)',
+                'help' => 'Format attendu : 255 caractères maximum',
+                'required' => false,
+                'mapped' => false,
+                'data' => $prenomReferentSocial,
+                'constraints' => [
+                    new Assert\Length(
+                        max: 255,
+                        maxMessage: 'Le prénom du référent social doit comporter au maximum {{ limit }} caractères.',
                     ),
                 ],
             ])

--- a/src/Form/SignalementeEditFO/UsagerSituationFoyerType.php
+++ b/src/Form/SignalementeEditFO/UsagerSituationFoyerType.php
@@ -55,7 +55,7 @@ class UsagerSituationFoyerType extends AbstractType
         $souhaiteQuitterLogement = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialQuitteLogement() : '';
         $preavisDepartDepose = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialPreavisDepart() : '';
         $accompagnementTravailleurSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnement() : '';
-        $accompagnementTravailleurSocialNomStructure = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomStructure() : '';
+        $accompagnementTravailleurSocialNomStructure = $signalement->getStructureReferentSocial();
 
         $beneficiaireRSA = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireRsa() : '';
         $beneficiaireFSL = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireFsl() : '';

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -790,10 +790,8 @@ class SignalementManager
             ->setTravailleurSocialAccompagnement(
                 $situationFoyerRequest->getTravailleurSocialAccompagnement()
             )
-            ->setTravailleurSocialAccompagnementNomStructure(
-                $situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure()
-            )
             ->setLogementSocialAllocationCaisse($situationFoyerRequest->getIsAllocataire());
+        $signalement->setStructureReferentSocial($situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure());
 
         if ('non' === $situationFoyerRequest->getTravailleurSocialPreavisDepart()) {
             $signalement->setIsPreavisDepart(false);

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -793,11 +793,11 @@ class SignalementManager
                 $situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure()
             )
              ->setTravailleurSocialAccompagnementNomReferent(
-                $situationFoyerRequest->getTravailleurSocialAccompagnementNomReferent()
-            )
+                 $situationFoyerRequest->getTravailleurSocialAccompagnementNomReferent()
+             )
              ->setTravailleurSocialAccompagnementPrenomReferent(
-                $situationFoyerRequest->getTravailleurSocialAccompagnementPrenomReferent()
-            );
+                 $situationFoyerRequest->getTravailleurSocialAccompagnementPrenomReferent()
+             );
 
         if ('non' === $situationFoyerRequest->getTravailleurSocialPreavisDepart()) {
             $signalement->setIsPreavisDepart(false);

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -180,8 +180,6 @@ class SignalementManager
             ->setIsConstructionAvant1949((bool) $data['isConstructionAvant1949'])
             ->setIsRisqueSurOccupation((bool) $data['isRisqueSurOccupation'])
             ->setProprioAvertiAt($data['prorioAvertiAt'])
-            ->setNomReferentSocial($data['nomReferentSocial'])
-            ->setStructureReferentSocial($data['StructureReferentSocial'])
             ->setNumeroInvariant($data['numeroInvariant'])
             ->setNbPiecesLogement((int) $data['nbPiecesLogement'])
             ->setNbChambresLogement((int) $data['nbChambresLogement'])
@@ -790,8 +788,16 @@ class SignalementManager
             ->setTravailleurSocialAccompagnement(
                 $situationFoyerRequest->getTravailleurSocialAccompagnement()
             )
-            ->setLogementSocialAllocationCaisse($situationFoyerRequest->getIsAllocataire());
-        $signalement->setStructureReferentSocial($situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure());
+            ->setLogementSocialAllocationCaisse($situationFoyerRequest->getIsAllocataire())
+            ->setTravailleurSocialAccompagnementNomStructure(
+                $situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure()
+            )
+             ->setTravailleurSocialAccompagnementNomReferent(
+                $situationFoyerRequest->getTravailleurSocialAccompagnementNomReferent()
+            )
+             ->setTravailleurSocialAccompagnementPrenomReferent(
+                $situationFoyerRequest->getTravailleurSocialAccompagnementPrenomReferent()
+            );
 
         if ('non' === $situationFoyerRequest->getTravailleurSocialPreavisDepart()) {
             $signalement->setIsPreavisDepart(false);

--- a/src/Service/Signalement/SignalementApiFactory.php
+++ b/src/Service/Signalement/SignalementApiFactory.php
@@ -155,7 +155,9 @@ class SignalementApiFactory
         }
 
         $situationFoyer->setTravailleurSocialAccompagnement(self::convertBoolToString($request->isAccompagnementTravailleurSocial));
-        $signalement->setStructureReferentSocial($request->accompagnementTravailleurSocialNomStructure);
+        $situationFoyer->setTravailleurSocialAccompagnementNomStructure($request->accompagnementTravailleurSocialNomStructure);
+        $situationFoyer->setTravailleurSocialAccompagnementNomReferent($request->accompagnementTravailleurSocialNomReferent);
+        $situationFoyer->setTravailleurSocialAccompagnementPrenomReferent($request->accompagnementTravailleurSocialPrenomReferent);
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireRsa(self::convertBoolToString($request->isBeneficiaireRsa));
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireFsl(self::convertBoolToString($request->isBeneficiaireFsl));
 

--- a/src/Service/Signalement/SignalementApiFactory.php
+++ b/src/Service/Signalement/SignalementApiFactory.php
@@ -155,7 +155,7 @@ class SignalementApiFactory
         }
 
         $situationFoyer->setTravailleurSocialAccompagnement(self::convertBoolToString($request->isAccompagnementTravailleurSocial));
-        $situationFoyer->setTravailleurSocialAccompagnementNomStructure($request->accompagnementTravailleurSocialNomStructure);
+        $signalement->setStructureReferentSocial($request->accompagnementTravailleurSocialNomStructure);
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireRsa(self::convertBoolToString($request->isBeneficiaireRsa));
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireFsl(self::convertBoolToString($request->isBeneficiaireFsl));
 

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -230,7 +230,7 @@ class SignalementBoManager
         $signalement->setMontantAllocation((int) $form->get('montantAllocation')->getData());
         $situationFoyer->setLogementSocialMontantAllocation($form->get('montantAllocation')->getData());
         $situationFoyer->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData());
-        $situationFoyer->setTravailleurSocialAccompagnementNomStructure($form->get('accompagnementTravailleurSocialNomStructure')->getData());
+        $signalement->setStructureReferentSocial($form->get('accompagnementTravailleurSocialNomStructure')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($form->get('beneficiaireRSA')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($form->get('beneficiaireFSL')->getData());
         if (!empty($form->get('dateProprietaireAverti')->getData())) {

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -230,7 +230,9 @@ class SignalementBoManager
         $signalement->setMontantAllocation((int) $form->get('montantAllocation')->getData());
         $situationFoyer->setLogementSocialMontantAllocation($form->get('montantAllocation')->getData());
         $situationFoyer->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData());
-        $signalement->setStructureReferentSocial($form->get('accompagnementTravailleurSocialNomStructure')->getData());
+        $situationFoyer->setTravailleurSocialAccompagnementNomStructure($form->get('accompagnementTravailleurSocialNomStructure')->getData());
+        $situationFoyer->setTravailleurSocialAccompagnementNomReferent($form->get('accompagnementTravailleurSocialNomReferent')->getData());
+        $situationFoyer->setTravailleurSocialAccompagnementPrenomReferent($form->get('accompagnementTravailleurSocialPrenomReferent')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($form->get('beneficiaireRSA')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($form->get('beneficiaireFSL')->getData());
         if (!empty($form->get('dateProprietaireAverti')->getData())) {

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -134,7 +134,17 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementNomStructure">Nom de la structure d'accompagnement</label>
-                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNomStructure" name="travailleurSocialAccompagnementNomStructure" value="{{ signalement.structureReferentSocial }}">
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNomStructure" name="travailleurSocialAccompagnementNomStructure" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementNomStructure : '' }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementNom">Nom de famille du travailleur social</label>
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNom" name="travailleurSocialAccompagnementNomReferentSocial" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementNomReferent : '' }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementPrenom">Prénom du travailleur social</label>
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementPrenom" name="travailleurSocialAccompagnementPrenomReferentSocial" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementPrenomReferent : '' }}">
                             </div>
 
                             <div class="fr-select-group">

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -138,13 +138,13 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementNom">Nom de famille du travailleur social</label>
-                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNom" name="travailleurSocialAccompagnementNomReferentSocial" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementNomReferent : '' }}">
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementNomReferent">Nom de famille du travailleur social</label>
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNomReferent" name="travailleurSocialAccompagnementNomReferent" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementNomReferent : '' }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementPrenom">Prénom du travailleur social</label>
-                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementPrenom" name="travailleurSocialAccompagnementPrenomReferentSocial" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementPrenomReferent : '' }}">
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementPrenomReferent">Prénom du travailleur social</label>
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementPrenomReferent" name="travailleurSocialAccompagnementPrenomReferent" value="{{ signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementPrenomReferent : '' }}">
                             </div>
 
                             <div class="fr-select-group">

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -133,9 +133,8 @@
                             </div>
 
                             <div class="fr-input-group">
-                                {% set travailleurSocialAccompagnementNomStructure = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementNomStructure : null %}
                                 <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementNomStructure">Nom de la structure d'accompagnement</label>
-                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNomStructure" name="travailleurSocialAccompagnementNomStructure" value="{{ travailleurSocialAccompagnementNomStructure }}">
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNomStructure" name="travailleurSocialAccompagnementNomStructure" value="{{ signalement.structureReferentSocial }}">
                             </div>
 
                             <div class="fr-select-group">

--- a/templates/back/signalement/view/information/information-situation-foyer.html.twig
+++ b/templates/back/signalement/view/information/information-situation-foyer.html.twig
@@ -105,7 +105,11 @@
     {% if structureAccompagnement %}
         <div class="fr-col-12 fr-col-md-6">
             <strong>Nom de la structure d'accompagnement :</strong>
-            {{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
+            {{ signalement.structureReferentSocial }}
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Nom du ou de la travailleuse sociale :</strong>
+            {{ signalement.nomReferentSocial }}
         </div>
     {% endif %}
     <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement/view/information/information-situation-foyer.html.twig
+++ b/templates/back/signalement/view/information/information-situation-foyer.html.twig
@@ -105,11 +105,11 @@
     {% if structureAccompagnement %}
         <div class="fr-col-12 fr-col-md-6">
             <strong>Nom de la structure d'accompagnement :</strong>
-            {{ signalement.structureReferentSocial }}
+            {{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
         </div>
         <div class="fr-col-12 fr-col-md-6">
-            <strong>Nom du ou de la travailleuse sociale :</strong>
-            {{ signalement.nomReferentSocial }}
+            <strong>Prénom et nom du ou de la travailleuse sociale :</strong>
+            {{ signalement.situationFoyer.travailleurSocialAccompagnementPrenomReferent }} {{ signalement.situationFoyer.travailleurSocialAccompagnementNomReferent }}
         </div>
     {% endif %}
     <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -65,6 +65,12 @@
                 {{ form_row(formSituation.accompagnementTravailleurSocialNomStructure) }}
             </div>
             <div class="fr-fieldset__element">
+                {{ form_row(formSituation.accompagnementTravailleurSocialNomReferent) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formSituation.accompagnementTravailleurSocialPrenomReferent) }}
+            </div>
+            <div class="fr-fieldset__element">
                 {{ form_row(formSituation.beneficiaireRSA) }}
             </div>
             <div class="fr-fieldset__element">

--- a/templates/front/edit-signalement/situation-foyer.html.twig
+++ b/templates/front/edit-signalement/situation-foyer.html.twig
@@ -83,6 +83,12 @@
 					{{ form_row(form.accompagnementTravailleurSocialNomStructure) }}
 				</div>
 				<div class="fr-fieldset__element">
+					{{ form_row(form.accompagnementTravailleurSocialNomReferent) }}
+				</div>
+				<div class="fr-fieldset__element">
+					{{ form_row(form.accompagnementTravailleurSocialPrenomReferent) }}
+				</div>
+				<div class="fr-fieldset__element">
 					{{ form_row(form.departApresTravaux) }}
 				</div>
 			</fieldset>

--- a/templates/front/suivi_signalement_dossier.html.twig
+++ b/templates/front/suivi_signalement_dossier.html.twig
@@ -806,9 +806,12 @@
 								{{signalement.situationFoyer.travailleurSocialAccompagnement(false)|capitalize}}
 							</li>
 						{% endif %}
-						{% if signalement.situationFoyer.travailleurSocialAccompagnement(false) is same as 'oui' and signalement.structureReferentSocial %}
+						{% if signalement.situationFoyer.travailleurSocialAccompagnement(false) is same as 'oui' %}
 							<li>Nom de la structure d'accompagnement :
-								{{ signalement.structureReferentSocial }}
+								{{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
+							</li>
+							<li>Prénom et nom du ou de la travailleuse sociale :
+								{{ signalement.situationFoyer.travailleurSocialAccompagnementPrenomReferent }} {{ signalement.situationFoyer.travailleurSocialAccompagnementNomReferent }}
 							</li>
 						{% endif %}
 					{% endif %}

--- a/templates/front/suivi_signalement_dossier.html.twig
+++ b/templates/front/suivi_signalement_dossier.html.twig
@@ -806,9 +806,9 @@
 								{{signalement.situationFoyer.travailleurSocialAccompagnement(false)|capitalize}}
 							</li>
 						{% endif %}
-						{% if signalement.situationFoyer.travailleurSocialAccompagnement(false) is same as 'oui' and signalement.situationFoyer.travailleurSocialAccompagnementNomStructure %}
+						{% if signalement.situationFoyer.travailleurSocialAccompagnement(false) is same as 'oui' and signalement.structureReferentSocial %}
 							<li>Nom de la structure d'accompagnement :
-								{{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
+								{{ signalement.structureReferentSocial }}
 							</li>
 						{% endif %}
 					{% endif %}

--- a/tests/Functional/Controller/Api/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementCreateControllerTest.php
@@ -116,8 +116,8 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertEquals($signalement->getMontantAllocation(), $payload['montantAllocation']);
         $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnement(), 'oui');
         $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementNomStructure(), $payload['accompagnementTravailleurSocialNomStructure']);
-        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementNomReferent(), $payload['accompagnementTravailleurSocialNom']);
-        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementPrenomReferent(), $payload['accompagnementTravailleurSocialPrenom']);
+        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementNomReferent(), $payload['accompagnementTravailleurSocialNomReferent']);
+        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementPrenomReferent(), $payload['accompagnementTravailleurSocialPrenomReferent']);
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsBeneficiaireRsa(), 'non');
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsBeneficiaireFsl(), 'non');
         $this->assertEquals($signalement->getIsProprioAverti(), $payload['isBailleurAverti']);

--- a/tests/Functional/Controller/Api/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementCreateControllerTest.php
@@ -115,7 +115,7 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsTypeAllocation(), mb_strtolower($payload['typeAllocation']));
         $this->assertEquals($signalement->getMontantAllocation(), $payload['montantAllocation']);
         $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnement(), 'oui');
-        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementNomStructure(), $payload['accompagnementTravailleurSocialNomStructure']);
+        $this->assertEquals($signalement->getStructureReferentSocial(), $payload['accompagnementTravailleurSocialNomStructure']);
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsBeneficiaireRsa(), 'non');
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsBeneficiaireFsl(), 'non');
         $this->assertEquals($signalement->getIsProprioAverti(), $payload['isBailleurAverti']);

--- a/tests/Functional/Controller/Api/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementCreateControllerTest.php
@@ -115,7 +115,9 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsTypeAllocation(), mb_strtolower($payload['typeAllocation']));
         $this->assertEquals($signalement->getMontantAllocation(), $payload['montantAllocation']);
         $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnement(), 'oui');
-        $this->assertEquals($signalement->getStructureReferentSocial(), $payload['accompagnementTravailleurSocialNomStructure']);
+        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementNomStructure(), $payload['accompagnementTravailleurSocialNomStructure']);
+        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementNomReferent(), $payload['accompagnementTravailleurSocialNom']);
+        $this->assertEquals($situationFoyer->getTravailleurSocialAccompagnementPrenomReferent(), $payload['accompagnementTravailleurSocialPrenom']);
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsBeneficiaireRsa(), 'non');
         $this->assertEquals($informationComplementaire->getInformationsComplementairesSituationOccupantsBeneficiaireFsl(), 'non');
         $this->assertEquals($signalement->getIsProprioAverti(), $payload['isBailleurAverti']);
@@ -544,6 +546,8 @@ class SignalementCreateControllerTest extends WebTestCase
             "montantAllocation": 250.75,
             "isAccompagnementTravailleurSocial": true,
             "accompagnementTravailleurSocialNomStructure": "CCAS de Montpellier",
+            "accompagnementTravailleurSocialPrenomReferent": "Marie",
+            "accompagnementTravailleurSocialNomReferent": "Dubois",
             "isBeneficiaireRsa": false,
             "isBeneficiaireFsl": false,
             "isBailleurAverti": true,

--- a/tests/Unit/Dto/Request/Signalement/SituationFoyerRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SituationFoyerRequestTest.php
@@ -30,6 +30,8 @@ class SituationFoyerRequestTest extends KernelTestCase
             travailleurSocialAccompagnement: 'oui',
             travailleurSocialAccompagnementDeclarant: '1',
             travailleurSocialAccompagnementNomStructure: 'Organisme Exemple',
+            travailleurSocialAccompagnementNomReferent: 'Yorn',
+            travailleurSocialAccompagnementPrenomReferent: 'Pete',
             beneficiaireRsa: 'oui',
             beneficiaireFsl: 'non',
             revenuFiscal: '20000'
@@ -46,6 +48,8 @@ class SituationFoyerRequestTest extends KernelTestCase
         $this->assertSame('oui', $situationFoyerRequest->getTravailleurSocialAccompagnement());
         $this->assertSame('1', $situationFoyerRequest->getTravailleurSocialAccompagnementDeclarant());
         $this->assertSame('Organisme Exemple', $situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure());
+        $this->assertSame('Yorn', $situationFoyerRequest->getTravailleurSocialAccompagnementNomReferent());
+        $this->assertSame('Pete', $situationFoyerRequest->getTravailleurSocialAccompagnementPrenomReferent());
         $this->assertSame('oui', $situationFoyerRequest->getBeneficiaireRsa());
         $this->assertSame('non', $situationFoyerRequest->getBeneficiaireFsl());
         $this->assertSame('20000', $situationFoyerRequest->getRevenuFiscal());

--- a/tests/Unit/Factory/SignalementFactoryTest.php
+++ b/tests/Unit/Factory/SignalementFactoryTest.php
@@ -180,8 +180,6 @@ class SignalementFactoryTest extends KernelTestCase
         $this->assertEquals($data['codeProcedure'], $signalement->getCodeProcedure());
         $this->assertEquals($data['raisonRefusIntervention'], $signalement->getRaisonRefusIntervention());
 
-        $this->assertEquals($data['nomReferentSocial'], $signalement->getNomReferentSocial());
-        $this->assertEquals($data['StructureReferentSocial'], $signalement->getStructureReferentSocial());
         $this->assertEquals([$data['mailOccupant'], $data['mailDeclarant']], $signalement->getMailUsagers());
         $this->assertTrue($signalement->getIsImported());
 


### PR DESCRIPTION
## Ticket

#5857   

## Description
Dans le formulaire de signalement usager, enregistrement du nom du travailleur social
Pour une déclaration faite par un occupant (bailleur ou locataire), il a la possibilité d'ajouter le référent en tant que tiers déclarant

## Changements apportés
* Suppression de deux champs `structure_referent_social` et `nom_referent_social` pas vraiment utilisés (et migration préalable car on en avait 4 dans des vieux signalements)
* Création de signalement FO :
  * ajout du prénom / nom du référent pour tous les profils sauf secours
  * ajout du mail du référent pour les locataires et propriétaires occupants
* Création de signalement BO : ajout du prénom / nom du référent
* Dans la fiche BO : affichage et édition du prénom / nom du référent
* Fiche de suivi usager : affichage et édition du prénom / nom du référent
* API : ajout du prénom / nom du référent
* Suppression de la prise en compte dans l'import de signalement

## Pré-requis
`make npm-watch`
`make execute-migration name=Version20260512153353 direction=up`

## Tests
- [ ] Faire différents signalements FO avec différents profils, et différents scénarii d'invitation ou non
  - [ ] Vérifier le mail d'invitation ou non
  - [ ] Vérifier les informations enregistrées et affichées
- [ ] Vérifier la création de signalement BO
- [ ] Vérifier l'affichage et l'édition dans la fiche BO
- [ ] Vérifier l'affichage et l'édition dans la fiche suivi usager
- [ ] Vérifier l'utilisation dans l'API
