### PR TITLE
[BO] Activer le plugin heatmap sur formulaire FO

### DIFF
--- a/assets/scripts/vanilla/services/cookie/cookie_matomo_tracking.js
+++ b/assets/scripts/vanilla/services/cookie/cookie_matomo_tracking.js
@@ -16,6 +16,8 @@
 /* global _paq */
 
 export function enableMatomoTracking() {
+  _paq.push(['setConsentGiven']);
+  _paq.push(['HeatmapSessionRecording::enable']);
   _paq.push(['rememberConsentGiven']);
 }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -76,6 +76,10 @@
             {% endif %}
             _paq.push(['trackPageView']);
             _paq.push(['enableLinkTracking']);
+            if (document.cookie.split(';').some((item) => item.trim().startsWith('cookieConsent=true'))) {
+                _paq.push(['setConsentGiven']);
+                _paq.push(['HeatmapSessionRecording::enable']);
+            }
             (function() {
                 var u="{{ matomo.url }}";
                 _paq.push(['setTrackerUrl', u+'matomo.php']);

--- a/templates/service_secours/base.html.twig
+++ b/templates/service_secours/base.html.twig
@@ -34,6 +34,10 @@
             {% endif %}
             _paq.push(['trackPageView']);
             _paq.push(['enableLinkTracking']);
+            if (document.cookie.split(';').some((item) => item.trim().startsWith('cookieConsent=true'))) {
+                _paq.push(['setConsentGiven']);
+                _paq.push(['HeatmapSessionRecording::enable']);
+            }
             (function() {
                 var u="{{ matomo.url }}";
                 _paq.push(['setTrackerUrl', u+'matomo.php']);


### PR DESCRIPTION
## Ticket

#5718    

## Description
Activer le plugin carte de chaleur

## Changements apportés
* Activer le plugin lors de l'acceptation
* Activer le plugin pour ceux qui ont déjà accepté 

## Pré-requis
<img width="1405" height="928" alt="image" src="https://github.com/user-attachments/assets/f6cfbc22-c8af-4d7e-919a-a86b1db53e70" />

J'ai pas réussi à teste le plugin en local apparemment impossible pour les plugins premium malgré vérfier qu'il la console navigateur ne renvoie pas d'erreur

- Activer matomo `MATOMO_ENABLE=1`
- Démarrer le container make tools-run 
- Mettre à jour les CSP
    - Remplacer https://stats.beta.gouv.fr par http://localhost:8083
    - Remplacer https://stats.beta.gouv.fr/matomo.js par http://localhost:8083/matomo.js

## Tests
- [ ] CI OK 
- [ ] Aucune console erreur OK
