### PR TITLE
[Tech - Context de suivi] Supprimer ou limiter leur utilisation

### DIFF
--- a/migrations/Version20260504151832.php
+++ b/migrations/Version20260504151832.php
@@ -17,14 +17,14 @@ final class Version20260504151832 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        foreach (SuiviCategory::CategoriesSubmittedByBailleur() as $category) {
+        foreach (SuiviCategory::categoriesSubmittedByBailleur() as $category) {
             $this->addSql('UPDATE suivi SET is_visible_for_bailleur = 1 WHERE category = :category', ['category' => $category->value]);
         }
     }
 
     public function down(Schema $schema): void
     {
-        foreach (SuiviCategory::CategoriesSubmittedByBailleur() as $category) {
+        foreach (SuiviCategory::categoriesSubmittedByBailleur() as $category) {
             $this->addSql('UPDATE suivi SET is_visible_for_bailleur = 0 WHERE category = :category', ['category' => $category->value]);
         }
     }

--- a/migrations/Version20260519155306.php
+++ b/migrations/Version20260519155306.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260519155306 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove context field from Suivi entity';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_suivi_context ON suivi');
+        $this->addSql('ALTER TABLE suivi DROP context');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE suivi ADD context VARCHAR(100) DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_suivi_context ON suivi (context)');
+    }
+}

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -4,7 +4,6 @@ namespace App\Command\Cron;
 
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Manager\SuiviManager;
 use App\Repository\AffectationRepository;
 use App\Repository\InterventionRepository;
@@ -72,7 +71,6 @@ class NotifyVisitsCommand extends AbstractCronCommand
                 category: SuiviCategory::INTERVENTION_PLANNED_REMINDER,
                 sendMail: false,
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_INTERVENTION,
             );
 
             $this->visiteNotifier->notifyUsagers(
@@ -125,7 +123,6 @@ class NotifyVisitsCommand extends AbstractCronCommand
                     description: $description,
                     category: SuiviCategory::INTERVENTION_IS_REQUIRED,
                     sendMail: false,
-                    context: Suivi::CONTEXT_INTERVENTION,
                 );
 
                 $this->visiteNotifier->notifyAffectationSubscribers(

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -92,7 +92,6 @@ class SignalementActionController extends AbstractController
             partner: $partner,
             user : $user,
             isVisibleForUsager: true,
-            context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
             createSubscription: false,
             flush: false,
         );
@@ -131,7 +130,6 @@ class SignalementActionController extends AbstractController
                 partner: $partner,
                 user : $user,
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
                 subscriptionCreated: $subscriptionCreated,
             );
             $this->addFlash('success', ['title' => 'Signalement accepté', 'message' => 'Le signalement a bien été accepté.']);
@@ -178,7 +176,6 @@ class SignalementActionController extends AbstractController
             partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user : $user,
             isVisibleForUsager: true,
-            context: Suivi::CONTEXT_SIGNALEMENT_REFUSED,
             files: $refusSignalement->getFiles(),
             subscriptionCreated: $subscriptionCreated,
         );

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -26,7 +26,7 @@ suivis:
   category: "ASK_FEEDBACK_SENT"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
-  description: "Le signalement a été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
+  description: "Le signalement a été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT. Plus précisément :<br />bla bla bla"
   is_public: 1
   signalement: "2022-3"
   category: "SIGNALEMENT_IS_REFUSED"
@@ -83,7 +83,7 @@ suivis:
   category: "ASK_FEEDBACK_SENT"
 -
   created_by: admin-territoire-13-01@signal-logement.fr
-  description: "Signalement Refusé"
+  description: "Signalement Refusé.Plus précisément :<br />bla bla bla"
   is_public: 1
   signalement: "2023-21"
   category: "SIGNALEMENT_IS_REFUSED"
@@ -112,7 +112,6 @@ suivis:
   description: "Le signalement a été clôturé pour tous les partenaires avec le motif suivant <br /><strong>Refus de visite</strong><br /><strong>Desc. : </strong>bla bla bla<br />"
   is_public: 1
   signalement: "2025-07"
-  context: signalementClosed
   category: "SIGNALEMENT_IS_CLOSED"
 - 
   created_by: user-13-05@signal-logement.fr

--- a/src/DataFixtures/Loader/LoadNotification.php
+++ b/src/DataFixtures/Loader/LoadNotification.php
@@ -3,6 +3,7 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\Enum\NotificationType;
+use App\Entity\Enum\SuiviCategory;
 use App\Factory\NotificationFactory;
 use App\Repository\AffectationRepository;
 use App\Repository\PartnerRepository;
@@ -50,7 +51,7 @@ class LoadNotification extends Fixture implements OrderedFixtureInterface
             $affectation = $this->affectationRepository->findOneBy(['signalement' => $signalement, 'partner' => $partner]);
         }
         if ('CLOTURE_SIGNALEMENT' === $row['type']) {
-            $suivi = $this->suiviRepository->findOneBy(['signalement' => $signalement, 'context' => 'signalementClosed']);
+            $suivi = $this->suiviRepository->findOneBy(['signalement' => $signalement, 'category' => SuiviCategory::SIGNALEMENT_IS_CLOSED->name]);
         }
         if (!empty($row['suivi'])) {
             $suivi = $this->suiviRepository->findOneBy(['signalement' => $signalement, 'description' => $row['suivi']]);

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -93,7 +93,7 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             partner: $createdBy?->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
             user: $createdBy,
             isVisibleForUsager: $row['is_public'],
-            isVisibleForBailleur: in_array($category, SuiviCategory::CategoriesSubmittedByBailleur()),
+            isVisibleForBailleur: in_array($category, SuiviCategory::categoriesSubmittedByBailleur()),
             createdAt: $createdAt,
             flush: false,
         );

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -46,7 +46,6 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
                 partner: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory()),
                 user: $user,
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
                 flush: false,
             );
             $createdAtUpdated = $signalement->getCreatedAt()->modify('+'.$second.' second');
@@ -81,10 +80,6 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
         } elseif (SuiviCategory::MESSAGE_USAGER_POST_CLOTURE->value === $row['category']) {
             $createdAt = $signalement->getClosedAt()->modify('+3 days');
         }
-        $context = null;
-        if (isset($row['context'])) {
-            $context = $row['context'];
-        }
         $category = null;
         if (isset($row['category'])) {
             $category = SuiviCategory::from($row['category']);
@@ -100,7 +95,6 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             isVisibleForUsager: $row['is_public'],
             isVisibleForBailleur: in_array($category, SuiviCategory::CategoriesSubmittedByBailleur()),
             createdAt: $createdAt,
-            context: $context,
             flush: false,
         );
         if (isset($row['force_notifications']) && $row['force_notifications']) {

--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -131,6 +131,15 @@ enum SuiviCategory: string
     }
 
     /** @return array<SuiviCategory> */
+    public static function CategoriesNotifyUsagerOnly(): array
+    {
+        return [
+            self::ASK_DOCUMENT,
+            self::AFFECTATION_IS_ACCEPTED,
+        ];
+    }
+
+    /** @return array<SuiviCategory> */
     public static function CategoriesSubmittedByBailleur(): array
     {
         return [

--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -131,7 +131,7 @@ enum SuiviCategory: string
     }
 
     /** @return array<SuiviCategory> */
-    public static function CategoriesNotifyUsagerOnly(): array
+    public static function categoriesNotifyUsagerOnly(): array
     {
         return [
             self::ASK_DOCUMENT,
@@ -140,7 +140,7 @@ enum SuiviCategory: string
     }
 
     /** @return array<SuiviCategory> */
-    public static function CategoriesSubmittedByBailleur(): array
+    public static function categoriesSubmittedByBailleur(): array
     {
         return [
             self::MESSAGE_BAILLEUR,

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -215,7 +215,7 @@ class Suivi implements EntityHistoryInterface
 
             return $this->getCreatedBy()->getPartnerInTerritoryOrFirstOne($this->getSignalement()->getTerritory())?->getNom().$separator.$this->getCreatedBy()->getNomComplet(true);
         }
-        if (in_array($this->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
+        if (in_array($this->getCategory(), SuiviCategory::categoriesSubmittedByBailleur())) {
             return $forBailleur ? 'Vous (bailleur)' : 'Bailleur';
         }
         if ($this->getCreatedAt()->format('Y') >= 2024) {
@@ -388,7 +388,7 @@ class Suivi implements EntityHistoryInterface
             return false;
         }
 
-        return in_array($this->category, SuiviCategory::CategoriesSubmittedByBailleur(), true);
+        return in_array($this->category, SuiviCategory::categoriesSubmittedByBailleur(), true);
     }
 
     public function setSeenByUsager(bool $seen): void

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['type'], name: 'idx_suivi_type')]
 #[ORM\Index(columns: ['created_at'], name: 'idx_suivi_created_at')]
 #[ORM\Index(columns: ['signalement_id', 'type', 'created_at'], name: 'idx_suivi_signalement_type_created_at')]
-#[ORM\Index(columns: ['context'], name: 'idx_suivi_context')]
 #[ORM\Index(columns: ['category', 'signalement_id', 'created_at'], name: 'idx_suivi_category_signalement_created_at')]
 #[ORM\Index(columns: ['is_visible_for_usager', 'signalement_id', 'created_at'], name: 'idx_suivi_is_visible_for_usager_signalement_created_at')]
 #[ORM\Index(columns: ['signalement_id', 'created_at'], name: 'idx_suivi_signalement_created_at')]
@@ -32,12 +31,6 @@ class Suivi implements EntityHistoryInterface
     public const int TYPE_PARTNER = 3;
     public const int TYPE_TECHNICAL = 4;
     public const int TYPE_USAGER_POST_CLOTURE = 5;
-    public const string CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
-    public const string CONTEXT_INTERVENTION = 'intervention';
-    public const string CONTEXT_SCHS = 'schs';
-    public const string CONTEXT_SIGNALEMENT_ACCEPTED = 'signalementAccepted';
-    public const string CONTEXT_SIGNALEMENT_REFUSED = 'signalementRefused';
-    public const string CONTEXT_SIGNALEMENT_CLOSED = 'signalementClosed';
 
     public const int DEFAULT_PERIOD_INACTIVITY = 30;
     public const int DEFAULT_PERIOD_RELANCE = 45;
@@ -76,9 +69,6 @@ class Suivi implements EntityHistoryInterface
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'suivis')]
     #[ORM\JoinColumn(nullable: false)]
     private Signalement $signalement;
-
-    #[ORM\Column(length: 100, nullable: true)]
-    private ?string $context = null;
 
     private bool $sendMail = true;
 
@@ -308,18 +298,6 @@ class Suivi implements EntityHistoryInterface
     public function setType(int $type): self
     {
         $this->type = $type;
-
-        return $this;
-    }
-
-    public function getContext(): ?string
-    {
-        return $this->context;
-    }
-
-    public function setContext(?string $context): self
-    {
-        $this->context = $context;
 
         return $this;
     }

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -5,7 +5,6 @@ namespace App\EventSubscriber;
 use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Event\AffectationAnsweredEvent;
 use App\Factory\Interconnection\Idoss\DossierMessageFactory;
@@ -91,7 +90,6 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
                 category: SuiviCategory::AFFECTATION_IS_ACCEPTED,
                 user: $adminUser,
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_NOTIFY_USAGER_ONLY,
             );
         }
     }

--- a/src/EventSubscriber/InterventionAbortedSubscriber.php
+++ b/src/EventSubscriber/InterventionAbortedSubscriber.php
@@ -5,7 +5,6 @@ namespace App\EventSubscriber;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Intervention;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
@@ -50,7 +49,7 @@ class InterventionAbortedSubscriber implements EventSubscriberInterface
                 partner: $context['createdByPartner'],
                 user: $currentUser,
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_INTERVENTION,
+                sendMail: false,
             );
 
             $this->visiteNotifier->notifyUsagers(

--- a/src/EventSubscriber/InterventionCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionCanceledSubscriber.php
@@ -5,7 +5,6 @@ namespace App\EventSubscriber;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Intervention;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
@@ -51,7 +50,7 @@ class InterventionCanceledSubscriber implements EventSubscriberInterface
                 partner: $context['createdByPartner'],
                 user: $currentUser,
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_INTERVENTION,
+                sendMail: false,
             );
 
             $this->visiteNotifier->notifyUsagers(

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -6,7 +6,6 @@ use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Intervention;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
@@ -63,7 +62,7 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
                 partner: $context['createdByPartner'],
                 user: $currentUser,
                 isVisibleForUsager: $isUsagerNotified,
-                context: Suivi::CONTEXT_INTERVENTION,
+                sendMail: false,
                 files: $intervention->getFiles(),
             );
 

--- a/src/EventSubscriber/InterventionCreatedSubscriber.php
+++ b/src/EventSubscriber/InterventionCreatedSubscriber.php
@@ -5,7 +5,6 @@ namespace App\EventSubscriber;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Intervention;
-use App\Entity\Suivi;
 use App\Event\InterventionCreatedEvent;
 use App\Manager\SuiviManager;
 use App\Service\Interconnection\Esabora\EsaboraSISHService;
@@ -64,7 +63,7 @@ readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
             partner: $event->getPartner(),
             user: $event->getUser(),
             isVisibleForUsager: $isVisibleForUsager,
-            context: Suivi::CONTEXT_INTERVENTION,
+            sendMail: false,
         );
         $event->setSuivi($suivi);
         if (InterventionType::VISITE === $intervention->getType()

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -4,7 +4,6 @@ namespace App\EventSubscriber;
 
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Event\InterventionEditedEvent;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
@@ -64,7 +63,7 @@ readonly class InterventionEditedSubscriber implements EventSubscriberInterface
                 partner: $event->getPartner(),
                 user: $currentUser,
                 isVisibleForUsager: $event->isUsagerNotified(),
-                context: Suivi::CONTEXT_INTERVENTION,
+                sendMail: false,
                 files: $intervention->getFiles(),
             );
 

--- a/src/EventSubscriber/InterventionRescheduledSubscriber.php
+++ b/src/EventSubscriber/InterventionRescheduledSubscriber.php
@@ -5,7 +5,6 @@ namespace App\EventSubscriber;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Intervention;
-use App\Entity\Suivi;
 use App\Event\InterventionRescheduledEvent;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
@@ -52,7 +51,7 @@ class InterventionRescheduledSubscriber implements EventSubscriberInterface
                 partner: $event->getPartner(),
                 user: $event->getUser(),
                 isVisibleForUsager: true,
-                context: Suivi::CONTEXT_INTERVENTION,
+                sendMail: false,
             );
 
             $this->visiteNotifier->notifyUsagers(

--- a/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
+++ b/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
@@ -4,7 +4,6 @@ namespace App\EventSubscriber;
 
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Event\InterventionUpdatedByEsaboraEvent;
 use App\Manager\SuiviManager;
 use App\Service\Intervention\InterventionDescriptionGenerator;
@@ -54,7 +53,7 @@ readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriber
             partner: $event->getPartner(),
             user: $event->getUser(),
             isVisibleForUsager: !$signalement->isTiersDeclarant(),
-            context: Suivi::CONTEXT_INTERVENTION,
+            sendMail: false,
         );
         $event->setSuivi($suivi);
         if (InterventionType::VISITE === $intervention->getType()

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -3,7 +3,6 @@
 namespace App\EventSubscriber;
 
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Event\SignalementClosedEvent;
 use App\Manager\SuiviManager;
@@ -46,7 +45,6 @@ readonly class SignalementClosedSubscriber implements EventSubscriberInterface
             partner: $event->getPartner(),
             user: $user,
             isVisibleForUsager: $signalementAffectationClose->isVisibleForUsager(),
-            context: Suivi::CONTEXT_SIGNALEMENT_CLOSED,
             files: $signalementAffectationClose->getFiles(),
         );
         $signalement->addSuivi($suivi);

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -46,7 +46,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
     private function sendToAdminAndPartners(Suivi $suivi): void
     {
-        if (in_array($suivi->getCategory(), SuiviCategory::CategoriesNotifyUsagerOnly()) || in_array($suivi->getCategory(), SuiviCategory::injonctionBailleurCategories())) {
+        if (in_array($suivi->getCategory(), SuiviCategory::categoriesNotifyUsagerOnly()) || in_array($suivi->getCategory(), SuiviCategory::injonctionBailleurCategories())) {
             return;
         }
         if (SuiviCategory::SIGNALEMENT_IS_CLOSED === $suivi->getCategory()) {
@@ -94,7 +94,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
     private function sendToBailleur(Suivi $suivi): void
     {
-        if ($suivi->getIsVisibleForBailleur() && !in_array($suivi->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
+        if ($suivi->getIsVisibleForBailleur() && !in_array($suivi->getCategory(), SuiviCategory::categoriesSubmittedByBailleur())) {
             $this->notificationAndMailSender->sendNewSuiviToBailleur($suivi);
         }
     }

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -32,9 +32,6 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
         if (!$suivi->getSendMail()) {
             return;
         }
-        if (Suivi::CONTEXT_INTERVENTION === $suivi->getContext()) {
-            return;
-        }
         $signalementStatus = $suivi->getSignalement()->getStatut();
         if (in_array($signalementStatus, SignalementStatus::excludedStatuses(includeInjonctionBailleur: false))) {
             return;
@@ -49,13 +46,10 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
     private function sendToAdminAndPartners(Suivi $suivi): void
     {
-        if (Suivi::CONTEXT_NOTIFY_USAGER_ONLY === $suivi->getContext()
-            // Excludes automatic suivis related to injonction bailleur, without blocking other types of suivis if signalement in status INJONCTION_BAILLEUR
-            // -> Avoids too much notifications for now
-            || in_array($suivi->getCategory(), SuiviCategory::injonctionBailleurCategories())) {
+        if (in_array($suivi->getCategory(), SuiviCategory::CategoriesNotifyUsagerOnly()) || in_array($suivi->getCategory(), SuiviCategory::injonctionBailleurCategories())) {
             return;
         }
-        if (Suivi::CONTEXT_SIGNALEMENT_CLOSED === $suivi->getContext()) {
+        if (SuiviCategory::SIGNALEMENT_IS_CLOSED === $suivi->getCategory()) {
             $this->notificationAndMailSender->sendSignalementIsClosedToPartners($suivi);
         } elseif (SuiviCategory::DEMANDE_ABANDON_PROCEDURE === $suivi->getCategory()) {
             $this->notificationAndMailSender->sendDemandeAbandonProcedureToAdminsAndPartners($suivi);
@@ -77,16 +71,16 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
                 return;
             }
-            switch ($suivi->getContext()) {
-                case Suivi::CONTEXT_SIGNALEMENT_ACCEPTED:
-                    $this->notificationAndMailSender->sendSignalementIsAcceptedToUsager($suivi);
+            switch ($suivi->getCategory()) {
+                case SuiviCategory::SIGNALEMENT_IS_CLOSED:
+                    $this->notificationAndMailSender->sendSignalementIsClosedToUsager($suivi);
                     break;
-                case Suivi::CONTEXT_SIGNALEMENT_REFUSED:
+                case SuiviCategory::SIGNALEMENT_IS_REFUSED:
                     $motifDescription = \explode(self::SEPARATOR_MOTIF_REFUS, $suivi->getDescription())[1];
                     $this->notificationAndMailSender->sendSignalementIsRefusedToUsager($suivi, $motifDescription);
                     break;
-                case Suivi::CONTEXT_SIGNALEMENT_CLOSED:
-                    $this->notificationAndMailSender->sendSignalementIsClosedToUsager($suivi);
+                case SuiviCategory::SIGNALEMENT_IS_ACTIVE:
+                    $this->notificationAndMailSender->sendSignalementIsAcceptedToUsager($suivi);
                     break;
                 default:
                     if (SignalementStatus::CLOSED !== $suivi->getSignalement()->getStatut()
@@ -100,7 +94,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
     private function sendToBailleur(Suivi $suivi): void
     {
-        if ($suivi->getSendMail() && $suivi->getIsVisibleForBailleur() && !in_array($suivi->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
+        if ($suivi->getIsVisibleForBailleur() && !in_array($suivi->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
             $this->notificationAndMailSender->sendNewSuiviToBailleur($suivi);
         }
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -29,7 +29,6 @@ use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\SignalementQualification;
-use App\Entity\Suivi;
 use App\Entity\Territory;
 use App\Entity\TiersInvitation;
 use App\Entity\User;
@@ -993,7 +992,6 @@ class SignalementManager
             partner: $partner,
             user: $adminUser,
             isVisibleForUsager: true,
-            context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
             flush: false,
             createSubscription: $createSubscription,
         );

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -57,7 +57,6 @@ class SuiviManager
         bool $isVisibleForUsager = false,
         bool $isVisibleForBailleur = false,
         ?\DateTimeImmutable $createdAt = null,
-        ?string $context = null,
         bool $sendMail = true,
         iterable $files = [],
         bool $flush = true,
@@ -76,7 +75,6 @@ class SuiviManager
             ->setType(SuiviCategory::getSuiviTypeForSuiviCategory($category))
             ->setIsVisibleForUsager($isVisibleForUsager)
             ->setIsVisibleForBailleur($isVisibleForBailleur)
-            ->setContext($context)
             ->setSendMail($sendMail)
             ->setCategory($category);
         if (!empty($createdAt)) {

--- a/src/Messenger/MessageHandler/NewSignalementCheckFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/NewSignalementCheckFileMessageHandler.php
@@ -230,7 +230,6 @@ class NewSignalementCheckFileMessageHandler
             category: SuiviCategory::ASK_DOCUMENT,
             user: $userAdmin,
             isVisibleForUsager: true,
-            context: Suivi::CONTEXT_NOTIFY_USAGER_ONLY,
         );
     }
 }

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -323,8 +323,8 @@ class SuiviRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('s')
             ->where('s.originalData IS NOT NULL')
-            ->andWhere('s.context = :context')
-            ->setParameter('context', Suivi::CONTEXT_SCHS);
+            ->andWhere('s.category = :category')
+            ->setParameter('category', SuiviCategory::MESSAGE_ESABORA_SCHS);
 
         $list = $qb->getQuery()->getResult();
         $indexed = [];

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -340,7 +340,6 @@ class EsaboraManager
             category: SuiviCategory::MESSAGE_ESABORA_SCHS,
             partner: $affectation->getPartner(),
             user: $this->adminUser,
-            context: Suivi::CONTEXT_SCHS,
             flush: false,
         );
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
@@ -41,7 +41,7 @@ class SuiviNewCommentBackMailer extends AbstractNotificationMailer
             if ($suivi->getPartner()) {
                 $suiviCreator .= ' ('.$suivi->getPartner()->getNom().')';
             }
-        } elseif (in_array($suivi->getCategory(), SuiviCategory::CategoriesSubmittedByBailleur())) {
+        } elseif (in_array($suivi->getCategory(), SuiviCategory::categoriesSubmittedByBailleur())) {
             $suiviCreator = $signalement->getDisplayedNomProprio().' (bailleur)';
         } elseif ($signalement->getPrenomDeclarant()) {
             $suiviCreator = $signalement->getPrenomDeclarant().' '.$signalement->getNomDeclarant();

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -77,6 +77,8 @@ class SuiviManagerTest extends KernelTestCase
             'motif_cloture' => MotifCloture::tryFrom('NON_DECENCE'),
             'subject' => 'test',
         ];
+        $signalement->setMotifCloture($params['motif_cloture']);
+        $signalement->setClosedBy($user);
         $suivi = $this->suiviManager->createSuivi(
             signalement : $signalement,
             description : SuiviManager::buildDescriptionClotureSignalement($params),
@@ -156,6 +158,8 @@ class SuiviManagerTest extends KernelTestCase
             'motif_cloture' => MotifCloture::tryFrom('NON_DECENCE'),
             'subject' => 'test',
         ];
+        $signalement->setMotifCloture($params['motif_cloture']);
+        $signalement->setClosedBy($user);
         $suivi = $this->suiviManager->createSuivi(
             signalement : $signalement,
             description : SuiviManager::buildDescriptionClotureSignalement($params),


### PR DESCRIPTION
## Ticket

#5834

## Description
Suppression du champ `context` de suivi, inutile maintenant que la propriété  `category `existe.

## Pré-requis
`make execute-migration name=Version20260519155306 direction=up`

## Tests
- [ ] CI OK
- [ ] Faire quelque textes et vérifier les notification sur les catégorie de suivi concerné par les modifications
