### PR TITLE
[BO - Signalement] Ajout de message pour les logements vacants lors de l'ajout de suivi

### DIFF
--- a/templates/back/signalement/view/add-edit-suivi-form.html.twig
+++ b/templates/back/signalement/view/add-edit-suivi-form.html.twig
@@ -8,19 +8,20 @@
             Destinataires du message
         </legend>
         <div class="fr-fieldset__element">
-            {% if show_email_alert(signalement.mailDeclarant) and show_email_alert(signalement.mailOccupant) %}
-                <p class="fr-badge fr-badge--error fr-mb-3w">L'adresse e-mail de l'usager n'est pas valide. Vous ne pouvez pas lui envoyer le suivi.</p>
-            {% endif %}
             {% if signalement.isLogementVacant %}
                 <p class="fr-badge fr-badge--error fr-mb-3w">Le logement est vacant. Vous ne pouvez pas envoyer le suivi aux usagers.</p>
+            {% elseif show_email_alert(signalement.mailDeclarant) and show_email_alert(signalement.mailOccupant) %}
+                <p class="fr-badge fr-badge--error fr-mb-3w">L'adresse e-mail de l'usager n'est pas valide. Vous ne pouvez pas lui envoyer le suivi.</p>
             {% endif %}
             {{ form_row(form.isVisibleForUsager) }}
+
             {% if form.isVisibleForBailleur is defined %}
                 {% if show_email_alert(signalement.mailProprio) %}
                     <p class="fr-badge fr-badge--error fr-mb-3w">L'adresse e-mail du bailleur n'est pas renseignée ou invalide. Il ne sera pas notifié par e-mail.</p>
                 {% endif %}
                 {{ form_row(form.isVisibleForBailleur) }}
             {% endif %}
+            
             {{ form_row(form.isVisibleForPartners) }}
         </div>
     </fieldset>

--- a/templates/back/signalement/view/add-edit-suivi-form.html.twig
+++ b/templates/back/signalement/view/add-edit-suivi-form.html.twig
@@ -11,6 +11,9 @@
             {% if show_email_alert(signalement.mailDeclarant) and show_email_alert(signalement.mailOccupant) %}
                 <p class="fr-badge fr-badge--error fr-mb-3w">L'adresse e-mail de l'usager n'est pas valide. Vous ne pouvez pas lui envoyer le suivi.</p>
             {% endif %}
+            {% if signalement.isLogementVacant %}
+                <p class="fr-badge fr-badge--error fr-mb-3w">Le logement est vacant. Vous ne pouvez pas envoyer le suivi aux usagers.</p>
+            {% endif %}
             {{ form_row(form.isVisibleForUsager) }}
             {% if form.isVisibleForBailleur is defined %}
                 {% if show_email_alert(signalement.mailProprio) %}


### PR DESCRIPTION
## Ticket

#5889   

## Description
Ajout de suivi : ajout d'une alerte concernant les usager quand le logement est vacant

## Tests
- [ ] Tester l'affichage avec différentes configurations
