### PR TITLE
[QA - BUG] Doctrine\DBAL\Exception\DeadlockException

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -27,6 +27,9 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+        show_file:
+            pattern: ^/show/
+            security: false
         api:
             pattern: ^/api
             stateless: true


### PR DESCRIPTION
## Ticket

#5891

## Description
Exclusion de la route d'affichage des documents du firewall pour éviter qu'elle provoque une erreur `DeadlockException` (et enregistre un historique de login)

Jusqu’à présent la route `show_file` était sous le firewall `main` ce qui implique que lorsque un user avec le cookie `remember-me` valide perdait sa session, l'appel a cette route passait dans le système d’authentification et enregistré un login. Cette route étant très utilisé (a chaque fois qu'on affiche l’aperçu d'une image) elle générait régulièrement une erreur `DeadlockException` à la sauvegarde du login : 

https://sentry.incubateur.net/organizations/betagouv/issues/278185/events/?environment=prod&project=61&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

## Tests
- [ ] Se connecter au BO avec l'option "se souvenir de moi" aller sur l'onglet document d'un signalement en contenant. 
- [ ] Supprimer via les outils de dev du navigateur le cookie `PHPSESSID`
- [ ] Ouvrir une des document et vérifier dans l'historique qu'aucun evenement LOGIN n'est enregistré
- [ ] Supprimer le firewall `show_file` ouvrir un doc et voir qu'une entrée est enregistré dans l'historique
