### PR TITLE
[BO - Esabora SISH] Renommer EsaboraStatusSAS_Etat par SAS_Etat + Commande de reprise dossier rejeté

### DIFF
--- a/migrations/Version20250729071740.php
+++ b/migrations/Version20250729071740.php
@@ -17,7 +17,11 @@ final class Version20250729071740 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->skipIf(!in_array($_ENV['APP_ENV'], ['test', 'dev']), 'This migration should only run in test or dev environments');
-        $this->addSql('CREATE UNIQUE INDEX unique_affectation_signalement_partner ON affectation (signalement_id, partner_id)');
+        $table = $schema->getTable('affectation');
+
+        if (!$table->hasIndex('unique_affectation_signalement_partner')) {
+            $this->addSql('CREATE UNIQUE INDEX unique_affectation_signalement_partner ON affectation (signalement_id, partner_id)');
+        }
     }
 
     public function down(Schema $schema): void

--- a/src/Command/Temp/SyncSishRejetCommand.php
+++ b/src/Command/Temp/SyncSishRejetCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Command\Temp;
+
+use App\Entity\Affectation;
+use App\Entity\Enum\AffectationStatus;
+use App\Entity\Enum\PartnerType;
+use App\Entity\JobEvent;
+use App\Entity\Partner;
+use App\Entity\Signalement;
+use App\Service\Interconnection\Esabora\AbstractEsaboraService;
+use App\Service\Interconnection\Esabora\EsaboraManager;
+use App\Service\Interconnection\Esabora\Response\DossierStateSISHResponse;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AsCommand(
+    name: 'app:sync-sish-rejet',
+    description: '[SISH] Resynchronize SISH dossiers rejected after 06/05/2026',
+)]
+class SyncSishRejetCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly EsaboraManager $esaboraManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->section('Recherche des dossiers SISH rejetés...');
+        $io->text('Veuillez patienter...');
+
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $queryBuilder->select('j')
+            ->from(JobEvent::class, 'j')
+            ->innerJoin(Signalement::class, 's', 'ON', 'j.signalementId = s.id')
+            ->innerJoin(Partner::class, 'p', 'ON', 'j.partnerId = p.id')
+            ->innerJoin(Affectation::class, 'a', 'ON', 'a.signalement = s AND a.partner = p')
+            ->where('j.createdAt > :date')
+            ->andWhere('j.partnerType = :partnerType')
+            ->andWhere('j.response LIKE :rejet')
+            ->andWhere('a.statut <> :statutRefuse')
+            ->setParameter('date', '2026-05-06')
+            ->setParameter('partnerType', PartnerType::ARS)
+            ->setParameter('rejet', '%Rejet%')
+            ->setParameter('statutRefuse', AffectationStatus::REFUSED);
+
+        $jobEvents = $queryBuilder->getQuery()->getResult();
+
+        $countProcessed = 0;
+        $countIgnored = 0;
+        $countError = 0;
+
+        /** @var JobEvent $jobEvent */
+        foreach ($jobEvents as $jobEvent) {
+            try {
+                $signalement = $this->entityManager->getRepository(Signalement::class)->find($jobEvent->getSignalementId());
+                $partner = $this->entityManager->getRepository(Partner::class)->find($jobEvent->getPartnerId());
+
+                if (!$signalement || !$partner) {
+                    $io->error(sprintf(
+                        'Signalement %s ou Partner %s non trouvé pour JobEvent %s',
+                        $jobEvent->getSignalementId(),
+                        $jobEvent->getPartnerId(), $jobEvent->getId()
+                    ));
+                    ++$countError;
+                    continue;
+                }
+
+                $affectation = $this->entityManager->getRepository(Affectation::class)->findOneBy([
+                    'signalement' => $signalement,
+                    'partner' => $partner,
+                ]);
+
+                if (!$affectation) {
+                    $io->warning(sprintf(
+                        'Affectation non trouvée pour Signalement %s et Partner %s',
+                        $signalement->getUuid(),
+                        $partner->getNom()
+                    ));
+                    ++$countIgnored;
+                    continue;
+                }
+
+                $responseData = json_decode($jobEvent->getResponse(), true);
+                if (null === $responseData) {
+                    $io->error(sprintf('Impossible de décoder la réponse pour JobEvent %s', $jobEvent->getId()));
+                    ++$countError;
+                    continue;
+                }
+
+                $dossierStateSISHResponse = new DossierStateSISHResponse($responseData, Response::HTTP_OK);
+                if (AbstractEsaboraService::hasSuccess($dossierStateSISHResponse)) {
+                    $this->esaboraManager->synchronizeAffectationFrom($dossierStateSISHResponse, $affectation);
+                    $io->success(sprintf(
+                        'Dossier %s (Affectation %s) traité avec succès.',
+                        $signalement->getUuid(),
+                        $affectation->getId()
+                    ));
+                    ++$countProcessed;
+                } else {
+                    $io->error(sprintf('Erreur lors du traitement du JobEvent %s avec SasEtat = %s',
+                        $jobEvent->getId(),
+                        $dossierStateSISHResponse->getSasEtat()
+                    ));
+                    ++$countError;
+                }
+            } catch (\Throwable $exception) {
+                $io->error(sprintf(
+                    'Erreur lors du traitement du JobEvent %s : %s',
+                    $jobEvent->getId(),
+                    $exception->getMessage()
+                ));
+                ++$countError;
+            }
+        }
+
+        $io->section('Compte rendu');
+        $io->table(
+            ['Dossiers traités', 'Dossiers ignorés', 'Erreurs'],
+            [[$countProcessed, $countIgnored, $countError]]
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Service/Interconnection/Esabora/Response/DossierStateSISHResponse.php
+++ b/src/Service/Interconnection/Esabora/Response/DossierStateSISHResponse.php
@@ -7,7 +7,7 @@ use App\Service\Interconnection\Esabora\EsaboraSISHService;
 class DossierStateSISHResponse implements DossierResponseInterface
 {
     public const string COL_REFERENCE_DOSSIER = 'Reference_Dossier';
-    public const string COL_SAS_ETAT = 'EsaboraStatusSAS_Etat';
+    public const string COL_SAS_ETAT = 'Sas_Etat';
     public const string COL_SAS_DATE_DECISION = 'Sas_DateDecision';
     public const string COL_SAS_CAUSE_REFUS = 'Sas_CauseRefus';
     public const string COL_SISH_DOSS_ID = 'SISH_DossId';

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_importe.json
@@ -3,7 +3,7 @@
   "nbResults": 1,
   "columnList": [
     "Reference_Dossier",
-    "EsaboraStatusSAS_Etat",
+    "Sas_Etat",
     "Sas_DateDecision",
     "Sas_CauseRefus",
     "SISH_DossId",

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_importe_sish_schs.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_importe_sish_schs.json
@@ -3,7 +3,7 @@
   "nbResults": 1,
   "columnList": [
     "Reference_Dossier",
-    "EsaboraStatusSAS_Etat",
+    "Sas_Etat",
     "Sas_DateDecision",
     "Sas_CauseRefus",
     "SISH_DossId",

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_rejete.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_rejete.json
@@ -3,7 +3,7 @@
   "nbResults": 1,
   "columnList": [
     "Reference_Dossier",
-    "EsaboraStatusSAS_Etat",
+    "Sas_Etat",
     "Sas_DateDecision",
     "Sas_CauseRefus",
     "SISH_DossId",

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_etat_dossier_sas/etat_termine.json
@@ -3,7 +3,7 @@
   "nbResults": 1,
   "columnList": [
     "Reference_Dossier",
-    "EsaboraStatusSAS_Etat",
+    "Sas_Etat",
     "Sas_DateDecision",
     "Sas_CauseRefus",
     "SISH_DossId",


### PR DESCRIPTION
## Ticket

#5877    

## Description
Régression synchro apparu suite à la revue du mapping SCHS appliqué au SISH https://github.com/MTES-MCT/histologe/pull/5821

## Changements apportés
* Renommer `EsaboraStatusSAS_Etat` par `Sas_Etat`  `DossierStateSISHResponse`
* Correction des mocks
* Ajout commande de reprise pour les dossiers refusés car ces derniers n'existent plus dans le Sas

## Pré-requis
`make load-data`

## Tests
### Commande de reprise
- [ ] Exécuter la commande `make console app="sync-sish-rejet"` pour faire la reprise à partir de la table job_event
- [ ] Se rendre sur la page de notifications http://localhost:8080/bo/notifications et vérifier que les synchronisations ont été effectués

### Commande de sync
- [ ] Exécuter les commandes `make create-db && make mock-restart` 
- [ ] Exécuter la commande `make console app="sync-esabora-sish"`

<img width="1003" height="448" alt="image" src="https://github.com/user-attachments/assets/ca1cc3df-5182-4c2a-b2e2-35cdea11f92f" />

- [ ] Se rendre sur la page de notifications http://localhost:8080/bo/notifications et vérifier que la synchronisation a été effectué sur les 3 dossiers.  
