### PR TITLE
[BO - Liste Signalements] Ancrer la liste

### DIFF
--- a/assets/scripts/vue/components/signalement-view/components/SignalementListCards.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementListCards.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-grid-row fr-my-2w" v-for=" (item, index) in list" :key="index">
+  <div class="fr-grid-row fr-my-2w" v-for=" (item, index) in list" :key="index" :data-signalement-uuid="item.uuid">
     <div class="fr-col-12">
       <div class="fr-card" :class="{ 'card-signalement--new': item.statut === 'NEED_VALIDATION' }">
         <div class="fr-card__body">
@@ -82,7 +82,7 @@
                           class="fr-btn fr-btn--icon-left fr-btn--secondary fr-mx-1w fr-icon-delete-line">
                     Supprimer le signalement
                   </button>
-                  <a :href="`/bo/signalements/${item.uuid}`" class="fr-btn fr-btn--icon-right fr-icon-arrow-right-line fr-mx-1w">
+                  <a :href="`/bo/signalements/${item.uuid}`" @click="saveScrollPosition(item)" class="fr-btn fr-btn--icon-right fr-icon-arrow-right-line fr-mx-1w">
                     Accéder au dossier
                   </a>
                 </div>
@@ -156,6 +156,9 @@ export default defineComponent({
       sharedProps: store.props,
       selectedItem: null as SignalementItem | null
     }
+  },
+  mounted () {
+    this.restoreScrollPosition()
   },
   methods: {
     formatDate (dateString: string | null): string {
@@ -270,6 +273,26 @@ export default defineComponent({
     },
     emitDeleteSignalementItem(item: SignalementItem|null) {
       this.$emit('deleteSignalementItem', item);
+    },
+    saveScrollPosition (item: SignalementItem) {
+      sessionStorage.setItem('signalement_list_clicked_uuid', item.uuid)
+      sessionStorage.setItem('signalement_list_scroll_y', window.scrollY.toString()) // fallback
+    },
+    restoreScrollPosition () {
+      const uuid = sessionStorage.getItem('signalement_list_clicked_uuid')
+      const scrollY = sessionStorage.getItem('signalement_list_scroll_y')
+      if (uuid) {
+        this.$nextTick(() => {
+          const element = document.querySelector(`[data-signalement-uuid="${uuid}"]`)
+          if (element) {
+            element.scrollIntoView({ block: 'center' })
+          } else if (scrollY) { // fallback
+            window.scrollTo(0, Number(scrollY))
+          }
+          sessionStorage.removeItem('signalement_list_scroll_y')
+          sessionStorage.removeItem('signalement_list_clicked_uuid')
+        })
+      }
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-view/components/SignalementListCards.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementListCards.vue
@@ -276,20 +276,15 @@ export default defineComponent({
     },
     saveScrollPosition (item: SignalementItem) {
       sessionStorage.setItem('signalement_list_clicked_uuid', item.uuid)
-      sessionStorage.setItem('signalement_list_scroll_y', window.scrollY.toString()) // fallback
     },
     restoreScrollPosition () {
       const uuid = sessionStorage.getItem('signalement_list_clicked_uuid')
-      const scrollY = sessionStorage.getItem('signalement_list_scroll_y')
       if (uuid) {
         this.$nextTick(() => {
           const element = document.querySelector(`[data-signalement-uuid="${uuid}"]`)
           if (element) {
             element.scrollIntoView({ block: 'center' })
-          } else if (scrollY) { // fallback
-            window.scrollTo(0, Number(scrollY))
           }
-          sessionStorage.removeItem('signalement_list_scroll_y')
           sessionStorage.removeItem('signalement_list_clicked_uuid')
         })
       }


### PR DESCRIPTION
## Ticket

#5866

## Description
Sauvegarder le signalement cliqué et la position de scroll afin de restaurer l’état de navigation lors du retour depuis la fiche signalement via le fil d’Ariane.

## Changements apportés
* Mise à jour du composant carte pour sauvegarder l’UUID et le scroll verticale du signalement cliqué dans le `sessionStorage` pour limiter les sauvegarde à l'onglet plutôt qu'au navigateur

## Pré-requis
`make npm-watch`

## Tests
- [ ] Depuis un listing, filtré ou non, ouvrir un signalement puis revenir à la liste via le fil d’Ariane et vérifier que le scroll revient sur le signalement précédemment cliqué
- [ ] Depuis une liste filtrée sur les nouveaux signalements, ouvrir un signalement, le refuser, puis revenir via le fil d’Ariane
- [ ] Vérifier que le fallback sur la position de scroll est utilisé lorsque le signalement n’est plus présent dans la liste  (Avoir une liste filtrée sur nouveau, sélectionné un signalement, le refuser et revenir via le fil d’Ariane)
