### PR TITLE
[Historique des affectation] Améliorer le regroupement par partenaire

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -193,40 +193,40 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     workflows?: bool|array{
  *         enabled?: bool|Param, // Default: false
  *         workflows?: array<string, array{ // Default: []
- *             audit_trail?: bool|array{
- *                 enabled?: bool|Param, // Default: false
- *             },
- *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
- *             marking_store?: array{
- *                 type?: "method"|Param,
- *                 property?: scalar|Param|null,
- *                 service?: scalar|Param|null,
- *             },
- *             supports?: string|list<scalar|Param|null>,
- *             definition_validators?: list<scalar|Param|null>,
- *             support_strategy?: scalar|Param|null,
- *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
- *             events_to_dispatch?: null|list<string|Param>,
- *             places?: string|list<array{ // Default: []
- *                 name?: scalar|Param|null,
+ *                 audit_trail?: bool|array{
+ *                     enabled?: bool|Param, // Default: false
+ *                 },
+ *                 type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
+ *                 marking_store?: array{
+ *                     type?: "method"|Param,
+ *                     property?: scalar|Param|null,
+ *                     service?: scalar|Param|null,
+ *                 },
+ *                 supports?: string|list<scalar|Param|null>,
+ *                 definition_validators?: list<scalar|Param|null>,
+ *                 support_strategy?: scalar|Param|null,
+ *                 initial_marking?: backed-enum|string|list<scalar|Param|null>,
+ *                 events_to_dispatch?: null|list<string|Param>,
+ *                 places?: string|list<array{ // Default: []
+ *                         name?: scalar|Param|null,
+ *                         metadata?: array<string, mixed>,
+ *                     }>,
+ *                 transitions?: list<array{ // Default: []
+ *                         name?: string|Param,
+ *                         guard?: string|Param, // An expression to block the transition.
+ *                         from?: backed-enum|string|list<array{ // Default: []
+ *                                 place?: string|Param,
+ *                                 weight?: int|Param, // Default: 1
+ *                             }>,
+ *                         to?: backed-enum|string|list<array{ // Default: []
+ *                                 place?: string|Param,
+ *                                 weight?: int|Param, // Default: 1
+ *                             }>,
+ *                         weight?: int|Param, // Default: 1
+ *                         metadata?: array<string, mixed>,
+ *                     }>,
  *                 metadata?: array<string, mixed>,
  *             }>,
- *             transitions?: list<array{ // Default: []
- *                 name?: string|Param,
- *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: \BackedEnum|string|list<array{ // Default: []
- *                     place?: string|Param,
- *                     weight?: int|Param, // Default: 1
- *                 }>,
- *                 to?: \BackedEnum|string|list<array{ // Default: []
- *                     place?: string|Param,
- *                     weight?: int|Param, // Default: 1
- *                 }>,
- *                 weight?: int|Param, // Default: 1
- *                 metadata?: array<string, mixed>,
- *             }>,
- *             metadata?: array<string, mixed>,
- *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
  *         enabled?: bool|Param, // Default: false
@@ -273,14 +273,14 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         base_path?: scalar|Param|null, // Default: ""
  *         base_urls?: string|list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
- *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|Param|null, // Default: null
- *             version?: scalar|Param|null,
- *             version_format?: scalar|Param|null, // Default: null
- *             json_manifest_path?: scalar|Param|null, // Default: null
- *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: string|list<scalar|Param|null>,
- *         }>,
+ *                 strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *                 version_strategy?: scalar|Param|null, // Default: null
+ *                 version?: scalar|Param|null,
+ *                 version_format?: scalar|Param|null, // Default: null
+ *                 json_manifest_path?: scalar|Param|null, // Default: null
+ *                 base_path?: scalar|Param|null, // Default: ""
+ *                 base_urls?: string|list<scalar|Param|null>,
+ *             }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
@@ -318,16 +318,16 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             localizable_html_attributes?: list<scalar|Param|null>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             domains?: list<scalar|Param|null>,
- *             locales?: list<scalar|Param|null>,
- *         }>,
+ *                 dsn?: scalar|Param|null,
+ *                 domains?: list<scalar|Param|null>,
+ *                 locales?: list<scalar|Param|null>,
+ *             }>,
  *         globals?: array<string, string|array{ // Default: []
- *             value?: mixed,
- *             message?: string|Param,
- *             parameters?: array<string, scalar|Param|null>,
- *             domain?: string|Param,
- *         }>,
+ *                 value?: mixed,
+ *                 message?: string|Param,
+ *                 parameters?: array<string, scalar|Param|null>,
+ *                 domain?: string|Param,
+ *             }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
@@ -345,8 +345,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         disable_translation?: bool|Param, // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|Param|null>,
- *         }>,
+ *                 services?: list<scalar|Param|null>,
+ *             }>,
  *     },
  *     annotations?: bool|array{
  *         enabled?: bool|Param, // Default: false
@@ -362,11 +362,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         default_context?: array<string, mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|Param|null,
- *             default_context?: array<string, mixed>,
- *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
- *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
- *         }>,
+ *                 name_converter?: scalar|Param|null,
+ *                 default_context?: array<string, mixed>,
+ *                 include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
+ *                 include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
+ *             }>,
  *     },
  *     property_access?: bool|array{ // Property access configuration
  *         enabled?: bool|Param, // Default: true
@@ -396,24 +396,24 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
  *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: string|list<scalar|Param|null>,
- *             tags?: scalar|Param|null, // Default: null
- *             public?: bool|Param, // Default: false
- *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
- *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|Param|null,
- *             clearer?: scalar|Param|null,
- *         }>,
+ *                 adapters?: string|list<scalar|Param|null>,
+ *                 tags?: scalar|Param|null, // Default: null
+ *                 public?: bool|Param, // Default: false
+ *                 default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
+ *                 provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
+ *                 early_expiration_message_bus?: scalar|Param|null,
+ *                 clearer?: scalar|Param|null,
+ *             }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
  *         log?: mixed, // Use the application logger instead of the PHP logger for logging PHP errors. // Default: true
  *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
- *     }>,
+ *             log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
+ *             status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *             log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         }>,
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: true
  *     },
@@ -428,8 +428,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: true
  *         routing?: array<string, string|array{ // Default: []
- *             senders?: list<scalar|Param|null>,
- *         }>,
+ *                 senders?: list<scalar|Param|null>,
+ *             }>,
  *         serializer?: array{
  *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
@@ -438,37 +438,37 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
- *             options?: array<string, mixed>,
- *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *             retry_strategy?: string|array{
- *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
- *                 max_retries?: int|Param, // Default: 3
- *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
- *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
- *             },
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
- *         }>,
+ *                 dsn?: scalar|Param|null,
+ *                 serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
+ *                 options?: array<string, mixed>,
+ *                 failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *                 retry_strategy?: string|array{
+ *                     service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                     max_retries?: int|Param, // Default: 3
+ *                     delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                     multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
+ *                     max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                     jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
+ *                 },
+ *                 rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *             }>,
  *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
  *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
- *             default_middleware?: bool|string|array{
- *                 enabled?: bool|Param, // Default: true
- *                 allow_no_handlers?: bool|Param, // Default: false
- *                 allow_no_senders?: bool|Param, // Default: true
- *             },
- *             middleware?: string|list<string|array{ // Default: []
- *                 id?: scalar|Param|null,
- *                 arguments?: list<mixed>,
+ *                 default_middleware?: bool|string|array{
+ *                     enabled?: bool|Param, // Default: true
+ *                     allow_no_handlers?: bool|Param, // Default: false
+ *                     allow_no_senders?: bool|Param, // Default: true
+ *                 },
+ *                 middleware?: string|list<string|array{ // Default: []
+ *                         id?: scalar|Param|null,
+ *                         arguments?: list<mixed>,
+ *                     }>,
  *             }>,
- *         }>,
  *     },
  *     scheduler?: bool|array{ // Scheduler configuration
- *         enabled?: bool|Param, // Default: true
+ *         enabled?: bool|Param, // Default: false
  *     },
  *     disallow_search_engine_index?: bool|Param, // Enabled by default when debug is enabled. // Default: true
  *     http_client?: bool|array{ // HTTP Client configuration
@@ -511,9 +511,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
  *                 http_codes?: int|string|array<string, array{ // Default: []
- *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
- *                 }>,
+ *                         code?: int|Param,
+ *                         methods?: string|list<string|Param>,
+ *                     }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
  *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
@@ -523,57 +523,57 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|Param|null>,
- *             headers?: array<string, mixed>,
- *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
- *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
- *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
- *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
- *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
- *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
- *                 sha1?: mixed,
- *                 pin-sha256?: mixed,
- *                 md5?: mixed,
- *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
- *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
- *             caching?: bool|array{ // Caching configuration.
- *                 enabled?: bool|Param, // Default: false
- *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
- *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
- *             },
- *             retry_failed?: bool|array{
- *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
- *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
- *                 }>,
- *                 max_retries?: int|Param, // Default: 3
- *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
- *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
- *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
- *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
- *             },
- *         }>,
+ *                 scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *                 base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *                 auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
+ *                 auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
+ *                 auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *                 query?: array<string, scalar|Param|null>,
+ *                 headers?: array<string, mixed>,
+ *                 max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *                 http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *                 resolve?: array<string, scalar|Param|null>,
+ *                 proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *                 no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *                 timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *                 max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *                 bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *                 verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *                 verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *                 cafile?: scalar|Param|null, // A certificate authority file.
+ *                 capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *                 local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *                 local_pk?: scalar|Param|null, // A private key file.
+ *                 passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *                 ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *                 peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
+ *                     sha1?: mixed,
+ *                     pin-sha256?: mixed,
+ *                     md5?: mixed,
+ *                 },
+ *                 crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *                 extra?: array<string, mixed>,
+ *                 rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *                 caching?: bool|array{ // Caching configuration.
+ *                     enabled?: bool|Param, // Default: false
+ *                     cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                     shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                     max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 },
+ *                 retry_failed?: bool|array{
+ *                     enabled?: bool|Param, // Default: false
+ *                     retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                     http_codes?: int|string|array<string, array{ // Default: []
+ *                             code?: int|Param,
+ *                             methods?: string|list<string|Param>,
+ *                         }>,
+ *                     max_retries?: int|Param, // Default: 3
+ *                     delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                     multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                     max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                     jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *                 },
+ *             }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
  *         enabled?: bool|Param, // Default: true
@@ -586,8 +586,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             allowed_recipients?: string|list<scalar|Param|null>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
- *             value?: mixed,
- *         }>,
+ *                 value?: mixed,
+ *             }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
  *             enabled?: bool|Param, // Default: false
  *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
@@ -624,25 +624,25 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         notification_on_failed_messages?: bool|Param, // Default: false
  *         channel_policy?: array<string, string|list<scalar|Param|null>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|Param|null,
- *             phone?: scalar|Param|null, // Default: ""
- *         }>,
+ *                 email?: scalar|Param|null,
+ *                 phone?: scalar|Param|null, // Default: ""
+ *             }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
  *         enabled?: bool|Param, // Default: true
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: string|list<scalar|Param|null>,
- *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
- *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
- *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
- *             },
- *         }>,
+ *                 lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *                 cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *                 storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *                 policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *                 limiters?: string|list<scalar|Param|null>,
+ *                 limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
+ *                 interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
+ *                     interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                     amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
+ *                 },
+ *             }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
  *         enabled?: bool|Param, // Default: true
@@ -655,33 +655,33 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: true
  *         sanitizers?: array<string, array{ // Default: []
- *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
- *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
- *             allow_elements?: array<string, mixed>,
- *             block_elements?: string|list<string|Param>,
- *             drop_elements?: string|list<string|Param>,
- *             allow_attributes?: array<string, mixed>,
- *             drop_attributes?: array<string, mixed>,
- *             force_attributes?: array<string, array<string, string|Param>>,
- *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: string|list<string|Param>,
- *             allowed_link_hosts?: null|string|list<string|Param>,
- *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: string|list<string|Param>,
- *             allowed_media_hosts?: null|string|list<string|Param>,
- *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: string|list<string|Param>,
- *             without_attribute_sanitizers?: string|list<string|Param>,
- *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
- *         }>,
+ *                 allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
+ *                 allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
+ *                 allow_elements?: array<string, mixed>,
+ *                 block_elements?: string|list<string|Param>,
+ *                 drop_elements?: string|list<string|Param>,
+ *                 allow_attributes?: array<string, mixed>,
+ *                 drop_attributes?: array<string, mixed>,
+ *                 force_attributes?: array<string, array<string, string|Param>>,
+ *                 force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
+ *                 allowed_link_schemes?: string|list<string|Param>,
+ *                 allowed_link_hosts?: null|string|list<string|Param>,
+ *                 allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
+ *                 allowed_media_schemes?: string|list<string|Param>,
+ *                 allowed_media_hosts?: null|string|list<string|Param>,
+ *                 allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
+ *                 with_attribute_sanitizers?: string|list<string|Param>,
+ *                 without_attribute_sanitizers?: string|list<string|Param>,
+ *                 max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
+ *             }>,
  *     },
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
  *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service?: scalar|Param|null,
- *             secret?: scalar|Param|null, // Default: ""
- *         }>,
+ *                 service?: scalar|Param|null,
+ *                 secret?: scalar|Param|null, // Default: ""
+ *             }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
  *         enabled?: bool|Param, // Default: false
@@ -693,10 +693,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type TwigConfig = array{
  *     form_themes?: list<scalar|Param|null>,
  *     globals?: array<string, array{ // Default: []
- *         id?: scalar|Param|null,
- *         type?: scalar|Param|null,
- *         value?: mixed,
- *     }>,
+ *             id?: scalar|Param|null,
+ *             type?: scalar|Param|null,
+ *             value?: mixed,
+ *         }>,
  *     autoescape_service?: scalar|Param|null, // Default: null
  *     autoescape_service_method?: scalar|Param|null, // Default: null
  *     base_template_class?: scalar|Param|null, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
@@ -735,169 +735,169 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     use_microseconds?: scalar|Param|null, // Default: true
  *     channels?: list<scalar|Param|null>,
  *     handlers?: array<string, array{ // Default: []
- *         type?: scalar|Param|null,
- *         id?: scalar|Param|null,
- *         enabled?: bool|Param, // Default: true
- *         priority?: scalar|Param|null, // Default: 0
- *         level?: scalar|Param|null, // Default: "DEBUG"
- *         bubble?: bool|Param, // Default: true
- *         interactive_only?: bool|Param, // Default: false
- *         app_name?: scalar|Param|null, // Default: null
- *         fill_extra_context?: bool|Param, // Default: false
- *         include_stacktraces?: bool|Param, // Default: false
- *         process_psr_3_messages?: array{
- *             enabled?: bool|Param|null, // Default: null
- *             date_format?: scalar|Param|null,
- *             remove_used_context_fields?: bool|Param,
- *         },
- *         path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
- *         file_permission?: scalar|Param|null, // Default: null
- *         use_locking?: bool|Param, // Default: false
- *         filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
- *         date_format?: scalar|Param|null, // Default: "Y-m-d"
- *         ident?: scalar|Param|null, // Default: false
- *         logopts?: scalar|Param|null, // Default: 1
- *         facility?: scalar|Param|null, // Default: "user"
- *         max_files?: scalar|Param|null, // Default: 0
- *         action_level?: scalar|Param|null, // Default: "WARNING"
- *         activation_strategy?: scalar|Param|null, // Default: null
- *         stop_buffering?: bool|Param, // Default: true
- *         passthru_level?: scalar|Param|null, // Default: null
- *         excluded_404s?: list<scalar|Param|null>,
- *         excluded_http_codes?: list<array{ // Default: []
- *             code?: scalar|Param|null,
- *             urls?: list<scalar|Param|null>,
- *         }>,
- *         accepted_levels?: list<scalar|Param|null>,
- *         min_level?: scalar|Param|null, // Default: "DEBUG"
- *         max_level?: scalar|Param|null, // Default: "EMERGENCY"
- *         buffer_size?: scalar|Param|null, // Default: 0
- *         flush_on_overflow?: bool|Param, // Default: false
- *         handler?: scalar|Param|null,
- *         url?: scalar|Param|null,
- *         exchange?: scalar|Param|null,
- *         exchange_name?: scalar|Param|null, // Default: "log"
- *         room?: scalar|Param|null,
- *         message_format?: scalar|Param|null, // Default: "text"
- *         api_version?: scalar|Param|null, // Default: null
- *         channel?: scalar|Param|null, // Default: null
- *         bot_name?: scalar|Param|null, // Default: "Monolog"
- *         use_attachment?: scalar|Param|null, // Default: true
- *         use_short_attachment?: scalar|Param|null, // Default: false
- *         include_extra?: scalar|Param|null, // Default: false
- *         icon_emoji?: scalar|Param|null, // Default: null
- *         webhook_url?: scalar|Param|null,
- *         exclude_fields?: list<scalar|Param|null>,
- *         team?: scalar|Param|null,
- *         notify?: scalar|Param|null, // Default: false
- *         nickname?: scalar|Param|null, // Default: "Monolog"
- *         token?: scalar|Param|null,
- *         region?: scalar|Param|null,
- *         source?: scalar|Param|null,
- *         use_ssl?: bool|Param, // Default: true
- *         user?: mixed,
- *         title?: scalar|Param|null, // Default: null
- *         host?: scalar|Param|null, // Default: null
- *         port?: scalar|Param|null, // Default: 514
- *         config?: list<scalar|Param|null>,
- *         members?: list<scalar|Param|null>,
- *         connection_string?: scalar|Param|null,
- *         timeout?: scalar|Param|null,
- *         time?: scalar|Param|null, // Default: 60
- *         deduplication_level?: scalar|Param|null, // Default: 400
- *         store?: scalar|Param|null, // Default: null
- *         connection_timeout?: scalar|Param|null,
- *         persistent?: bool|Param,
- *         dsn?: scalar|Param|null,
- *         hub_id?: scalar|Param|null, // Default: null
- *         client_id?: scalar|Param|null, // Default: null
- *         auto_log_stacks?: scalar|Param|null, // Default: false
- *         release?: scalar|Param|null, // Default: null
- *         environment?: scalar|Param|null, // Default: null
- *         message_type?: scalar|Param|null, // Default: 0
- *         parse_mode?: scalar|Param|null, // Default: null
- *         disable_webpage_preview?: bool|Param|null, // Default: null
- *         disable_notification?: bool|Param|null, // Default: null
- *         split_long_messages?: bool|Param, // Default: false
- *         delay_between_messages?: bool|Param, // Default: false
- *         topic?: int|Param, // Default: null
- *         factor?: int|Param, // Default: 1
- *         tags?: string|list<scalar|Param|null>,
- *         console_formater_options?: mixed, // Deprecated: "monolog.handlers..console_formater_options.console_formater_options" is deprecated, use "monolog.handlers..console_formater_options.console_formatter_options" instead.
- *         console_formatter_options?: mixed, // Default: []
- *         formatter?: scalar|Param|null,
- *         nested?: bool|Param, // Default: false
- *         publisher?: string|array{
- *             id?: scalar|Param|null,
- *             hostname?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 12201
- *             chunk_size?: scalar|Param|null, // Default: 1420
- *             encoder?: "json"|"compressed_json"|Param,
- *         },
- *         mongo?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 27017
- *             user?: scalar|Param|null,
- *             pass?: scalar|Param|null,
- *             database?: scalar|Param|null, // Default: "monolog"
- *             collection?: scalar|Param|null, // Default: "logs"
- *         },
- *         mongodb?: string|array{
- *             id?: scalar|Param|null, // ID of a MongoDB\Client service
- *             uri?: scalar|Param|null,
- *             username?: scalar|Param|null,
- *             password?: scalar|Param|null,
- *             database?: scalar|Param|null, // Default: "monolog"
- *             collection?: scalar|Param|null, // Default: "logs"
- *         },
- *         elasticsearch?: string|array{
- *             id?: scalar|Param|null,
- *             hosts?: list<scalar|Param|null>,
- *             host?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 9200
- *             transport?: scalar|Param|null, // Default: "Http"
- *             user?: scalar|Param|null, // Default: null
- *             password?: scalar|Param|null, // Default: null
- *         },
- *         index?: scalar|Param|null, // Default: "monolog"
- *         document_type?: scalar|Param|null, // Default: "logs"
- *         ignore_error?: scalar|Param|null, // Default: false
- *         redis?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
- *             password?: scalar|Param|null, // Default: null
- *             port?: scalar|Param|null, // Default: 6379
- *             database?: scalar|Param|null, // Default: 0
- *             key_name?: scalar|Param|null, // Default: "monolog_redis"
- *         },
- *         predis?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
- *         },
- *         from_email?: scalar|Param|null,
- *         to_email?: string|list<scalar|Param|null>,
- *         subject?: scalar|Param|null,
- *         content_type?: scalar|Param|null, // Default: null
- *         headers?: list<scalar|Param|null>,
- *         mailer?: scalar|Param|null, // Default: null
- *         email_prototype?: string|array{
- *             id?: scalar|Param|null,
- *             method?: scalar|Param|null, // Default: null
- *         },
- *         lazy?: bool|Param, // Default: true
- *         verbosity_levels?: array{
- *             VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
- *             VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
- *             VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
- *             VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
- *             VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
- *         },
- *         channels?: string|array{
  *             type?: scalar|Param|null,
- *             elements?: list<scalar|Param|null>,
- *         },
- *     }>,
+ *             id?: scalar|Param|null,
+ *             enabled?: bool|Param, // Default: true
+ *             priority?: scalar|Param|null, // Default: 0
+ *             level?: scalar|Param|null, // Default: "DEBUG"
+ *             bubble?: bool|Param, // Default: true
+ *             interactive_only?: bool|Param, // Default: false
+ *             app_name?: scalar|Param|null, // Default: null
+ *             fill_extra_context?: bool|Param, // Default: false
+ *             include_stacktraces?: bool|Param, // Default: false
+ *             process_psr_3_messages?: array{
+ *                 enabled?: bool|Param|null, // Default: null
+ *                 date_format?: scalar|Param|null,
+ *                 remove_used_context_fields?: bool|Param,
+ *             },
+ *             path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
+ *             file_permission?: scalar|Param|null, // Default: null
+ *             use_locking?: bool|Param, // Default: false
+ *             filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
+ *             date_format?: scalar|Param|null, // Default: "Y-m-d"
+ *             ident?: scalar|Param|null, // Default: false
+ *             logopts?: scalar|Param|null, // Default: 1
+ *             facility?: scalar|Param|null, // Default: "user"
+ *             max_files?: scalar|Param|null, // Default: 0
+ *             action_level?: scalar|Param|null, // Default: "WARNING"
+ *             activation_strategy?: scalar|Param|null, // Default: null
+ *             stop_buffering?: bool|Param, // Default: true
+ *             passthru_level?: scalar|Param|null, // Default: null
+ *             excluded_404s?: list<scalar|Param|null>,
+ *             excluded_http_codes?: list<array{ // Default: []
+ *                     code?: scalar|Param|null,
+ *                     urls?: list<scalar|Param|null>,
+ *                 }>,
+ *             accepted_levels?: list<scalar|Param|null>,
+ *             min_level?: scalar|Param|null, // Default: "DEBUG"
+ *             max_level?: scalar|Param|null, // Default: "EMERGENCY"
+ *             buffer_size?: scalar|Param|null, // Default: 0
+ *             flush_on_overflow?: bool|Param, // Default: false
+ *             handler?: scalar|Param|null,
+ *             url?: scalar|Param|null,
+ *             exchange?: scalar|Param|null,
+ *             exchange_name?: scalar|Param|null, // Default: "log"
+ *             room?: scalar|Param|null,
+ *             message_format?: scalar|Param|null, // Default: "text"
+ *             api_version?: scalar|Param|null, // Default: null
+ *             channel?: scalar|Param|null, // Default: null
+ *             bot_name?: scalar|Param|null, // Default: "Monolog"
+ *             use_attachment?: scalar|Param|null, // Default: true
+ *             use_short_attachment?: scalar|Param|null, // Default: false
+ *             include_extra?: scalar|Param|null, // Default: false
+ *             icon_emoji?: scalar|Param|null, // Default: null
+ *             webhook_url?: scalar|Param|null,
+ *             exclude_fields?: list<scalar|Param|null>,
+ *             team?: scalar|Param|null,
+ *             notify?: scalar|Param|null, // Default: false
+ *             nickname?: scalar|Param|null, // Default: "Monolog"
+ *             token?: scalar|Param|null,
+ *             region?: scalar|Param|null,
+ *             source?: scalar|Param|null,
+ *             use_ssl?: bool|Param, // Default: true
+ *             user?: mixed,
+ *             title?: scalar|Param|null, // Default: null
+ *             host?: scalar|Param|null, // Default: null
+ *             port?: scalar|Param|null, // Default: 514
+ *             config?: list<scalar|Param|null>,
+ *             members?: list<scalar|Param|null>,
+ *             connection_string?: scalar|Param|null,
+ *             timeout?: scalar|Param|null,
+ *             time?: scalar|Param|null, // Default: 60
+ *             deduplication_level?: scalar|Param|null, // Default: 400
+ *             store?: scalar|Param|null, // Default: null
+ *             connection_timeout?: scalar|Param|null,
+ *             persistent?: bool|Param,
+ *             dsn?: scalar|Param|null,
+ *             hub_id?: scalar|Param|null, // Default: null
+ *             client_id?: scalar|Param|null, // Default: null
+ *             auto_log_stacks?: scalar|Param|null, // Default: false
+ *             release?: scalar|Param|null, // Default: null
+ *             environment?: scalar|Param|null, // Default: null
+ *             message_type?: scalar|Param|null, // Default: 0
+ *             parse_mode?: scalar|Param|null, // Default: null
+ *             disable_webpage_preview?: bool|Param|null, // Default: null
+ *             disable_notification?: bool|Param|null, // Default: null
+ *             split_long_messages?: bool|Param, // Default: false
+ *             delay_between_messages?: bool|Param, // Default: false
+ *             topic?: int|Param, // Default: null
+ *             factor?: int|Param, // Default: 1
+ *             tags?: string|list<scalar|Param|null>,
+ *             console_formater_options?: mixed, // Deprecated: "monolog.handlers..console_formater_options.console_formater_options" is deprecated, use "monolog.handlers..console_formater_options.console_formatter_options" instead.
+ *             console_formatter_options?: mixed, // Default: []
+ *             formatter?: scalar|Param|null,
+ *             nested?: bool|Param, // Default: false
+ *             publisher?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 hostname?: scalar|Param|null,
+ *                 port?: scalar|Param|null, // Default: 12201
+ *                 chunk_size?: scalar|Param|null, // Default: 1420
+ *                 encoder?: "json"|"compressed_json"|Param,
+ *             },
+ *             mongo?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 host?: scalar|Param|null,
+ *                 port?: scalar|Param|null, // Default: 27017
+ *                 user?: scalar|Param|null,
+ *                 pass?: scalar|Param|null,
+ *                 database?: scalar|Param|null, // Default: "monolog"
+ *                 collection?: scalar|Param|null, // Default: "logs"
+ *             },
+ *             mongodb?: string|array{
+ *                 id?: scalar|Param|null, // ID of a MongoDB\Client service
+ *                 uri?: scalar|Param|null,
+ *                 username?: scalar|Param|null,
+ *                 password?: scalar|Param|null,
+ *                 database?: scalar|Param|null, // Default: "monolog"
+ *                 collection?: scalar|Param|null, // Default: "logs"
+ *             },
+ *             elasticsearch?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 hosts?: list<scalar|Param|null>,
+ *                 host?: scalar|Param|null,
+ *                 port?: scalar|Param|null, // Default: 9200
+ *                 transport?: scalar|Param|null, // Default: "Http"
+ *                 user?: scalar|Param|null, // Default: null
+ *                 password?: scalar|Param|null, // Default: null
+ *             },
+ *             index?: scalar|Param|null, // Default: "monolog"
+ *             document_type?: scalar|Param|null, // Default: "logs"
+ *             ignore_error?: scalar|Param|null, // Default: false
+ *             redis?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 host?: scalar|Param|null,
+ *                 password?: scalar|Param|null, // Default: null
+ *                 port?: scalar|Param|null, // Default: 6379
+ *                 database?: scalar|Param|null, // Default: 0
+ *                 key_name?: scalar|Param|null, // Default: "monolog_redis"
+ *             },
+ *             predis?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 host?: scalar|Param|null,
+ *             },
+ *             from_email?: scalar|Param|null,
+ *             to_email?: string|list<scalar|Param|null>,
+ *             subject?: scalar|Param|null,
+ *             content_type?: scalar|Param|null, // Default: null
+ *             headers?: list<scalar|Param|null>,
+ *             mailer?: scalar|Param|null, // Default: null
+ *             email_prototype?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 method?: scalar|Param|null, // Default: null
+ *             },
+ *             lazy?: bool|Param, // Default: true
+ *             verbosity_levels?: array{
+ *                 VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
+ *                 VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
+ *                 VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
+ *                 VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
+ *                 VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
+ *             },
+ *             channels?: string|array{
+ *                 type?: scalar|Param|null,
+ *                 elements?: list<scalar|Param|null>,
+ *             },
+ *         }>,
  * }
  * @psalm-type DebugConfig = array{
  *     max_items?: int|Param, // Max number of displayed items past the first level, -1 means no limit. // Default: 2500
@@ -915,62 +915,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     dbal?: array{
  *         default_connection?: scalar|Param|null,
  *         types?: array<string, string|array{ // Default: []
- *             class?: scalar|Param|null,
- *             commented?: bool|Param, // Deprecated: The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.
- *         }>,
+ *                 class?: scalar|Param|null,
+ *                 commented?: bool|Param, // Deprecated: The doctrine-bundle type commenting features were removed; the corresponding config parameter was deprecated in 2.0 and will be dropped in 3.0.
+ *             }>,
  *         driver_schemes?: array<string, scalar|Param|null>,
  *         connections?: array<string, array{ // Default: []
- *             url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *             dbname?: scalar|Param|null,
- *             host?: scalar|Param|null, // Defaults to "localhost" at runtime.
- *             port?: scalar|Param|null, // Defaults to null at runtime.
- *             user?: scalar|Param|null, // Defaults to "root" at runtime.
- *             password?: scalar|Param|null, // Defaults to null at runtime.
- *             override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *             dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *             application_name?: scalar|Param|null,
- *             charset?: scalar|Param|null,
- *             path?: scalar|Param|null,
- *             memory?: bool|Param,
- *             unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
- *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *             protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
- *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
- *             sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
- *             sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
- *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *             use_savepoints?: bool|Param, // Use savepoints for nested transactions
- *             instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *             connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             driver?: scalar|Param|null, // Default: "pdo_mysql"
- *             platform_service?: scalar|Param|null, // Deprecated: The "platform_service" configuration key is deprecated since doctrine-bundle 2.9. DBAL 4 will not support setting a custom platform via connection params anymore.
- *             auto_commit?: bool|Param,
- *             schema_filter?: scalar|Param|null,
- *             logging?: bool|Param, // Default: true
- *             profiling?: bool|Param, // Default: true
- *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
- *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
- *             disable_type_comments?: bool|Param,
- *             server_version?: scalar|Param|null,
- *             idle_connection_ttl?: int|Param, // Default: 600
- *             driver_class?: scalar|Param|null,
- *             wrapper_class?: scalar|Param|null,
- *             keep_slave?: bool|Param, // Deprecated: The "keep_slave" configuration key is deprecated since doctrine-bundle 2.2. Use the "keep_replica" configuration key instead.
- *             keep_replica?: bool|Param,
- *             options?: array<string, mixed>,
- *             mapping_types?: array<string, scalar|Param|null>,
- *             default_table_options?: array<string, scalar|Param|null>,
- *             schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.legacy_schema_manager_factory"
- *             result_cache?: scalar|Param|null,
- *             slaves?: array<string, array{ // Default: []
  *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
  *                 dbname?: scalar|Param|null,
  *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
@@ -1001,40 +950,91 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 use_savepoints?: bool|Param, // Use savepoints for nested transactions
  *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
  *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 driver?: scalar|Param|null, // Default: "pdo_mysql"
+ *                 platform_service?: scalar|Param|null, // Deprecated: The "platform_service" configuration key is deprecated since doctrine-bundle 2.9. DBAL 4 will not support setting a custom platform via connection params anymore.
+ *                 auto_commit?: bool|Param,
+ *                 schema_filter?: scalar|Param|null,
+ *                 logging?: bool|Param, // Default: true
+ *                 profiling?: bool|Param, // Default: true
+ *                 profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
+ *                 profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
+ *                 disable_type_comments?: bool|Param,
+ *                 server_version?: scalar|Param|null,
+ *                 idle_connection_ttl?: int|Param, // Default: 600
+ *                 driver_class?: scalar|Param|null,
+ *                 wrapper_class?: scalar|Param|null,
+ *                 keep_slave?: bool|Param, // Deprecated: The "keep_slave" configuration key is deprecated since doctrine-bundle 2.2. Use the "keep_replica" configuration key instead.
+ *                 keep_replica?: bool|Param,
+ *                 options?: array<string, mixed>,
+ *                 mapping_types?: array<string, scalar|Param|null>,
+ *                 default_table_options?: array<string, scalar|Param|null>,
+ *                 schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.legacy_schema_manager_factory"
+ *                 result_cache?: scalar|Param|null,
+ *                 slaves?: array<string, array{ // Default: []
+ *                         url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                         dbname?: scalar|Param|null,
+ *                         host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *                         port?: scalar|Param|null, // Defaults to null at runtime.
+ *                         user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *                         password?: scalar|Param|null, // Defaults to null at runtime.
+ *                         override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
+ *                         dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                         application_name?: scalar|Param|null,
+ *                         charset?: scalar|Param|null,
+ *                         path?: scalar|Param|null,
+ *                         memory?: bool|Param,
+ *                         unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *                         persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                         protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                         service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                         servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                         sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *                         server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *                         default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                         sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                         sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                         sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *                         sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *                         sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                         pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                         MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                         use_savepoints?: bool|Param, // Use savepoints for nested transactions
+ *                         instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                         connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                     }>,
+ *                 replicas?: array<string, array{ // Default: []
+ *                         url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                         dbname?: scalar|Param|null,
+ *                         host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *                         port?: scalar|Param|null, // Defaults to null at runtime.
+ *                         user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *                         password?: scalar|Param|null, // Defaults to null at runtime.
+ *                         override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
+ *                         dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                         application_name?: scalar|Param|null,
+ *                         charset?: scalar|Param|null,
+ *                         path?: scalar|Param|null,
+ *                         memory?: bool|Param,
+ *                         unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *                         persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                         protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                         service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                         servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                         sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *                         server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *                         default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                         sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                         sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                         sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *                         sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *                         sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                         pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                         MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                         use_savepoints?: bool|Param, // Use savepoints for nested transactions
+ *                         instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                         connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                     }>,
  *             }>,
- *             replicas?: array<string, array{ // Default: []
- *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|Param|null,
- *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
- *                 port?: scalar|Param|null, // Defaults to null at runtime.
- *                 user?: scalar|Param|null, // Defaults to "root" at runtime.
- *                 password?: scalar|Param|null, // Defaults to null at runtime.
- *                 override_url?: bool|Param, // Deprecated: The "doctrine.dbal.override_url" configuration key is deprecated.
- *                 dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|Param|null,
- *                 charset?: scalar|Param|null,
- *                 path?: scalar|Param|null,
- *                 memory?: bool|Param,
- *                 unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
- *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
- *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
- *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
- *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
- *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 use_savepoints?: bool|Param, // Use savepoints for nested transactions
- *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             }>,
- *         }>,
  *     },
  *     orm?: array{
  *         default_entity_manager?: scalar|Param|null,
@@ -1049,94 +1049,94 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             evict_cache?: bool|Param, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
  *         },
  *         entity_managers?: array<string, array{ // Default: []
- *             query_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
- *             },
- *             metadata_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
- *             },
- *             result_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
- *             },
- *             entity_listeners?: array{
- *                 entities?: array<string, array{ // Default: []
- *                     listeners?: array<string, array{ // Default: []
- *                         events?: list<array{ // Default: []
- *                             type?: scalar|Param|null,
- *                             method?: scalar|Param|null, // Default: null
- *                         }>,
- *                     }>,
- *                 }>,
- *             },
- *             connection?: scalar|Param|null,
- *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
- *             default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
- *             auto_mapping?: scalar|Param|null, // Default: false
- *             naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
- *             quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
- *             typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
- *             entity_listener_resolver?: scalar|Param|null, // Default: null
- *             fetch_mode_subselect_batch_size?: scalar|Param|null,
- *             repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
- *             schema_ignore_classes?: list<scalar|Param|null>,
- *             report_fields_where_declared?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455. // Default: true
- *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728. // Default: false
- *             second_level_cache?: array{
- *                 region_cache_driver?: string|array{
+ *                 query_cache_driver?: string|array{
  *                     type?: scalar|Param|null, // Default: null
  *                     id?: scalar|Param|null,
  *                     pool?: scalar|Param|null,
  *                 },
- *                 region_lock_lifetime?: scalar|Param|null, // Default: 60
- *                 log_enabled?: bool|Param, // Default: true
- *                 region_lifetime?: scalar|Param|null, // Default: 3600
- *                 enabled?: bool|Param, // Default: true
- *                 factory?: scalar|Param|null,
- *                 regions?: array<string, array{ // Default: []
- *                     cache_driver?: string|array{
+ *                 metadata_cache_driver?: string|array{
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
+ *                 },
+ *                 result_cache_driver?: string|array{
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
+ *                 },
+ *                 entity_listeners?: array{
+ *                     entities?: array<string, array{ // Default: []
+ *                             listeners?: array<string, array{ // Default: []
+ *                                     events?: list<array{ // Default: []
+ *                                             type?: scalar|Param|null,
+ *                                             method?: scalar|Param|null, // Default: null
+ *                                         }>,
+ *                                 }>,
+ *                         }>,
+ *                 },
+ *                 connection?: scalar|Param|null,
+ *                 class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *                 default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
+ *                 auto_mapping?: scalar|Param|null, // Default: false
+ *                 naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
+ *                 quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
+ *                 typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
+ *                 entity_listener_resolver?: scalar|Param|null, // Default: null
+ *                 fetch_mode_subselect_batch_size?: scalar|Param|null,
+ *                 repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
+ *                 schema_ignore_classes?: list<scalar|Param|null>,
+ *                 report_fields_where_declared?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.16 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/10455. // Default: true
+ *                 validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14. See https://github.com/doctrine/orm/pull/6728. // Default: false
+ *                 second_level_cache?: array{
+ *                     region_cache_driver?: string|array{
  *                         type?: scalar|Param|null, // Default: null
  *                         id?: scalar|Param|null,
  *                         pool?: scalar|Param|null,
  *                     },
- *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
- *                     lock_lifetime?: scalar|Param|null, // Default: 60
- *                     type?: scalar|Param|null, // Default: "default"
- *                     lifetime?: scalar|Param|null, // Default: 0
- *                     service?: scalar|Param|null,
- *                     name?: scalar|Param|null,
- *                 }>,
- *                 loggers?: array<string, array{ // Default: []
- *                     name?: scalar|Param|null,
- *                     service?: scalar|Param|null,
- *                 }>,
- *             },
- *             hydrators?: array<string, scalar|Param|null>,
- *             mappings?: array<string, bool|string|array{ // Default: []
- *                 mapping?: scalar|Param|null, // Default: true
- *                 type?: scalar|Param|null,
- *                 dir?: scalar|Param|null,
- *                 alias?: scalar|Param|null,
- *                 prefix?: scalar|Param|null,
- *                 is_bundle?: bool|Param,
+ *                     region_lock_lifetime?: scalar|Param|null, // Default: 60
+ *                     log_enabled?: bool|Param, // Default: true
+ *                     region_lifetime?: scalar|Param|null, // Default: 3600
+ *                     enabled?: bool|Param, // Default: true
+ *                     factory?: scalar|Param|null,
+ *                     regions?: array<string, array{ // Default: []
+ *                             cache_driver?: string|array{
+ *                                 type?: scalar|Param|null, // Default: null
+ *                                 id?: scalar|Param|null,
+ *                                 pool?: scalar|Param|null,
+ *                             },
+ *                             lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                             lock_lifetime?: scalar|Param|null, // Default: 60
+ *                             type?: scalar|Param|null, // Default: "default"
+ *                             lifetime?: scalar|Param|null, // Default: 0
+ *                             service?: scalar|Param|null,
+ *                             name?: scalar|Param|null,
+ *                         }>,
+ *                     loggers?: array<string, array{ // Default: []
+ *                             name?: scalar|Param|null,
+ *                             service?: scalar|Param|null,
+ *                         }>,
+ *                 },
+ *                 hydrators?: array<string, scalar|Param|null>,
+ *                 mappings?: array<string, bool|string|array{ // Default: []
+ *                         mapping?: scalar|Param|null, // Default: true
+ *                         type?: scalar|Param|null,
+ *                         dir?: scalar|Param|null,
+ *                         alias?: scalar|Param|null,
+ *                         prefix?: scalar|Param|null,
+ *                         is_bundle?: bool|Param,
+ *                     }>,
+ *                 dql?: array{
+ *                     string_functions?: array<string, scalar|Param|null>,
+ *                     numeric_functions?: array<string, scalar|Param|null>,
+ *                     datetime_functions?: array<string, scalar|Param|null>,
+ *                 },
+ *                 filters?: array<string, string|array{ // Default: []
+ *                         class?: scalar|Param|null,
+ *                         enabled?: bool|Param, // Default: false
+ *                         parameters?: array<string, mixed>,
+ *                     }>,
+ *                 identity_generation_preferences?: array<string, scalar|Param|null>,
  *             }>,
- *             dql?: array{
- *                 string_functions?: array<string, scalar|Param|null>,
- *                 numeric_functions?: array<string, scalar|Param|null>,
- *                 datetime_functions?: array<string, scalar|Param|null>,
- *             },
- *             filters?: array<string, string|array{ // Default: []
- *                 class?: scalar|Param|null,
- *                 enabled?: bool|Param, // Default: false
- *                 parameters?: array<string, mixed>,
- *             }>,
- *             identity_generation_preferences?: array<string, scalar|Param|null>,
- *         }>,
  *         resolve_target_entities?: array<string, scalar|Param|null>,
  *     },
  * }
@@ -1178,323 +1178,323 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         allow_if_equal_granted_denied?: bool|Param, // Default: true
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
- *         algorithm?: scalar|Param|null,
- *         migrate_from?: string|list<scalar|Param|null>,
- *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
- *         key_length?: scalar|Param|null, // Default: 40
- *         ignore_case?: bool|Param, // Default: false
- *         encode_as_base64?: bool|Param, // Default: true
- *         iterations?: scalar|Param|null, // Default: 5000
- *         cost?: int|Param, // Default: null
- *         memory_cost?: scalar|Param|null, // Default: null
- *         time_cost?: scalar|Param|null, // Default: null
- *         id?: scalar|Param|null,
- *     }>,
+ *             algorithm?: scalar|Param|null,
+ *             migrate_from?: string|list<scalar|Param|null>,
+ *             hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
+ *             key_length?: scalar|Param|null, // Default: 40
+ *             ignore_case?: bool|Param, // Default: false
+ *             encode_as_base64?: bool|Param, // Default: true
+ *             iterations?: scalar|Param|null, // Default: 5000
+ *             cost?: int|Param, // Default: null
+ *             memory_cost?: scalar|Param|null, // Default: null
+ *             time_cost?: scalar|Param|null, // Default: null
+ *             id?: scalar|Param|null,
+ *         }>,
  *     providers?: array<string, array{ // Default: []
- *         id?: scalar|Param|null,
- *         chain?: array{
- *             providers?: string|list<scalar|Param|null>,
- *         },
- *         entity?: array{
- *             class?: scalar|Param|null, // The full entity class name of your user class.
- *             property?: scalar|Param|null, // Default: null
- *             manager_name?: scalar|Param|null, // Default: null
- *         },
- *         memory?: array{
- *             users?: array<string, array{ // Default: []
- *                 password?: scalar|Param|null, // Default: null
- *                 roles?: string|list<scalar|Param|null>,
- *             }>,
- *         },
- *         ldap?: array{
- *             service?: scalar|Param|null,
- *             base_dn?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: null
- *             search_password?: scalar|Param|null, // Default: null
- *             extra_fields?: list<scalar|Param|null>,
- *             default_roles?: string|list<scalar|Param|null>,
- *             role_fetcher?: scalar|Param|null, // Default: null
- *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
- *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
- *             password_attribute?: scalar|Param|null, // Default: null
- *         },
- *     }>,
+ *             id?: scalar|Param|null,
+ *             chain?: array{
+ *                 providers?: string|list<scalar|Param|null>,
+ *             },
+ *             entity?: array{
+ *                 class?: scalar|Param|null, // The full entity class name of your user class.
+ *                 property?: scalar|Param|null, // Default: null
+ *                 manager_name?: scalar|Param|null, // Default: null
+ *             },
+ *             memory?: array{
+ *                 users?: array<string, array{ // Default: []
+ *                         password?: scalar|Param|null, // Default: null
+ *                         roles?: string|list<scalar|Param|null>,
+ *                     }>,
+ *             },
+ *             ldap?: array{
+ *                 service?: scalar|Param|null,
+ *                 base_dn?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: null
+ *                 search_password?: scalar|Param|null, // Default: null
+ *                 extra_fields?: list<scalar|Param|null>,
+ *                 default_roles?: string|list<scalar|Param|null>,
+ *                 role_fetcher?: scalar|Param|null, // Default: null
+ *                 uid_key?: scalar|Param|null, // Default: "sAMAccountName"
+ *                 filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
+ *                 password_attribute?: scalar|Param|null, // Default: null
+ *             },
+ *         }>,
  *     firewalls?: array<string, array{ // Default: []
- *         pattern?: scalar|Param|null,
- *         host?: scalar|Param|null,
- *         methods?: string|list<scalar|Param|null>,
- *         security?: bool|Param, // Default: true
- *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
- *         request_matcher?: scalar|Param|null,
- *         access_denied_url?: scalar|Param|null,
- *         access_denied_handler?: scalar|Param|null,
- *         entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
- *         provider?: scalar|Param|null,
- *         stateless?: bool|Param, // Default: false
- *         lazy?: bool|Param, // Default: false
- *         context?: scalar|Param|null,
- *         logout?: array{
- *             enable_csrf?: bool|Param|null, // Default: null
- *             csrf_token_id?: scalar|Param|null, // Default: "logout"
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_manager?: scalar|Param|null,
- *             path?: scalar|Param|null, // Default: "/logout"
- *             target?: scalar|Param|null, // Default: "/"
- *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
- *             delete_cookies?: string|array<string, array{ // Default: []
- *                 path?: scalar|Param|null, // Default: null
- *                 domain?: scalar|Param|null, // Default: null
- *                 secure?: scalar|Param|null, // Default: false
- *                 samesite?: scalar|Param|null, // Default: null
- *                 partitioned?: scalar|Param|null, // Default: false
- *             }>,
- *         },
- *         switch_user?: array{
+ *             pattern?: scalar|Param|null,
+ *             host?: scalar|Param|null,
+ *             methods?: string|list<scalar|Param|null>,
+ *             security?: bool|Param, // Default: true
+ *             user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
+ *             request_matcher?: scalar|Param|null,
+ *             access_denied_url?: scalar|Param|null,
+ *             access_denied_handler?: scalar|Param|null,
+ *             entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
  *             provider?: scalar|Param|null,
- *             parameter?: scalar|Param|null, // Default: "_switch_user"
- *             role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
- *             target_route?: scalar|Param|null, // Default: null
- *         },
- *         required_badges?: list<scalar|Param|null>,
- *         custom_authenticators?: list<scalar|Param|null>,
- *         login_throttling?: array{
- *             limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
- *             max_attempts?: int|Param, // Default: 5
- *             interval?: scalar|Param|null, // Default: "1 minute"
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
- *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
- *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
- *         },
- *         two_factor?: array{
- *             check_path?: scalar|Param|null, // Default: "/2fa_check"
- *             post_only?: bool|Param, // Default: true
- *             auth_form_path?: scalar|Param|null, // Default: "/2fa"
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             success_handler?: scalar|Param|null, // Default: null
- *             failure_handler?: scalar|Param|null, // Default: null
- *             authentication_required_handler?: scalar|Param|null, // Default: null
- *             auth_code_parameter_name?: scalar|Param|null, // Default: "_auth_code"
- *             trusted_parameter_name?: scalar|Param|null, // Default: "_trusted"
- *             remember_me_sets_trusted?: scalar|Param|null, // Default: false
- *             multi_factor?: bool|Param, // Default: false
- *             prepare_on_login?: bool|Param, // Default: false
- *             prepare_on_access_denied?: bool|Param, // Default: false
- *             enable_csrf?: scalar|Param|null, // Default: false
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|Param|null, // Default: "two_factor"
- *             csrf_header?: scalar|Param|null, // Default: null
- *             csrf_token_manager?: scalar|Param|null, // Default: "scheb_two_factor.csrf_token_manager"
- *             provider?: scalar|Param|null, // Default: null
- *         },
- *         x509?: array{
- *             provider?: scalar|Param|null,
- *             user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
- *             credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
- *             user_identifier?: scalar|Param|null, // Default: "emailAddress"
- *         },
- *         remote_user?: array{
- *             provider?: scalar|Param|null,
- *             user?: scalar|Param|null, // Default: "REMOTE_USER"
- *         },
- *         login_link?: array{
- *             check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
- *             check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
- *             signature_properties?: list<scalar|Param|null>,
- *             lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
- *             max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
- *             used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
- *             success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
- *             failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
- *             provider?: scalar|Param|null, // The user provider to load users from.
- *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
- *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|Param|null, // Default: null
- *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
- *         },
- *         form_login?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_parameter?: scalar|Param|null, // Default: "_username"
- *             password_parameter?: scalar|Param|null, // Default: "_password"
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
- *             enable_csrf?: bool|Param, // Default: false
- *             post_only?: bool|Param, // Default: true
- *             form_only?: bool|Param, // Default: false
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
- *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|Param|null, // Default: null
- *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
- *         },
- *         form_login_ldap?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_parameter?: scalar|Param|null, // Default: "_username"
- *             password_parameter?: scalar|Param|null, // Default: "_password"
- *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
- *             enable_csrf?: bool|Param, // Default: false
- *             post_only?: bool|Param, // Default: true
- *             form_only?: bool|Param, // Default: false
- *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|Param|null, // Default: "/"
- *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
- *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|Param|null, // Default: null
- *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
- *             service?: scalar|Param|null, // Default: "ldap"
- *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
- *             query_string?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: ""
- *             search_password?: scalar|Param|null, // Default: ""
- *         },
- *         json_login?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_path?: scalar|Param|null, // Default: "username"
- *             password_path?: scalar|Param|null, // Default: "password"
- *         },
- *         json_login_ldap?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             check_path?: scalar|Param|null, // Default: "/login_check"
- *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|Param|null, // Default: "/login"
- *             username_path?: scalar|Param|null, // Default: "username"
- *             password_path?: scalar|Param|null, // Default: "password"
- *             service?: scalar|Param|null, // Default: "ldap"
- *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
- *             query_string?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: ""
- *             search_password?: scalar|Param|null, // Default: ""
- *         },
- *         access_token?: array{
- *             provider?: scalar|Param|null,
- *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|Param|null,
- *             failure_handler?: scalar|Param|null,
- *             realm?: scalar|Param|null, // Default: null
- *             token_extractors?: string|list<scalar|Param|null>,
- *             token_handler?: string|array{
- *                 id?: scalar|Param|null,
- *                 oidc_user_info?: string|array{
- *                     base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
- *                     discovery?: array{ // Enable the OIDC discovery.
- *                         cache?: array{
- *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *             stateless?: bool|Param, // Default: false
+ *             lazy?: bool|Param, // Default: false
+ *             context?: scalar|Param|null,
+ *             logout?: array{
+ *                 enable_csrf?: bool|Param|null, // Default: null
+ *                 csrf_token_id?: scalar|Param|null, // Default: "logout"
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_manager?: scalar|Param|null,
+ *                 path?: scalar|Param|null, // Default: "/logout"
+ *                 target?: scalar|Param|null, // Default: "/"
+ *                 invalidate_session?: bool|Param, // Default: true
+ *                 clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *                 delete_cookies?: string|array<string, array{ // Default: []
+ *                         path?: scalar|Param|null, // Default: null
+ *                         domain?: scalar|Param|null, // Default: null
+ *                         secure?: scalar|Param|null, // Default: false
+ *                         samesite?: scalar|Param|null, // Default: null
+ *                         partitioned?: scalar|Param|null, // Default: false
+ *                     }>,
+ *             },
+ *             switch_user?: array{
+ *                 provider?: scalar|Param|null,
+ *                 parameter?: scalar|Param|null, // Default: "_switch_user"
+ *                 role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
+ *                 target_route?: scalar|Param|null, // Default: null
+ *             },
+ *             required_badges?: list<scalar|Param|null>,
+ *             custom_authenticators?: list<scalar|Param|null>,
+ *             login_throttling?: array{
+ *                 limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
+ *                 max_attempts?: int|Param, // Default: 5
+ *                 interval?: scalar|Param|null, // Default: "1 minute"
+ *                 lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
+ *                 cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
+ *                 storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
+ *             },
+ *             two_factor?: array{
+ *                 check_path?: scalar|Param|null, // Default: "/2fa_check"
+ *                 post_only?: bool|Param, // Default: true
+ *                 auth_form_path?: scalar|Param|null, // Default: "/2fa"
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 success_handler?: scalar|Param|null, // Default: null
+ *                 failure_handler?: scalar|Param|null, // Default: null
+ *                 authentication_required_handler?: scalar|Param|null, // Default: null
+ *                 auth_code_parameter_name?: scalar|Param|null, // Default: "_auth_code"
+ *                 trusted_parameter_name?: scalar|Param|null, // Default: "_trusted"
+ *                 remember_me_sets_trusted?: scalar|Param|null, // Default: false
+ *                 multi_factor?: bool|Param, // Default: false
+ *                 prepare_on_login?: bool|Param, // Default: false
+ *                 prepare_on_access_denied?: bool|Param, // Default: false
+ *                 enable_csrf?: scalar|Param|null, // Default: false
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_id?: scalar|Param|null, // Default: "two_factor"
+ *                 csrf_header?: scalar|Param|null, // Default: null
+ *                 csrf_token_manager?: scalar|Param|null, // Default: "scheb_two_factor.csrf_token_manager"
+ *                 provider?: scalar|Param|null, // Default: null
+ *             },
+ *             x509?: array{
+ *                 provider?: scalar|Param|null,
+ *                 user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
+ *                 credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
+ *                 user_identifier?: scalar|Param|null, // Default: "emailAddress"
+ *             },
+ *             remote_user?: array{
+ *                 provider?: scalar|Param|null,
+ *                 user?: scalar|Param|null, // Default: "REMOTE_USER"
+ *             },
+ *             login_link?: array{
+ *                 check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
+ *                 check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
+ *                 signature_properties?: list<scalar|Param|null>,
+ *                 lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
+ *                 max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
+ *                 used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
+ *                 success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
+ *                 failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
+ *                 provider?: scalar|Param|null, // The user provider to load users from.
+ *                 secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *                 use_referer?: bool|Param, // Default: false
+ *                 failure_path?: scalar|Param|null, // Default: null
+ *                 failure_forward?: bool|Param, // Default: false
+ *                 failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             },
+ *             form_login?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_parameter?: scalar|Param|null, // Default: "_username"
+ *                 password_parameter?: scalar|Param|null, // Default: "_password"
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *                 enable_csrf?: bool|Param, // Default: false
+ *                 post_only?: bool|Param, // Default: true
+ *                 form_only?: bool|Param, // Default: false
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *                 use_referer?: bool|Param, // Default: false
+ *                 failure_path?: scalar|Param|null, // Default: null
+ *                 failure_forward?: bool|Param, // Default: false
+ *                 failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             },
+ *             form_login_ldap?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_parameter?: scalar|Param|null, // Default: "_username"
+ *                 password_parameter?: scalar|Param|null, // Default: "_password"
+ *                 csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *                 csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *                 enable_csrf?: bool|Param, // Default: false
+ *                 post_only?: bool|Param, // Default: true
+ *                 form_only?: bool|Param, // Default: false
+ *                 always_use_default_target_path?: bool|Param, // Default: false
+ *                 default_target_path?: scalar|Param|null, // Default: "/"
+ *                 target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *                 use_referer?: bool|Param, // Default: false
+ *                 failure_path?: scalar|Param|null, // Default: null
+ *                 failure_forward?: bool|Param, // Default: false
+ *                 failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *                 service?: scalar|Param|null, // Default: "ldap"
+ *                 dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *                 query_string?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: ""
+ *                 search_password?: scalar|Param|null, // Default: ""
+ *             },
+ *             json_login?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_path?: scalar|Param|null, // Default: "username"
+ *                 password_path?: scalar|Param|null, // Default: "password"
+ *             },
+ *             json_login_ldap?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 check_path?: scalar|Param|null, // Default: "/login_check"
+ *                 use_forward?: bool|Param, // Default: false
+ *                 login_path?: scalar|Param|null, // Default: "/login"
+ *                 username_path?: scalar|Param|null, // Default: "username"
+ *                 password_path?: scalar|Param|null, // Default: "password"
+ *                 service?: scalar|Param|null, // Default: "ldap"
+ *                 dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *                 query_string?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: ""
+ *                 search_password?: scalar|Param|null, // Default: ""
+ *             },
+ *             access_token?: array{
+ *                 provider?: scalar|Param|null,
+ *                 remember_me?: bool|Param, // Default: true
+ *                 success_handler?: scalar|Param|null,
+ *                 failure_handler?: scalar|Param|null,
+ *                 realm?: scalar|Param|null, // Default: null
+ *                 token_extractors?: string|list<scalar|Param|null>,
+ *                 token_handler?: string|array{
+ *                     id?: scalar|Param|null,
+ *                     oidc_user_info?: string|array{
+ *                         base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
+ *                         discovery?: array{ // Enable the OIDC discovery.
+ *                             cache?: array{
+ *                                 id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             },
  *                         },
+ *                         claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
+ *                         client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
  *                     },
- *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
- *                     client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
- *                 },
- *                 oidc?: array{
- *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri?: string|list<scalar|Param|null>,
- *                         cache?: array{
- *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                     oidc?: array{
+ *                         discovery?: array{ // Enable the OIDC discovery.
+ *                             base_uri?: string|list<scalar|Param|null>,
+ *                             cache?: array{
+ *                                 id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             },
  *                         },
- *                     },
- *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
- *                     audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
- *                     issuers?: list<scalar|Param|null>,
- *                     algorithm?: array<mixed>,
- *                     algorithms?: list<scalar|Param|null>,
- *                     key?: scalar|Param|null, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
- *                     keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
- *                     encryption?: bool|array{
- *                         enabled?: bool|Param, // Default: false
- *                         enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                         claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
+ *                         audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
+ *                         issuers?: list<scalar|Param|null>,
+ *                         algorithm?: array<mixed>,
  *                         algorithms?: list<scalar|Param|null>,
- *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         key?: scalar|Param|null, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
+ *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
+ *                         encryption?: bool|array{
+ *                             enabled?: bool|Param, // Default: false
+ *                             enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                             algorithms?: list<scalar|Param|null>,
+ *                             keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         },
+ *                     },
+ *                     cas?: array{
+ *                         validation_url?: scalar|Param|null, // CAS server validation URL
+ *                         prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
+ *                         http_client?: scalar|Param|null, // HTTP Client service // Default: null
+ *                     },
+ *                     oauth2?: scalar|Param|null,
+ *                 },
+ *             },
+ *             http_basic?: array{
+ *                 provider?: scalar|Param|null,
+ *                 realm?: scalar|Param|null, // Default: "Secured Area"
+ *             },
+ *             http_basic_ldap?: array{
+ *                 provider?: scalar|Param|null,
+ *                 realm?: scalar|Param|null, // Default: "Secured Area"
+ *                 service?: scalar|Param|null, // Default: "ldap"
+ *                 dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *                 query_string?: scalar|Param|null,
+ *                 search_dn?: scalar|Param|null, // Default: ""
+ *                 search_password?: scalar|Param|null, // Default: ""
+ *             },
+ *             remember_me?: array{
+ *                 secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *                 service?: scalar|Param|null,
+ *                 user_providers?: string|list<scalar|Param|null>,
+ *                 catch_exceptions?: bool|Param, // Default: true
+ *                 signature_properties?: list<scalar|Param|null>,
+ *                 token_provider?: string|array{
+ *                     service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
+ *                     doctrine?: bool|array{
+ *                         enabled?: bool|Param, // Default: false
+ *                         connection?: scalar|Param|null, // Default: null
  *                     },
  *                 },
- *                 cas?: array{
- *                     validation_url?: scalar|Param|null, // CAS server validation URL
- *                     prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
- *                     http_client?: scalar|Param|null, // HTTP Client service // Default: null
- *                 },
- *                 oauth2?: scalar|Param|null,
+ *                 token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
+ *                 name?: scalar|Param|null, // Default: "REMEMBERME"
+ *                 lifetime?: int|Param, // Default: 31536000
+ *                 path?: scalar|Param|null, // Default: "/"
+ *                 domain?: scalar|Param|null, // Default: null
+ *                 secure?: true|false|"auto"|Param, // Default: null
+ *                 httponly?: bool|Param, // Default: true
+ *                 samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *                 always_remember_me?: bool|Param, // Default: false
+ *                 remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
  *             },
- *         },
- *         http_basic?: array{
- *             provider?: scalar|Param|null,
- *             realm?: scalar|Param|null, // Default: "Secured Area"
- *         },
- *         http_basic_ldap?: array{
- *             provider?: scalar|Param|null,
- *             realm?: scalar|Param|null, // Default: "Secured Area"
- *             service?: scalar|Param|null, // Default: "ldap"
- *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
- *             query_string?: scalar|Param|null,
- *             search_dn?: scalar|Param|null, // Default: ""
- *             search_password?: scalar|Param|null, // Default: ""
- *         },
- *         remember_me?: array{
- *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
- *             service?: scalar|Param|null,
- *             user_providers?: string|list<scalar|Param|null>,
- *             catch_exceptions?: bool|Param, // Default: true
- *             signature_properties?: list<scalar|Param|null>,
- *             token_provider?: string|array{
- *                 service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
- *                 doctrine?: bool|array{
- *                     enabled?: bool|Param, // Default: false
- *                     connection?: scalar|Param|null, // Default: null
- *                 },
- *             },
- *             token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
- *             name?: scalar|Param|null, // Default: "REMEMBERME"
- *             lifetime?: int|Param, // Default: 31536000
- *             path?: scalar|Param|null, // Default: "/"
- *             domain?: scalar|Param|null, // Default: null
- *             secure?: true|false|"auto"|Param, // Default: null
- *             httponly?: bool|Param, // Default: true
- *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
- *             always_remember_me?: bool|Param, // Default: false
- *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
- *         },
- *     }>,
+ *         }>,
  *     access_control?: list<array{ // Default: []
- *         request_matcher?: scalar|Param|null, // Default: null
- *         requires_channel?: scalar|Param|null, // Default: null
- *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
- *         host?: scalar|Param|null, // Default: null
- *         port?: int|Param, // Default: null
- *         ips?: string|list<scalar|Param|null>,
- *         attributes?: array<string, scalar|Param|null>,
- *         route?: scalar|Param|null, // Default: null
- *         methods?: string|list<scalar|Param|null>,
- *         allow_if?: scalar|Param|null, // Default: null
- *         roles?: string|list<scalar|Param|null>,
- *     }>,
+ *             request_matcher?: scalar|Param|null, // Default: null
+ *             requires_channel?: scalar|Param|null, // Default: null
+ *             path?: scalar|Param|null, // Use the urldecoded format. // Default: null
+ *             host?: scalar|Param|null, // Default: null
+ *             port?: int|Param, // Default: null
+ *             ips?: string|list<scalar|Param|null>,
+ *             attributes?: array<string, scalar|Param|null>,
+ *             route?: scalar|Param|null, // Default: null
+ *             methods?: string|list<scalar|Param|null>,
+ *             allow_if?: scalar|Param|null, // Default: null
+ *             roles?: string|list<scalar|Param|null>,
+ *         }>,
  *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
  * }
  * @psalm-type TwigExtraConfig = array{
@@ -1556,135 +1556,135 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type FlysystemConfig = array{
  *     storages?: array<string, array{ // Default: []
- *         adapter?: scalar|Param|null, // DEPRECATED: Use the new config format instead (e.g. "local:" instead of "adapter: local")
- *         options?: list<mixed>,
- *         asyncaws?: array{
- *             client?: scalar|Param|null, // The AsyncAws S3 client service name
- *             bucket?: scalar|Param|null, // The name of the AWS S3 bucket
- *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
- *         },
- *         aws?: array{
- *             client?: scalar|Param|null, // The AWS S3 client service name
- *             bucket?: scalar|Param|null, // The name of the AWS S3 bucket
- *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *             adapter?: scalar|Param|null, // DEPRECATED: Use the new config format instead (e.g. "local:" instead of "adapter: local")
  *             options?: list<mixed>,
- *             streamReads?: bool|Param, // Whether to use streaming for file reads // Default: true
- *         },
- *         azure?: array{
- *             client?: scalar|Param|null, // The Azure Blob Storage client service name
- *             container?: scalar|Param|null, // The name of the Azure Blob Storage container
- *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all blob names // Default: ""
- *         },
- *         ftp?: array{
- *             host?: scalar|Param|null, // FTP host
- *             username?: scalar|Param|null, // FTP username
- *             password?: scalar|Param|null, // FTP password
- *             port?: int|Param, // FTP port number // Default: 21
- *             root?: scalar|Param|null, // FTP root directory // Default: ""
- *             passive?: bool|Param, // Use passive mode // Default: true
- *             ssl?: bool|Param, // Use SSL/TLS encryption // Default: false
- *             timeout?: int|Param, // Connection timeout in seconds // Default: 90
- *             ignore_passive_address?: scalar|Param|null, // Ignore passive address // Default: null
- *             utf8?: bool|Param, // Enable UTF8 mode // Default: false
- *             transfer_mode?: scalar|Param|null, // Transfer mode (FTP_ASCII or FTP_BINARY constante on ftp extension) // Default: null
- *             system_type?: null|"windows"|"unix"|Param, // FTP system type // Default: null
- *             timestamps_on_unix_listings_enabled?: bool|Param, // Enable timestamps on Unix listings // Default: false
- *             recurse_manually?: bool|Param, // Recurse directories manually // Default: true
- *             use_raw_list_options?: bool|Param|null, // Use raw list options // Default: null
- *             connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
- *             permissions?: array{ // Unix permissions configuration for files and directories
- *                 file?: array{ // File permissions
- *                     public?: int|Param, // Public file permissions // Default: 420
- *                     private?: int|Param, // Private file permissions // Default: 384
- *                 },
- *                 dir?: array{ // Directory permissions
- *                     public?: int|Param, // Public directory permissions // Default: 493
- *                     private?: int|Param, // Private directory permissions // Default: 448
+ *             asyncaws?: array{
+ *                 client?: scalar|Param|null, // The AsyncAws S3 client service name
+ *                 bucket?: scalar|Param|null, // The name of the AWS S3 bucket
+ *                 prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *             },
+ *             aws?: array{
+ *                 client?: scalar|Param|null, // The AWS S3 client service name
+ *                 bucket?: scalar|Param|null, // The name of the AWS S3 bucket
+ *                 prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *                 options?: list<mixed>,
+ *                 streamReads?: bool|Param, // Whether to use streaming for file reads // Default: true
+ *             },
+ *             azure?: array{
+ *                 client?: scalar|Param|null, // The Azure Blob Storage client service name
+ *                 container?: scalar|Param|null, // The name of the Azure Blob Storage container
+ *                 prefix?: scalar|Param|null, // Optional path prefix to prepend to all blob names // Default: ""
+ *             },
+ *             ftp?: array{
+ *                 host?: scalar|Param|null, // FTP host
+ *                 username?: scalar|Param|null, // FTP username
+ *                 password?: scalar|Param|null, // FTP password
+ *                 port?: int|Param, // FTP port number // Default: 21
+ *                 root?: scalar|Param|null, // FTP root directory // Default: ""
+ *                 passive?: bool|Param, // Use passive mode // Default: true
+ *                 ssl?: bool|Param, // Use SSL/TLS encryption // Default: false
+ *                 timeout?: int|Param, // Connection timeout in seconds // Default: 90
+ *                 ignore_passive_address?: scalar|Param|null, // Ignore passive address // Default: null
+ *                 utf8?: bool|Param, // Enable UTF8 mode // Default: false
+ *                 transfer_mode?: scalar|Param|null, // Transfer mode (FTP_ASCII or FTP_BINARY constante on ftp extension) // Default: null
+ *                 system_type?: null|"windows"|"unix"|Param, // FTP system type // Default: null
+ *                 timestamps_on_unix_listings_enabled?: bool|Param, // Enable timestamps on Unix listings // Default: false
+ *                 recurse_manually?: bool|Param, // Recurse directories manually // Default: true
+ *                 use_raw_list_options?: bool|Param|null, // Use raw list options // Default: null
+ *                 connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
+ *                 permissions?: array{ // Unix permissions configuration for files and directories
+ *                     file?: array{ // File permissions
+ *                         public?: int|Param, // Public file permissions // Default: 420
+ *                         private?: int|Param, // Private file permissions // Default: 384
+ *                     },
+ *                     dir?: array{ // Directory permissions
+ *                         public?: int|Param, // Public directory permissions // Default: 493
+ *                         private?: int|Param, // Private directory permissions // Default: 448
+ *                     },
  *                 },
  *             },
- *         },
- *         gcloud?: array{
- *             client?: scalar|Param|null, // The Google Cloud Storage client service name
- *             bucket?: scalar|Param|null, // The name of the Google Cloud Storage bucket
- *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
- *             visibility_handler?: scalar|Param|null, // Optional visibility handler service name // Default: null
- *             streamReads?: bool|Param, // Whether to use streaming for file reads // Default: false
- *         },
- *         gridfs?: array{
- *             bucket?: scalar|Param|null, // GridFS bucket service name (if using an existing bucket service) // Default: null
- *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all file names // Default: ""
- *             database?: scalar|Param|null, // MongoDB database name // Default: null
- *             doctrine_connection?: scalar|Param|null, // Doctrine MongoDB connection name (mutually exclusive with mongodb_uri)
- *             mongodb_uri?: scalar|Param|null, // MongoDB connection URI (mutually exclusive with doctrine_connection)
- *             mongodb_uri_options?: list<mixed>,
- *             mongodb_driver_options?: list<mixed>,
- *         },
- *         lazy?: array{ // Lazy adapter for runtime storage selection
- *             source?: scalar|Param|null, // The service name of the storage to use at runtime
- *         },
- *         local?: array{
- *             directory?: scalar|Param|null, // Directory path for local storage
- *             lock?: int|Param, // Lock flags for file operations // Default: 0
- *             skip_links?: bool|Param, // Whether to skip symbolic links // Default: false
- *             lazy_root_creation?: bool|Param, // Whether to create the root directory lazily // Default: false
- *             permissions?: array{ // Unix permissions configuration for files and directories
- *                 file?: array{ // File permissions
- *                     public?: int|Param, // Public file permissions // Default: 420
- *                     private?: int|Param, // Private file permissions // Default: 384
- *                 },
- *                 dir?: array{ // Directory permissions
- *                     public?: int|Param, // Public directory permissions // Default: 493
- *                     private?: int|Param, // Private directory permissions // Default: 448
+ *             gcloud?: array{
+ *                 client?: scalar|Param|null, // The Google Cloud Storage client service name
+ *                 bucket?: scalar|Param|null, // The name of the Google Cloud Storage bucket
+ *                 prefix?: scalar|Param|null, // Optional path prefix to prepend to all object keys // Default: ""
+ *                 visibility_handler?: scalar|Param|null, // Optional visibility handler service name // Default: null
+ *                 streamReads?: bool|Param, // Whether to use streaming for file reads // Default: false
+ *             },
+ *             gridfs?: array{
+ *                 bucket?: scalar|Param|null, // GridFS bucket service name (if using an existing bucket service) // Default: null
+ *                 prefix?: scalar|Param|null, // Optional path prefix to prepend to all file names // Default: ""
+ *                 database?: scalar|Param|null, // MongoDB database name // Default: null
+ *                 doctrine_connection?: scalar|Param|null, // Doctrine MongoDB connection name (mutually exclusive with mongodb_uri)
+ *                 mongodb_uri?: scalar|Param|null, // MongoDB connection URI (mutually exclusive with doctrine_connection)
+ *                 mongodb_uri_options?: list<mixed>,
+ *                 mongodb_driver_options?: list<mixed>,
+ *             },
+ *             lazy?: array{ // Lazy adapter for runtime storage selection
+ *                 source?: scalar|Param|null, // The service name of the storage to use at runtime
+ *             },
+ *             local?: array{
+ *                 directory?: scalar|Param|null, // Directory path for local storage
+ *                 lock?: int|Param, // Lock flags for file operations // Default: 0
+ *                 skip_links?: bool|Param, // Whether to skip symbolic links // Default: false
+ *                 lazy_root_creation?: bool|Param, // Whether to create the root directory lazily // Default: false
+ *                 permissions?: array{ // Unix permissions configuration for files and directories
+ *                     file?: array{ // File permissions
+ *                         public?: int|Param, // Public file permissions // Default: 420
+ *                         private?: int|Param, // Private file permissions // Default: 384
+ *                     },
+ *                     dir?: array{ // Directory permissions
+ *                         public?: int|Param, // Public directory permissions // Default: 493
+ *                         private?: int|Param, // Private directory permissions // Default: 448
+ *                     },
  *                 },
  *             },
- *         },
- *         memory?: array<mixed>,
- *         sftp?: array{
- *             host?: scalar|Param|null, // SFTP host
- *             username?: scalar|Param|null, // SFTP username
- *             password?: scalar|Param|null, // SFTP password (optional if using private key) // Default: null
- *             privateKey?: scalar|Param|null, // Path to private key file or private key content // Default: null
- *             passphrase?: scalar|Param|null, // Private key passphrase // Default: null
- *             port?: int|Param, // SFTP port number // Default: 22
- *             timeout?: int|Param, // Connection timeout in seconds // Default: 90
- *             hostFingerprint?: scalar|Param|null, // Host fingerprint for verification // Default: null
- *             connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
- *             preferredAlgorithms?: list<mixed>,
- *             root?: scalar|Param|null, // SFTP root directory // Default: ""
- *             permissions?: array{ // Unix permissions configuration for files and directories
- *                 file?: array{ // File permissions
- *                     public?: int|Param, // Public file permissions // Default: 420
- *                     private?: int|Param, // Private file permissions // Default: 384
- *                 },
- *                 dir?: array{ // Directory permissions
- *                     public?: int|Param, // Public directory permissions // Default: 493
- *                     private?: int|Param, // Private directory permissions // Default: 448
+ *             memory?: array<mixed>,
+ *             sftp?: array{
+ *                 host?: scalar|Param|null, // SFTP host
+ *                 username?: scalar|Param|null, // SFTP username
+ *                 password?: scalar|Param|null, // SFTP password (optional if using private key) // Default: null
+ *                 privateKey?: scalar|Param|null, // Path to private key file or private key content // Default: null
+ *                 passphrase?: scalar|Param|null, // Private key passphrase // Default: null
+ *                 port?: int|Param, // SFTP port number // Default: 22
+ *                 timeout?: int|Param, // Connection timeout in seconds // Default: 90
+ *                 hostFingerprint?: scalar|Param|null, // Host fingerprint for verification // Default: null
+ *                 connectivityChecker?: scalar|Param|null, // Connectivity checker service name // Default: null
+ *                 preferredAlgorithms?: list<mixed>,
+ *                 root?: scalar|Param|null, // SFTP root directory // Default: ""
+ *                 permissions?: array{ // Unix permissions configuration for files and directories
+ *                     file?: array{ // File permissions
+ *                         public?: int|Param, // Public file permissions // Default: 420
+ *                         private?: int|Param, // Private file permissions // Default: 384
+ *                     },
+ *                     dir?: array{ // Directory permissions
+ *                         public?: int|Param, // Public directory permissions // Default: 493
+ *                         private?: int|Param, // Private directory permissions // Default: 448
+ *                     },
  *                 },
  *             },
- *         },
- *         webdav?: array{
- *             client?: scalar|Param|null, // The WebDAV client service name
- *             prefix?: scalar|Param|null, // Optional path prefix to prepend to all paths // Default: ""
- *             visibility_handling?: "throw"|"ignore"|Param, // How to handle visibility operations // Default: "throw"
- *             manual_copy?: bool|Param, // Whether to handle copy operations manually // Default: false
- *             manual_move?: bool|Param, // Whether to handle move operations manually // Default: false
- *         },
- *         bunnycdn?: array{
- *             client?: scalar|Param|null, // The BunnyCDN client service name
- *             pull_zone?: scalar|Param|null, // The BunnyCDN pull zone name // Default: ""
- *         },
- *         service?: scalar|Param|null, // Reference to a custom adapter service (alternative to registered adapter types)
- *         visibility?: scalar|Param|null, // Default visibility for files // Default: null
- *         directory_visibility?: scalar|Param|null, // Default visibility for directories // Default: null
- *         retain_visibility?: scalar|Param|null, // Keeps the original file visibility (public/private) when copying or moving. // Default: null
- *         case_sensitive?: bool|Param, // Deprecated: The "case_sensitive" option is deprecated and will be removed in 4.0. // Default: true
- *         disable_asserts?: bool|Param, // Deprecated: The "disable_asserts" option is deprecated and will be removed in 4.0. // Default: false
- *         public_url?: list<scalar|Param|null>,
- *         path_normalizer?: scalar|Param|null, // Path normalizer service name (should implement League\Flysystem\PathNormalizer) // Default: null
- *         public_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities and public_url option, a public URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\PublicUrlGenerator) // Default: null
- *         temporary_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities, a temporary URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\TemporaryUrlGenerator) // Default: null
- *         read_only?: bool|Param, // Converts a file system to read-only // Default: false
- *     }>,
+ *             webdav?: array{
+ *                 client?: scalar|Param|null, // The WebDAV client service name
+ *                 prefix?: scalar|Param|null, // Optional path prefix to prepend to all paths // Default: ""
+ *                 visibility_handling?: "throw"|"ignore"|Param, // How to handle visibility operations // Default: "throw"
+ *                 manual_copy?: bool|Param, // Whether to handle copy operations manually // Default: false
+ *                 manual_move?: bool|Param, // Whether to handle move operations manually // Default: false
+ *             },
+ *             bunnycdn?: array{
+ *                 client?: scalar|Param|null, // The BunnyCDN client service name
+ *                 pull_zone?: scalar|Param|null, // The BunnyCDN pull zone name // Default: ""
+ *             },
+ *             service?: scalar|Param|null, // Reference to a custom adapter service (alternative to registered adapter types)
+ *             visibility?: scalar|Param|null, // Default visibility for files // Default: null
+ *             directory_visibility?: scalar|Param|null, // Default visibility for directories // Default: null
+ *             retain_visibility?: scalar|Param|null, // Keeps the original file visibility (public/private) when copying or moving. // Default: null
+ *             case_sensitive?: bool|Param, // Deprecated: The "case_sensitive" option is deprecated and will be removed in 4.0. // Default: true
+ *             disable_asserts?: bool|Param, // Deprecated: The "disable_asserts" option is deprecated and will be removed in 4.0. // Default: false
+ *             public_url?: list<scalar|Param|null>,
+ *             path_normalizer?: scalar|Param|null, // Path normalizer service name (should implement League\Flysystem\PathNormalizer) // Default: null
+ *             public_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities and public_url option, a public URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\PublicUrlGenerator) // Default: null
+ *             temporary_url_generator?: scalar|Param|null, // For adapter that do not provide public URLs or override adapter capabilities, a temporary URL generator service name can be configured in the main Filesystem configuration (should implement League\Flysystem\TemporaryUrlGenerator) // Default: null
+ *             read_only?: bool|Param, // Converts a file system to read-only // Default: false
+ *         }>,
  * }
  * @psalm-type SentryConfig = array{
  *     dsn?: scalar|Param|null, // If this value is not provided, the SDK will try to read it from the SENTRY_DSN environment variable. If that variable also does not exist, the SDK will not send any events.
@@ -1823,36 +1823,36 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         stoplight_config?: array<mixed>,
  *     },
  *     areas?: array<string, array{ // Default: {"default":{"path_patterns":[],"host_patterns":[],"with_attribute":false,"documentation":[],"name_patterns":[],"disable_default_routes":false,"cache":[],"security":[]}}
- *         path_patterns?: list<scalar|Param|null>,
- *         host_patterns?: list<scalar|Param|null>,
- *         name_patterns?: list<scalar|Param|null>,
- *         security?: array<string, array{ // Default: []
- *             type?: scalar|Param|null,
- *             scheme?: scalar|Param|null,
- *             in?: scalar|Param|null,
- *             name?: scalar|Param|null,
- *             description?: scalar|Param|null,
- *             openIdConnectUrl?: scalar|Param|null,
- *             ...<string, mixed>
+ *             path_patterns?: list<scalar|Param|null>,
+ *             host_patterns?: list<scalar|Param|null>,
+ *             name_patterns?: list<scalar|Param|null>,
+ *             security?: array<string, array{ // Default: []
+ *                     type?: scalar|Param|null,
+ *                     scheme?: scalar|Param|null,
+ *                     in?: scalar|Param|null,
+ *                     name?: scalar|Param|null,
+ *                     description?: scalar|Param|null,
+ *                     openIdConnectUrl?: scalar|Param|null,
+ *                     ...<string, mixed>
+ *                 }>,
+ *             with_attribute?: bool|Param, // whether to filter by attributes // Default: false
+ *             disable_default_routes?: bool|Param, // if set disables default routes without attributes // Default: false
+ *             documentation?: array<string, mixed>,
+ *             cache?: array{
+ *                 pool?: scalar|Param|null, // define cache pool to use // Default: null
+ *                 item_id?: scalar|Param|null, // define cache item id // Default: null
+ *             },
  *         }>,
- *         with_attribute?: bool|Param, // whether to filter by attributes // Default: false
- *         disable_default_routes?: bool|Param, // if set disables default routes without attributes // Default: false
- *         documentation?: array<string, mixed>,
- *         cache?: array{
- *             pool?: scalar|Param|null, // define cache pool to use // Default: null
- *             item_id?: scalar|Param|null, // define cache item id // Default: null
- *         },
- *     }>,
  *     models?: array{
  *         use_jms?: bool|Param, // Default: false
  *         names?: list<array{ // Default: []
- *             alias?: scalar|Param|null,
- *             type?: scalar|Param|null,
- *             groups?: mixed, // Default: null
- *             options?: mixed, // Default: null
- *             serializationContext?: list<mixed>,
- *             areas?: list<scalar|Param|null>,
- *         }>,
+ *                 alias?: scalar|Param|null,
+ *                 type?: scalar|Param|null,
+ *                 groups?: mixed, // Default: null
+ *                 options?: mixed, // Default: null
+ *                 serializationContext?: list<mixed>,
+ *                 areas?: list<scalar|Param|null>,
+ *             }>,
  *     },
  * }
  * @psalm-type CoopTilleulsUrlSignerConfig = array{

--- a/src/Manager/HistoryEntryManager.php
+++ b/src/Manager/HistoryEntryManager.php
@@ -14,6 +14,7 @@ use App\Entity\HistoryEntry;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Entity\UserPartner;
 use App\Entity\UserSignalementSubscription;
 use App\EventListener\Behaviour\DoctrineListenerRemoverTrait;
 use App\EventListener\EntityHistoryListener;
@@ -155,8 +156,10 @@ class HistoryEntryManager
         /** @var HistoryEntry $entry */
         foreach ($entries as $entry) {
             $userName = $entry->getUser() ? $entry->getUser()->getNomComplet(true) : 'Système (automatique)';
-            if ('affectation' === $type || 'subscription' === $type) {
-                $partner = $entry->getUser()?->getPartnerInTerritoryOrFirstOne($entry->getSignalement()->getTerritory());
+            if ('subscription' === $type || ('affectation' === $type && HistoryEntryEvent::UPDATE !== $entry->getEvent())) {
+                $partner = $this->getPartnerByEntryUser($entry);
+            } elseif ('affectation' === $type) {
+                $partner = $this->getPartnerByAffectationId($entry->getEntityId()) ?? $this->getPartnerByDeleteHistoryEntry($entry->getEntityId());
             } else {
                 $partner = $entry->getUser()?->getPartnerInTerritoryOrFirstOne($signalement->getTerritory());
             }
@@ -172,13 +175,12 @@ class HistoryEntryManager
             }
 
             if ('affectation' === $type) {
-                $partnerTarget = $this->getPartnerByEntityId($entry->getEntityId()) ?? $this->getPartnerByDeleteHistoryEntry($entry->getEntityId());
+                $partnerTarget = $this->getPartnerByAffectationId($entry->getEntityId()) ?? $this->getPartnerByDeleteHistoryEntry($entry->getEntityId());
             } else {
                 $partnerTarget = null;
             }
 
             $id = $entry->getEntityId();
-
             switch ($type) {
                 case 'affectation':
                     $action = $this->getAffectationActionSummary($entry, $userName, $partnerTarget?->getNom() ?? 'N/A');
@@ -302,16 +304,16 @@ class HistoryEntryManager
                     switch ($changes['statut']['new']) {
                         case AffectationStatus::ACCEPTED->value:
                             if (AffectationStatus::WAIT->value === $changes['statut']['old']) {
-                                $description .= ' a accepté l\'affectation pour le partenaire ';
+                                $description .= ' a accepté l\'affectation pour le partenaire '.$partnerName;
                             } else {
-                                $description .= ' a réouvert l\'affectation pour le partenaire ';
+                                $description .= ' a réouvert l\'affectation pour le partenaire '.$partnerName;
                             }
                             break;
                         case AffectationStatus::REFUSED->value:
-                            $description .= ' a refusé l\'affectation pour le partenaire ';
+                            $description .= ' a refusé l\'affectation pour le partenaire '.$partnerName;
                             break;
                         case AffectationStatus::CLOSED->value:
-                            $description .= ' a clôturé l\'affectation pour le partenaire ';
+                            $description .= ' a clôturé l\'affectation pour le partenaire '.$partnerName;
                             break;
                         case AffectationStatus::WAIT->value:
                             $description .= ' a remis en attente l\'affectation pour le partenaire ';
@@ -370,7 +372,7 @@ class HistoryEntryManager
         return $this->userRepository->find($entry->getChanges()['user']);
     }
 
-    private function getPartnerByEntityId(int $affectationId): ?Partner
+    private function getPartnerByAffectationId(int $affectationId): ?Partner
     {
         $affectation = $this->affectationRepository->find($affectationId);
 
@@ -395,5 +397,50 @@ class HistoryEntryManager
         }
 
         return null;
+    }
+
+    private function getPartnerByEntryUser(HistoryEntry $entry): ?Partner
+    {
+        $user = $entry->getUser();
+        if (null === $user) {
+            return null;
+        }
+
+        $territory = $entry->getSignalement()->getTerritory();
+        $currentPartner = $user->getPartnerInTerritoryOrFirstOne($territory);
+
+        if (null === $currentPartner) {
+            return null;
+        }
+
+        $userPartner = null;
+        foreach ($user->getUserPartners() as $up) {
+            if ($up->getPartner()->getId() === $currentPartner->getId()) {
+                $userPartner = $up;
+                break;
+            }
+        }
+
+        if (null === $userPartner) {
+            return $currentPartner;
+        }
+
+        $userPartnerEntityName = str_replace($this->historyEntryFactory::ENTITY_PROXY_PREFIX, '', UserPartner::class);
+        $laterUpdate = $this->historyEntryRepository->findFirstEntityUpdateAfter(
+            $userPartner->getId(),
+            $userPartnerEntityName,
+            $entry->getCreatedAt()
+        );
+
+        if (null === $laterUpdate) {
+            return $currentPartner;
+        }
+
+        $oldPartnerId = $laterUpdate->getChanges()['partner']['old'] ?? null;
+        if (null === $oldPartnerId) {
+            return $currentPartner;
+        }
+
+        return $this->partnerRepository->find($oldPartnerId) ?? $currentPartner;
     }
 }

--- a/src/Repository/HistoryEntryRepository.php
+++ b/src/Repository/HistoryEntryRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\HistoryEntry;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -19,5 +20,22 @@ class HistoryEntryRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, HistoryEntry::class);
+    }
+
+    public function findFirstEntityUpdateAfter(int $entityId, string $entityName, \DateTimeImmutable $afterDate): ?HistoryEntry
+    {
+        return $this->createQueryBuilder('h')
+            ->where('h.entityId = :entityId')
+            ->andWhere('h.entityName = :entityName')
+            ->andWhere('h.event = :event')
+            ->andWhere('h.createdAt > :date')
+            ->setParameter('entityId', $entityId)
+            ->setParameter('entityName', $entityName)
+            ->setParameter('event', HistoryEntryEvent::UPDATE)
+            ->setParameter('date', $afterDate)
+            ->orderBy('h.createdAt', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 }

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -3,11 +3,15 @@
 namespace App\Tests\Functional\Manager;
 
 use App\Dto\Command\CommandContext;
+use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\HistoryEntry;
+use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Entity\UserPartner;
+use App\Entity\UserSignalementSubscription;
 use App\Factory\HistoryEntryFactory;
 use App\Manager\HistoryEntryManager;
 use App\Repository\AffectationRepository;
@@ -141,6 +145,98 @@ class HistoryEntryManagerTest extends WebTestCase
         $this->assertInstanceOf(HistoryEntry::class, $historyEntry);
         $this->assertEquals(HistoryEntryEvent::DELETE, $historyEntry->getEvent());
         $this->assertEquals($affectation->getId(), $historyEntry->getEntityId());
+    }
+
+    public function testGetAffectationHistoryDeleteAppearsInBothAdminAndPartnerSections(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $adminUser = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
+        $this->client->loginUser($adminUser);
+
+        /** @var Signalement $signalement */
+        $signalement = $this->entityManager->getRepository(Signalement::class)->findOneBy(['reference' => '2022-8']);
+        $affectation = $signalement->getAffectations()->first();
+        $this->assertInstanceOf(Affectation::class, $affectation);
+        $partnerName = $affectation->getPartner()->getNom();
+
+        $historyEntry = $this->historyEntryManager->create(
+            HistoryEntryEvent::DELETE,
+            $affectation,
+            ['partner' => $affectation->getPartner()->getId()]
+        );
+        $this->entityManager->persist($historyEntry);
+        $this->entityManager->flush();
+
+        $historyEntries = $this->historyEntryManager->getAffectationHistory($signalement);
+
+        $hasDeleteAction = static fn (array $entries) => !empty(array_filter(
+            array_column($entries, 'Action'),
+            static fn (string $action) => str_contains($action, "a supprimé l'affectation du partenaire")
+        ));
+
+        $this->assertArrayHasKey(Partner::DEFAULT_PARTNER, $historyEntries);
+        $this->assertTrue($hasDeleteAction($historyEntries[Partner::DEFAULT_PARTNER]));
+
+        $this->assertArrayHasKey($partnerName, $historyEntries);
+        $this->assertTrue($hasDeleteAction($historyEntries[$partnerName]));
+    }
+
+    public function testGetAffectationHistorySubscriptionAppearsUnderOriginalPartnerAfterTransfer(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'user-13-01@signal-logement.fr']);
+
+        /** @var Signalement $signalement */
+        $signalement = $this->entityManager->getRepository(Signalement::class)->findOneBy(['reference' => '2022-8']);
+
+        $subscription = $this->userSignalementSubscriptionRepository->findOneBy([
+            'user' => $user,
+            'signalement' => $signalement,
+        ]);
+
+        $userPartner = $user->getUserPartners()->first();
+        $this->assertInstanceOf(UserPartner::class, $userPartner);
+        $currentPartnerName = $userPartner->getPartner()->getNom();
+
+        $oldPartner = $this->partnerRepository->findOneBy(['nom' => 'Partenaire 13-03']);
+
+        $subscriptionEntry = (new HistoryEntry())
+            ->setEvent(HistoryEntryEvent::CREATE)
+            ->setEntityId($subscription?->getId() ?? 0)
+            ->setEntityName(str_replace(HistoryEntryFactory::ENTITY_PROXY_PREFIX, '', UserSignalementSubscription::class))
+            ->setUser($user)
+            ->setSignalement($signalement)
+            ->setChanges([])
+            ->setCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'));
+        $this->entityManager->persist($subscriptionEntry);
+
+        $userPartnerUpdateEntry = (new HistoryEntry())
+            ->setEvent(HistoryEntryEvent::UPDATE)
+            ->setEntityId($userPartner->getId())
+            ->setEntityName(str_replace(HistoryEntryFactory::ENTITY_PROXY_PREFIX, '', UserPartner::class))
+            ->setChanges(['partner' => ['old' => $oldPartner->getId(), 'new' => $userPartner->getPartner()->getId()]])
+            ->setCreatedAt(new \DateTimeImmutable('2020-01-01 11:00:00'));
+        $this->entityManager->persist($userPartnerUpdateEntry);
+
+        $this->entityManager->flush();
+
+        $historyEntries = $this->historyEntryManager->getAffectationHistory($signalement);
+
+        $hasSubscriptionAction = static fn (array $entries) => !empty(array_filter(
+            array_column($entries, 'Action'),
+            static fn (string $action) => str_contains($action, 'a rejoint le dossier')
+                || str_contains($action, 'a attribué le dossier')
+        ));
+
+        $this->assertArrayHasKey($oldPartner->getNom(), $historyEntries);
+        $this->assertTrue($hasSubscriptionAction($historyEntries[$oldPartner->getNom()]));
+
+        $this->assertFalse(
+            isset($historyEntries[$currentPartnerName])
+            && $hasSubscriptionAction($historyEntries[$currentPartnerName])
+        );
     }
 
     public function testGetAffectationHistory(): void


### PR DESCRIPTION
## Ticket

#5851   

## Description
Le groupement par partenaire dans l'historique des affectation se fait en fonction du partenaire courant de l'utilisateur ayant fait l'action. Si ce partenaire à changé, des infos concernant d'autres affectations peuvent apparaître sur le mauvais partenaire.


## Changements apportés
* Création d'une fonction `getPartnerByEntryUser` qui vérifie si l'utilisateur a été transféré de partenaire
* Création de la fonction `findFirstEntityUpdateAfter` dans le `HistoryEntryRepository` pour trouver un événement de type `Update` plus récent qu'une certaine date

## Pré-requis

## Tests
- [ ] Affecter un signalement à 2 partenaires
- [ ] Se connecter avec un agent du premier partenaire, accepter l'affectation, et abonner un autre agent au dossier (jouer avec les abonnements et affectations)
- [ ] Transférer cet agent au deuxième partenaire
- [ ] Vérifier dans l'historique des affectations que les événements sont bien rangés dans les bons partenaires (événéments d'affectation et d'abonnement)
