### PR TITLE
[BO - Dashboard] Invalider le cache

### DIFF
--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -266,4 +266,38 @@ enum SuiviCategory: string
                 throw new \LogicException(sprintf('La catégorie de suivi %s n\'a pas de type de suivi défini.', $category->name));
         }
     }
+
+    /** @return array<SuiviCategory> */
+    public static function getSuiviTypeActivitePartenaire(): array
+    {
+        return [
+            SuiviCategory::MESSAGE_PARTNER,
+            SuiviCategory::SIGNALEMENT_EDITED_BO,
+            SuiviCategory::SIGNALEMENT_IS_ACTIVE,
+            SuiviCategory::SIGNALEMENT_IS_REOPENED,
+            SuiviCategory::INTERVENTION_IS_CREATED,
+            SuiviCategory::INTERVENTION_IS_CANCELED,
+            SuiviCategory::INTERVENTION_IS_ABORTED,
+            SuiviCategory::INTERVENTION_HAS_CONCLUSION,
+            SuiviCategory::INTERVENTION_HAS_CONCLUSION_EDITED,
+            SuiviCategory::INTERVENTION_IS_RESCHEDULED,
+            SuiviCategory::INTERVENTION_IS_DONE,
+            SuiviCategory::INTERVENTION_CONTROLE_IS_CREATED,
+            SuiviCategory::INTERVENTION_CONTROLE_IS_RESCHEDULED,
+            SuiviCategory::INTERVENTION_CONTROLE_IS_DONE,
+            SuiviCategory::INTERVENTION_ARRETE_IS_CREATED,
+            SuiviCategory::INTERVENTION_ARRETE_IS_RESCHEDULED,
+            SuiviCategory::NEW_DOCUMENT,
+            SuiviCategory::AFFECTATION_IS_CLOSED,
+        ];
+    }
+
+    /** @return array<SuiviCategory> */
+    public static function getSuiviTypeActiviteUsager(): array
+    {
+        return [
+            SuiviCategory::MESSAGE_USAGER_POST_CLOTURE,
+            SuiviCategory::MESSAGE_USAGER,
+        ];
+    }
 }

--- a/src/EventListener/DashboardKpiCacheInvalidationListener.php
+++ b/src/EventListener/DashboardKpiCacheInvalidationListener.php
@@ -57,6 +57,7 @@ final readonly class DashboardKpiCacheInvalidationListener
             );
 
             // DOSSIERS_A_FERMER - Dossiers fermés par tous les partenaires
+            // DOSSIERS_A_FERMER - Dossiers fermés par les communes
             $this->invalidateTerritoryKpiTags(
                 TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
                 $territoryId

--- a/src/EventListener/DashboardKpiCacheInvalidationListener.php
+++ b/src/EventListener/DashboardKpiCacheInvalidationListener.php
@@ -90,7 +90,10 @@ final readonly class DashboardKpiCacheInvalidationListener
                 );
             }
 
-            if (SuiviCategory::MESSAGE_PARTNER == $entity->getCategory()) {
+            if (in_array($entity->getCategory(), [
+                SuiviCategory::MESSAGE_USAGER_POST_CLOTURE,
+                SuiviCategory::MESSAGE_USAGER,
+            ], true)) {
                 // DOSSIERS_MESSAGES_PARTNERS - Nouveaux messages
                 // DOSSIERS_MESSAGES_PARTNERS - Messages après fermeture
                 // DOSSIERS_MESSAGES_PARTNERS - Messages usagers n'ayant pas eu de réponse
@@ -144,6 +147,11 @@ final readonly class DashboardKpiCacheInvalidationListener
                 // DOSSIERS_A_FERMER - Dossiers fermés par tous les partenaires
                 $this->invalidateTerritoryKpiTags(
                     TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                    $territoryId
+                );
+                // DOSSIERS_MESSAGES_PARTNERS - Nouveaux messages
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
                     $territoryId
                 );
             }

--- a/src/EventListener/DashboardKpiCacheInvalidationListener.php
+++ b/src/EventListener/DashboardKpiCacheInvalidationListener.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Affectation;
+use App\Entity\Enum\AffectationStatus;
+use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\SuiviCategory;
+use App\Entity\FailedEmail;
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Entity\UserSignalementSubscription;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCacheHelper;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+final readonly class DashboardKpiCacheInvalidationListener
+{
+    public function __construct(
+        private TagAwareCacheInterface $cache,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof Signalement) {
+            // NOUVEAUX_DOSSIERS - Dossiers déposés depuis le formulaire usager
+            // NOUVEAUX_DOSSIERS - Dossiers déposés depuis un formulaire pro
+            $territoryId = $entity->getTerritory()->getId();
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
+                $territoryId
+            );
+        }
+
+        if ($entity instanceof Affectation) {
+            $territoryId = $entity->getTerritory()->getId();
+            // NOUVEAUX_DOSSIERS - Dossiers non affectés aux partenaires
+            // NOUVEAUX_DOSSIERS - Nouveaux dossiers
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
+                $territoryId
+            );
+
+            // DOSSIERS_A_FERMER - Dossiers fermés par tous les partenaires
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                $territoryId
+            );
+        }
+
+        if ($entity instanceof Suivi) {
+            $territoryId = $entity->getSignalement()->getTerritory()->getId();
+
+            if (in_array($entity->getCategory(), [
+                SuiviCategory::MESSAGE_PARTNER,
+                SuiviCategory::SIGNALEMENT_EDITED_BO,
+                SuiviCategory::SIGNALEMENT_IS_ACTIVE,
+                SuiviCategory::SIGNALEMENT_IS_REOPENED,
+                SuiviCategory::INTERVENTION_IS_CREATED,
+                SuiviCategory::INTERVENTION_IS_CANCELED,
+                SuiviCategory::INTERVENTION_IS_ABORTED,
+                SuiviCategory::INTERVENTION_HAS_CONCLUSION,
+                SuiviCategory::INTERVENTION_HAS_CONCLUSION_EDITED,
+                SuiviCategory::INTERVENTION_IS_RESCHEDULED,
+                SuiviCategory::INTERVENTION_IS_DONE,
+                SuiviCategory::INTERVENTION_CONTROLE_IS_CREATED,
+                SuiviCategory::INTERVENTION_CONTROLE_IS_RESCHEDULED,
+                SuiviCategory::INTERVENTION_CONTROLE_IS_DONE,
+                SuiviCategory::INTERVENTION_ARRETE_IS_CREATED,
+                SuiviCategory::INTERVENTION_ARRETE_IS_RESCHEDULED,
+                SuiviCategory::NEW_DOCUMENT,
+                SuiviCategory::AFFECTATION_IS_CLOSED,
+            ], true)) {
+                // DOSSIERS_A_VERIFIER - Dossier sans activité partenaire
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
+                    $territoryId
+                );
+            }
+
+            if (SuiviCategory::MESSAGE_PARTNER == $entity->getCategory()) {
+                // DOSSIERS_MESSAGES_PARTNERS - Nouveaux messages
+                // DOSSIERS_MESSAGES_PARTNERS - Messages après fermeture
+                // DOSSIERS_MESSAGES_PARTNERS - Messages usagers n'ayant pas eu de réponse
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
+                    $territoryId
+                );
+            }
+
+            // DOSSIERS_A_FERMER - Dossiers avec au moins 3 relances usager restées sans réponse
+            if (SuiviCategory::MESSAGE_USAGER == $entity->getCategory()) {
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                    $territoryId
+                );
+            }
+
+            // DOSSIERS_A_FERMER - Demandes de fermeture par l'usager
+            if (SuiviCategory::DEMANDE_ABANDON_PROCEDURE == $entity->getCategory()) {
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                    $territoryId
+                );
+            }
+        }
+
+        if ($entity instanceof FailedEmail) {
+            // DOSSIERS_A_VERIFIER - Adresses e-mail à vérifier
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
+            );
+        }
+
+        if ($entity instanceof UserSignalementSubscription) {
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
+            );
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof Signalement) {
+            $territoryId = $entity->getTerritory()->getId();
+            if (SignalementStatus::CLOSED === $entity->getStatut()) {
+                // DOSSIERS_A_FERMER - Dossiers fermés par tous les partenaires
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                    $territoryId
+                );
+            }
+
+            if ($this->hasUsagerEmailChanged($args, $entity)) {
+                // DOSSIERS_MESSAGES_USAGERS - Adresses e-mail à vérifier
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
+                    $territoryId
+                );
+            }
+        }
+
+        if ($entity instanceof Affectation) {
+            $territoryId = $entity->getTerritory()->getId();
+            if (AffectationStatus::CLOSED === $entity->getStatut()) {
+                // DOSSIERS_A_FERMER - Dossiers fermés par tous les partenaires
+                // DOSSIERS_A_FERMER -  Dossiers fermés par les communes
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                    $territoryId
+                );
+            }
+
+            if (AffectationStatus::ACCEPTED === $entity->getStatut()) {
+                // DOSSIERS_A_VERIFIER - Dossier en attente
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
+                    $territoryId
+                );
+
+                // NOUVEAUX_DOSSIERS - Nouveaux dossiers
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
+                    $territoryId
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function invalidateTerritoryKpiTags(string $kpiName, ?int $territoryId = null): void
+    {
+        $this->cache->invalidateTags([
+            'territory_'.$kpiName.'_all',
+            'territory_'.$kpiName.'_'.$territoryId,
+        ]);
+    }
+
+    private function hasUsagerEmailChanged(PostUpdateEventArgs $args, Signalement $signalement): bool
+    {
+        $changeSet = $args->getObjectManager()->getUnitOfWork()->getEntityChangeSet($signalement);
+
+        return array_key_exists('mailOccupant', $changeSet)
+            || array_key_exists('mailDeclarant', $changeSet);
+    }
+}

--- a/src/EventListener/DashboardKpiCacheInvalidationListener.php
+++ b/src/EventListener/DashboardKpiCacheInvalidationListener.php
@@ -13,6 +13,7 @@ use App\Entity\UserSignalementSubscription;
 use App\Service\DashboardTabPanel\Kpi\TabCountKpiCacheHelper;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Events;
 use Psr\Cache\InvalidArgumentException;
@@ -20,6 +21,7 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 #[AsDoctrineListener(event: Events::postPersist)]
 #[AsDoctrineListener(event: Events::postUpdate)]
+#[AsDoctrineListener(event: Events::postRemove)]
 final readonly class DashboardKpiCacheInvalidationListener
 {
     public function __construct(
@@ -63,26 +65,7 @@ final readonly class DashboardKpiCacheInvalidationListener
         if ($entity instanceof Suivi) {
             $territoryId = $entity->getSignalement()->getTerritory()->getId();
 
-            if (in_array($entity->getCategory(), [
-                SuiviCategory::MESSAGE_PARTNER,
-                SuiviCategory::SIGNALEMENT_EDITED_BO,
-                SuiviCategory::SIGNALEMENT_IS_ACTIVE,
-                SuiviCategory::SIGNALEMENT_IS_REOPENED,
-                SuiviCategory::INTERVENTION_IS_CREATED,
-                SuiviCategory::INTERVENTION_IS_CANCELED,
-                SuiviCategory::INTERVENTION_IS_ABORTED,
-                SuiviCategory::INTERVENTION_HAS_CONCLUSION,
-                SuiviCategory::INTERVENTION_HAS_CONCLUSION_EDITED,
-                SuiviCategory::INTERVENTION_IS_RESCHEDULED,
-                SuiviCategory::INTERVENTION_IS_DONE,
-                SuiviCategory::INTERVENTION_CONTROLE_IS_CREATED,
-                SuiviCategory::INTERVENTION_CONTROLE_IS_RESCHEDULED,
-                SuiviCategory::INTERVENTION_CONTROLE_IS_DONE,
-                SuiviCategory::INTERVENTION_ARRETE_IS_CREATED,
-                SuiviCategory::INTERVENTION_ARRETE_IS_RESCHEDULED,
-                SuiviCategory::NEW_DOCUMENT,
-                SuiviCategory::AFFECTATION_IS_CLOSED,
-            ], true)) {
+            if (in_array($entity->getCategory(), SuiviCategory::getSuiviTypeActivitePartenaire(), true)) {
                 // DOSSIERS_A_VERIFIER - Dossier sans activité partenaire
                 $this->invalidateTerritoryKpiTags(
                     TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
@@ -90,10 +73,7 @@ final readonly class DashboardKpiCacheInvalidationListener
                 );
             }
 
-            if (in_array($entity->getCategory(), [
-                SuiviCategory::MESSAGE_USAGER_POST_CLOTURE,
-                SuiviCategory::MESSAGE_USAGER,
-            ], true)) {
+            if (in_array($entity->getCategory(), SuiviCategory::getSuiviTypeActiviteUsager(), true)) {
                 // DOSSIERS_MESSAGES_PARTNERS - Nouveaux messages
                 // DOSSIERS_MESSAGES_PARTNERS - Messages après fermeture
                 // DOSSIERS_MESSAGES_PARTNERS - Messages usagers n'ayant pas eu de réponse
@@ -189,6 +169,30 @@ final readonly class DashboardKpiCacheInvalidationListener
                     $territoryId
                 );
             }
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function postRemove(PostRemoveEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof Affectation) {
+            $territoryId = $entity->getTerritory()->getId();
+
+            // NOUVEAUX_DOSSIERS - Dossiers non affectés aux partenaires
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
+                $territoryId
+            );
+
+            // DOSSIERS_A_FERMER - Dossiers fermés par tous les partenaires
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+                $territoryId
+            );
         }
     }
 

--- a/src/EventListener/DashboardKpiCacheInvalidationListener.php
+++ b/src/EventListener/DashboardKpiCacheInvalidationListener.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\FailedEmail;
+use App\Entity\Notification;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\UserSignalementSubscription;
@@ -76,6 +77,14 @@ final readonly class DashboardKpiCacheInvalidationListener
             if (in_array($entity->getCategory(), SuiviCategory::getSuiviTypeActiviteUsager(), true)) {
                 // DOSSIERS_MESSAGES_PARTNERS - Nouveaux messages
                 // DOSSIERS_MESSAGES_PARTNERS - Messages après fermeture
+                // DOSSIERS_MESSAGES_PARTNERS - Messages usagers n'ayant pas eu de réponse
+                $this->invalidateTerritoryKpiTags(
+                    TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
+                    $territoryId
+                );
+            }
+
+            if ($entity->getIsVisibleForUsager() && SuiviCategory::MESSAGE_PARTNER == $entity->getCategory()) {
                 // DOSSIERS_MESSAGES_PARTNERS - Messages usagers n'ayant pas eu de réponse
                 $this->invalidateTerritoryKpiTags(
                     TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
@@ -169,6 +178,20 @@ final readonly class DashboardKpiCacheInvalidationListener
                     $territoryId
                 );
             }
+        }
+
+        if ($entity instanceof Notification) {
+            $territoryId = $entity->getSignalement()?->getTerritory()?->getId();
+            if (null === $territoryId) {
+                return;
+            }
+
+            // DOSSIERS_MESSAGES_PARTNERS - Nouveaux messages
+            // DOSSIERS_MESSAGES_PARTNERS - Messages après fermeture
+            $this->invalidateTerritoryKpiTags(
+                TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
+                $territoryId
+            );
         }
     }
 

--- a/src/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculator.php
+++ b/src/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculator.php
@@ -18,6 +18,7 @@ class CachedTabCountKpiCalculator implements TabCountKpiCalculatorInterface
 
     /**
      * @param array<int, mixed> $territories
+     *
      * @throws InvalidArgumentException
      */
     public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers

--- a/src/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculator.php
+++ b/src/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculator.php
@@ -21,13 +21,13 @@ class CachedTabCountKpiCalculator implements TabCountKpiCalculatorInterface
      *
      * @throws InvalidArgumentException
      */
-    public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers
+    public function countNouveauxDossiers(array $territories, User $user, TabQueryParameters $params): CountNouveauxDossiers
     {
         return $this->cacheHelper->getOrSet(
             TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
             $user,
-            null,
-            fn () => $this->calculator->countNouveauxDossiers($territories, $user)
+            $params,
+            fn () => $this->calculator->countNouveauxDossiers($territories, $user, $params)
         );
     }
 

--- a/src/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculator.php
+++ b/src/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Service\DashboardTabPanel\Kpi;
+
+use App\Entity\User;
+use App\Service\DashboardTabPanel\TabQueryParameters;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+
+#[AsDecorator(decorates: TabCountKpiCalculatorInterface::class)]
+class CachedTabCountKpiCalculator implements TabCountKpiCalculatorInterface
+{
+    public function __construct(
+        private readonly TabCountKpiCalculatorInterface $calculator,
+        private readonly TabCountKpiCacheHelper $cacheHelper,
+    ) {
+    }
+
+    /**
+     * @param array<int, mixed> $territories
+     * @throws InvalidArgumentException
+     */
+    public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers
+    {
+        return $this->cacheHelper->getOrSet(
+            TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
+            $user,
+            null,
+            fn () => $this->calculator->countNouveauxDossiers($territories, $user)
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function countDossiersAFermer(User $user, TabQueryParameters $params): CountAfermer
+    {
+        return $this->cacheHelper->getOrSet(
+            TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
+            $user,
+            $params,
+            fn () => $this->calculator->countDossiersAFermer($user, $params)
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function countDossiersMessagesUsagers(User $user, TabQueryParameters $params): CountDossiersMessagesUsagers
+    {
+        return $this->cacheHelper->getOrSet(
+            TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
+            $user,
+            $params,
+            fn () => $this->calculator->countDossiersMessagesUsagers($user, $params)
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function countDossiersAVerifier(User $user, TabQueryParameters $params): CountDossiersAVerifier
+    {
+        return $this->cacheHelper->getOrSet(
+            TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
+            $user,
+            $params,
+            fn () => $this->calculator->countDossiersAVerifier($user, $params)
+        );
+    }
+}

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiBuilder.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiBuilder.php
@@ -70,7 +70,7 @@ class TabCountKpiBuilder
         /** @var User $user */
         $user = $this->security->getUser();
 
-        $countNouveauxDossiers = $this->tabCountKpiCalculator->countNouveauxDossiers($this->territories, $user);
+        $countNouveauxDossiers = $this->tabCountKpiCalculator->countNouveauxDossiers($this->territories, $user, $params);
         $countDossiersAFermer = $this->tabCountKpiCalculator->countDossiersAFermer($user, $params);
         $countDossiersMessagesUsagers = $this->tabCountKpiCalculator->countDossiersMessagesUsagers($user, $params);
         $countDossiersAVerifier = $this->tabCountKpiCalculator->countDossiersAVerifier($user, $params);

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiBuilder.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiBuilder.php
@@ -3,15 +3,7 @@
 namespace App\Service\DashboardTabPanel\Kpi;
 
 use App\Entity\User;
-use App\Repository\Query\Dashboard\DossiersQuery;
-use App\Repository\Query\Dashboard\DossiersSansSuivisPartenaireQuery;
-use App\Repository\Query\Dashboard\DossiersSuivisUsagerQuery;
-use App\Repository\Query\Dashboard\DossiersUndeliverableEmailQuery;
-use App\Repository\Query\Dashboard\NouveauxDossiersKpiQuery;
-use App\Repository\Query\Dashboard\SignalementsSansAffectationAccepteeQuery;
 use App\Service\DashboardTabPanel\TabQueryParameters;
-use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\NoResultException;
 use Symfony\Bundle\SecurityBundle\Security;
 
 class TabCountKpiBuilder
@@ -29,14 +21,8 @@ class TabCountKpiBuilder
     private array $partners = [];
 
     public function __construct(
-        private readonly NouveauxDossiersKpiQuery $nouveauxDossiersKpiQuery,
+        private readonly TabCountKpiCalculatorInterface $tabCountKpiCalculator,
         private readonly Security $security,
-        private readonly TabCountKpiCacheHelper $tabCountKpiCacheHelper,
-        private readonly SignalementsSansAffectationAccepteeQuery $signalementsSansAffectationAccepteeQuery,
-        private readonly DossiersSuivisUsagerQuery $dossiersSuivisUsagerQuery,
-        private readonly DossiersQuery $dossiersQuery,
-        private readonly DossiersSansSuivisPartenaireQuery $dossiersSansSuivisPartenaireQuery,
-        private readonly DossiersUndeliverableEmailQuery $dossiersUndeliverableEmailQuery,
     ) {
     }
 
@@ -71,55 +57,23 @@ class TabCountKpiBuilder
         return $this;
     }
 
-    /**
-     * @throws NonUniqueResultException
-     * @throws NoResultException
-     */
     public function withTabCountKpi(): static
     {
         $params = new TabQueryParameters(
             territoireId: $this->territoryId,
+            partners: $this->partners,
             mesDossiersMessagesUsagers: $this->mesDossiersMessagesUsagers,
             mesDossiersAverifier: $this->mesDossiersAverifier,
             mesDossiersActiviteRecente: $this->mesDossiersActiviteRecente,
-            queryCommune: $this->queryCommune,
-            partners: $this->partners
+            queryCommune: $this->queryCommune
         );
         /** @var User $user */
         $user = $this->security->getUser();
-        if ($this->security->isGranted('ROLE_ADMIN_TERRITORY')) {
-            $countNouveauxDossiers = $this->tabCountKpiCacheHelper->getOrSet(
-                TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
-                $user,
-                $params,
-                fn () => $this->nouveauxDossiersKpiQuery->countNouveauxDossiersKpi($this->territories)
-            );
-        } else {
-            $countNouveauxDossiers = $this->tabCountKpiCacheHelper->getOrSet(
-                TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS,
-                $user,
-                $params,
-                fn () => $this->nouveauxDossiersKpiQuery->countNouveauxDossiersKpi($this->territories, $user)
-            );
-        }
-        $countDossiersAFermer = $this->tabCountKpiCacheHelper->getOrSet(
-            TabCountKpiCacheHelper::DOSSIERS_A_FERMER,
-            $user,
-            $params,
-            fn () => $this->dossiersQuery->countAllDossiersAferme($user, $params)
-        );
-        $countDossiersMessagesUsagers = $this->tabCountKpiCacheHelper->getOrSet(
-            TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
-            $user,
-            $params,
-            fn () => $this->dossiersSuivisUsagerQuery->countAllMessagesUsagers($user, $params)
-        );
-        $countDossiersAVerifier = $this->tabCountKpiCacheHelper->getOrSet(
-            TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
-            $user,
-            $params,
-            fn () => $this->countAllDossiersAVerifier($user, $params)
-        );
+
+        $countNouveauxDossiers = $this->tabCountKpiCalculator->countNouveauxDossiers($this->territories, $user);
+        $countDossiersAFermer = $this->tabCountKpiCalculator->countDossiersAFermer($user, $params);
+        $countDossiersMessagesUsagers = $this->tabCountKpiCalculator->countDossiersMessagesUsagers($user, $params);
+        $countDossiersAVerifier = $this->tabCountKpiCalculator->countDossiersAVerifier($user, $params);
 
         $this->tabCountKpi = new TabCountKpi(
             countNouveauxDossiers: $countNouveauxDossiers->total(),
@@ -134,14 +88,5 @@ class TabCountKpiBuilder
     public function build(): TabCountKpi
     {
         return $this->tabCountKpi;
-    }
-
-    private function countAllDossiersAVerifier(User $user, ?TabQueryParameters $params): CountDossiersAVerifier
-    {
-        return new CountDossiersAVerifier(
-            countSignalementsSansAffectationAcceptee: $this->signalementsSansAffectationAccepteeQuery->countSignalements($user, $params),
-            countSignalementsSansSuiviPartenaireDepuis60Jours: $this->dossiersSansSuivisPartenaireQuery->countSignalements($user, $params),
-            countAdresseEmailAVerifier: $this->dossiersUndeliverableEmailQuery->count($user, $params)
-        );
     }
 }

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelper.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelper.php
@@ -4,6 +4,7 @@ namespace App\Service\DashboardTabPanel\Kpi;
 
 use App\Entity\User;
 use App\Service\DashboardTabPanel\TabQueryParameters;
+use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
@@ -21,17 +22,24 @@ class TabCountKpiCacheHelper
     {
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function getOrSet(string $kpiName, User $user, ?TabQueryParameters $params, callable $callback): mixed
     {
         $key = $this->generateKey($kpiName, $user, $params);
 
-        return $this->cache->get($key, function (ItemInterface $item) use ($callback) {
+        return $this->cache->get($key, function (ItemInterface $item) use ($callback, $user, $kpiName, $params) {
             $item->expiresAfter($this->parameterBag->get('tab_data_kpi_cache_expired_after'));
+            $item->tag($this->getTags($user, $kpiName, $params));
 
             return $callback();
         });
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function delete(string $kpiName, User $user, ?TabQueryParameters $params): bool
     {
         $key = $this->generateKey($kpiName, $user, $params);
@@ -47,10 +55,8 @@ class TabCountKpiCacheHelper
         $otherParamsKey = '';
         if ($params) {
             switch ($kpiName) {
-                case self::NOUVEAUX_DOSSIERS:
-                    $otherParams = null;
-                    break;
                 case self::DOSSIERS_A_FERMER:
+                case self::NOUVEAUX_DOSSIERS:
                     $otherParams = null;
                     break;
                 case self::DOSSIERS_MESSAGES_USAGERS:
@@ -122,5 +128,25 @@ class TabCountKpiCacheHelper
         asort($partners);
 
         return implode('-', $partners);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getTags(User $user, string $kpiName, ?TabQueryParameters $params): array
+    {
+        $tags = [];
+
+        if ($params?->territoireId) {
+            $tags[] = 'territory_'.$kpiName.'_'.$params->territoireId;
+        } elseif (!$user->isSuperAdmin()) {
+            foreach ($user->getPartnersTerritories() as $territory) {
+                $tags[] = 'territory_'.$kpiName.'_'.$territory->getId();
+            }
+        } else {
+            $tags[] = 'territory_'.$kpiName.'_all';
+        }
+
+        return $tags;
     }
 }

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelper.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelper.php
@@ -55,10 +55,6 @@ class TabCountKpiCacheHelper
         $otherParamsKey = '';
         if ($params) {
             switch ($kpiName) {
-                case self::DOSSIERS_A_FERMER:
-                case self::NOUVEAUX_DOSSIERS:
-                    $otherParams = null;
-                    break;
                 case self::DOSSIERS_MESSAGES_USAGERS:
                     $otherParams = [
                         'mesDossiersMessagesUsagers' => '1' === $params->mesDossiersMessagesUsagers ? $user->getId() : 'null',
@@ -70,7 +66,7 @@ class TabCountKpiCacheHelper
                         'mesDossiersAverifier' => '1' === $params->mesDossiersAverifier ? $user->getId() : 'null',
                     ];
                     break;
-                default:
+                default: // DOSSIERS_A_FERMER, NOUVEAUX_DOSSIERS
                     $otherParams = null;
             }
             if ($otherParams) {

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculator.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Service\DashboardTabPanel\Kpi;
+
+use App\Entity\User;
+use App\Repository\Query\Dashboard\DossiersQuery;
+use App\Repository\Query\Dashboard\DossiersSansSuivisPartenaireQuery;
+use App\Repository\Query\Dashboard\DossiersSuivisUsagerQuery;
+use App\Repository\Query\Dashboard\DossiersUndeliverableEmailQuery;
+use App\Repository\Query\Dashboard\NouveauxDossiersKpiQuery;
+use App\Repository\Query\Dashboard\SignalementsSansAffectationAccepteeQuery;
+use App\Service\DashboardTabPanel\TabQueryParameters;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(TabCountKpiCalculatorInterface::class)]
+class TabCountKpiCalculator implements TabCountKpiCalculatorInterface
+{
+    public function __construct(
+        private readonly NouveauxDossiersKpiQuery $nouveauxDossiersKpiQuery,
+        private readonly SignalementsSansAffectationAccepteeQuery $signalementsSansAffectationAccepteeQuery,
+        private readonly DossiersSuivisUsagerQuery $dossiersSuivisUsagerQuery,
+        private readonly DossiersQuery $dossiersQuery,
+        private readonly DossiersSansSuivisPartenaireQuery $dossiersSansSuivisPartenaireQuery,
+        private readonly DossiersUndeliverableEmailQuery $dossiersUndeliverableEmailQuery,
+        private readonly Security $security,
+    ) {
+    }
+
+    /**
+     * @param array<int, mixed> $territories
+     */
+    public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers
+    {
+        if ($this->security->isGranted('ROLE_ADMIN_TERRITORY')) {
+            return $this->nouveauxDossiersKpiQuery->countNouveauxDossiersKpi($territories);
+        }
+
+        return $this->nouveauxDossiersKpiQuery->countNouveauxDossiersKpi($territories, $user);
+    }
+
+    public function countDossiersAFermer(User $user, TabQueryParameters $params): CountAfermer
+    {
+        return $this->dossiersQuery->countAllDossiersAferme($user, $params);
+    }
+
+    public function countDossiersMessagesUsagers(User $user, TabQueryParameters $params): CountDossiersMessagesUsagers
+    {
+        return $this->dossiersSuivisUsagerQuery->countAllMessagesUsagers($user, $params);
+    }
+
+    public function countDossiersAVerifier(User $user, TabQueryParameters $params): CountDossiersAVerifier
+    {
+        return new CountDossiersAVerifier(
+            countSignalementsSansSuiviPartenaireDepuis60Jours: $this->dossiersSansSuivisPartenaireQuery->countSignalements($user, $params),
+            countSignalementsSansAffectationAcceptee: $this->signalementsSansAffectationAccepteeQuery->countSignalements($user, $params),
+            countAdresseEmailAVerifier: $this->dossiersUndeliverableEmailQuery->count($user, $params)
+        );
+    }
+}

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculator.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculator.php
@@ -30,7 +30,7 @@ class TabCountKpiCalculator implements TabCountKpiCalculatorInterface
     /**
      * @param array<int, mixed> $territories
      */
-    public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers
+    public function countNouveauxDossiers(array $territories, User $user, TabQueryParameters $params): CountNouveauxDossiers
     {
         if ($this->security->isGranted('ROLE_ADMIN_TERRITORY')) {
             return $this->nouveauxDossiersKpiQuery->countNouveauxDossiersKpi($territories);

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorInterface.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorInterface.php
@@ -10,7 +10,7 @@ interface TabCountKpiCalculatorInterface
     /**
      * @param array<int, mixed> $territories
      */
-    public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers;
+    public function countNouveauxDossiers(array $territories, User $user, TabQueryParameters $params): CountNouveauxDossiers;
 
     public function countDossiersAFermer(User $user, TabQueryParameters $params): CountAfermer;
 

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorInterface.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Service\DashboardTabPanel\Kpi;
+
+use App\Entity\User;
+use App\Service\DashboardTabPanel\TabQueryParameters;
+
+interface TabCountKpiCalculatorInterface
+{
+    /**
+     * @param array<int, mixed> $territories
+     */
+    public function countNouveauxDossiers(array $territories, User $user): CountNouveauxDossiers;
+
+    public function countDossiersAFermer(User $user, TabQueryParameters $params): CountAfermer;
+
+    public function countDossiersMessagesUsagers(User $user, TabQueryParameters $params): CountDossiersMessagesUsagers;
+
+    public function countDossiersAVerifier(User $user, TabQueryParameters $params): CountDossiersAVerifier;
+}

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculatorTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculatorTest.php
@@ -30,20 +30,21 @@ class CachedTabCountKpiCalculatorTest extends TestCase
     public function testCountNouveauxDossiers(): void
     {
         $user = new User();
+        $params = new TabQueryParameters();
         $territories = [1, 2];
         $count = new CountNouveauxDossiers(1, 2, 3, 4);
 
         $this->cacheHelper->expects($this->once())
             ->method('getOrSet')
-            ->with(TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS, $user, null, $this->callback(static fn ($callback) => is_callable($callback)))
+            ->with(TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS, $user, $params, $this->callback(static fn ($callback) => is_callable($callback)))
             ->willReturnCallback(static fn ($name, $u, $p, $callback) => $callback());
 
         $this->calculator->expects($this->once())
             ->method('countNouveauxDossiers')
-            ->with($territories, $user)
+            ->with($territories, $user, $params)
             ->willReturn($count);
 
-        $result = $this->cachedCalculator->countNouveauxDossiers($territories, $user);
+        $result = $this->cachedCalculator->countNouveauxDossiers($territories, $user, $params);
         $this->assertSame($count, $result);
     }
 

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculatorTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/CachedTabCountKpiCalculatorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
+
+use App\Entity\User;
+use App\Service\DashboardTabPanel\Kpi\CachedTabCountKpiCalculator;
+use App\Service\DashboardTabPanel\Kpi\CountAfermer;
+use App\Service\DashboardTabPanel\Kpi\CountDossiersAVerifier;
+use App\Service\DashboardTabPanel\Kpi\CountDossiersMessagesUsagers;
+use App\Service\DashboardTabPanel\Kpi\CountNouveauxDossiers;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCacheHelper;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCalculator;
+use App\Service\DashboardTabPanel\TabQueryParameters;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CachedTabCountKpiCalculatorTest extends TestCase
+{
+    private MockObject&TabCountKpiCalculator $calculator;
+    private MockObject&TabCountKpiCacheHelper $cacheHelper;
+    private CachedTabCountKpiCalculator $cachedCalculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = $this->createMock(TabCountKpiCalculator::class);
+        $this->cacheHelper = $this->createMock(TabCountKpiCacheHelper::class);
+        $this->cachedCalculator = new CachedTabCountKpiCalculator($this->calculator, $this->cacheHelper);
+    }
+
+    public function testCountNouveauxDossiers(): void
+    {
+        $user = new User();
+        $territories = [1, 2];
+        $count = new CountNouveauxDossiers(1, 2, 3, 4);
+
+        $this->cacheHelper->expects($this->once())
+            ->method('getOrSet')
+            ->with(TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS, $user, null, $this->callback(static fn ($callback) => is_callable($callback)))
+            ->willReturnCallback(static fn ($name, $u, $p, $callback) => $callback());
+
+        $this->calculator->expects($this->once())
+            ->method('countNouveauxDossiers')
+            ->with($territories, $user)
+            ->willReturn($count);
+
+        $result = $this->cachedCalculator->countNouveauxDossiers($territories, $user);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountDossiersAFermer(): void
+    {
+        $user = new User();
+        $params = new TabQueryParameters();
+        $count = new CountAfermer(1, 1, 1, 1);
+
+        $this->cacheHelper->expects($this->once())
+            ->method('getOrSet')
+            ->with(TabCountKpiCacheHelper::DOSSIERS_A_FERMER, $user, $params, $this->callback(static fn ($callback) => is_callable($callback)))
+            ->willReturnCallback(static fn ($name, $u, $p, $callback) => $callback());
+
+        $this->calculator->expects($this->once())
+            ->method('countDossiersAFermer')
+            ->with($user, $params)
+            ->willReturn($count);
+
+        $result = $this->cachedCalculator->countDossiersAFermer($user, $params);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountDossiersMessagesUsagers(): void
+    {
+        $user = new User();
+        $params = new TabQueryParameters();
+        $count = new CountDossiersMessagesUsagers(1, 2, 3);
+
+        $this->cacheHelper->expects($this->once())
+            ->method('getOrSet')
+            ->with(TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS, $user, $params, $this->callback(static fn ($callback) => is_callable($callback)))
+            ->willReturnCallback(static fn ($name, $u, $p, $callback) => $callback());
+
+        $this->calculator->expects($this->once())
+            ->method('countDossiersMessagesUsagers')
+            ->with($user, $params)
+            ->willReturn($count);
+
+        $result = $this->cachedCalculator->countDossiersMessagesUsagers($user, $params);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountDossiersAVerifier(): void
+    {
+        $user = new User();
+        $params = new TabQueryParameters();
+        $count = new CountDossiersAVerifier(3, 2, 9);
+
+        $this->cacheHelper->expects($this->once())
+            ->method('getOrSet')
+            ->with(TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER, $user, $params, $this->callback(static fn ($callback) => is_callable($callback)))
+            ->willReturnCallback(static fn ($name, $u, $p, $callback) => $callback());
+
+        $this->calculator->expects($this->once())
+            ->method('countDossiersAVerifier')
+            ->with($user, $params)
+            ->willReturn($count);
+
+        $result = $this->cachedCalculator->countDossiersAVerifier($user, $params);
+        $this->assertSame($count, $result);
+    }
+}

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiBuilderTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiBuilderTest.php
@@ -3,19 +3,12 @@
 namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
 
 use App\Entity\User;
-use App\Repository\Query\Dashboard\DossiersQuery;
-use App\Repository\Query\Dashboard\DossiersSansSuivisPartenaireQuery;
-use App\Repository\Query\Dashboard\DossiersSuivisUsagerQuery;
-use App\Repository\Query\Dashboard\DossiersUndeliverableEmailQuery;
-use App\Repository\Query\Dashboard\NouveauxDossiersKpiQuery;
-use App\Repository\Query\Dashboard\SignalementsSansAffectationAccepteeQuery;
 use App\Service\DashboardTabPanel\Kpi\CountAfermer;
 use App\Service\DashboardTabPanel\Kpi\CountDossiersAVerifier;
 use App\Service\DashboardTabPanel\Kpi\CountDossiersMessagesUsagers;
 use App\Service\DashboardTabPanel\Kpi\CountNouveauxDossiers;
-use App\Service\DashboardTabPanel\Kpi\TabCountKpi;
 use App\Service\DashboardTabPanel\Kpi\TabCountKpiBuilder;
-use App\Service\DashboardTabPanel\Kpi\TabCountKpiCacheHelper;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCalculatorInterface;
 use App\Service\DashboardTabPanel\TabQueryParameters;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -23,36 +16,18 @@ use Symfony\Bundle\SecurityBundle\Security;
 
 class TabCountKpiBuilderTest extends TestCase
 {
-    protected MockObject&NouveauxDossiersKpiQuery $nouveauxDossiersKpiQuery;
+    protected MockObject&TabCountKpiCalculatorInterface $tabCountKpiCalculator;
     protected MockObject&Security $security;
     protected TabCountKpiBuilder $tabCountKpiBuilder;
-    protected MockObject&TabCountKpiCacheHelper $tabCountKpiCacheHelper;
-    protected MockObject&SignalementsSansAffectationAccepteeQuery $signalementsSansAffectationAccepteeQuery;
-    protected MockObject&DossiersQuery $dossiersQuery;
-    protected MockObject&DossiersSuivisUsagerQuery $dossiersSuivisUsagerQuery;
-    protected MockObject&DossiersSansSuivisPartenaireQuery $dossiersSansSuivisPartenaireQuery;
-    protected MockObject&DossiersUndeliverableEmailQuery $dossiersUndeliverableEmailQuery;
 
     protected function setUp(): void
     {
-        $this->nouveauxDossiersKpiQuery = $this->createMock(NouveauxDossiersKpiQuery::class);
+        $this->tabCountKpiCalculator = $this->createMock(TabCountKpiCalculatorInterface::class);
         $this->security = $this->createMock(Security::class);
-        $this->dossiersQuery = $this->createMock(DossiersQuery::class);
-        $this->dossiersSuivisUsagerQuery = $this->createMock(DossiersSuivisUsagerQuery::class);
-        $this->dossiersSansSuivisPartenaireQuery = $this->createMock(DossiersSansSuivisPartenaireQuery::class);
-        $this->dossiersUndeliverableEmailQuery = $this->createMock(DossiersUndeliverableEmailQuery::class);
-        $this->tabCountKpiCacheHelper = $this->createMock(TabCountKpiCacheHelper::class);
-        $this->signalementsSansAffectationAccepteeQuery = $this->createMock(SignalementsSansAffectationAccepteeQuery::class);
 
         $this->tabCountKpiBuilder = new TabCountKpiBuilder(
-            $this->nouveauxDossiersKpiQuery,
+            $this->tabCountKpiCalculator,
             $this->security,
-            $this->tabCountKpiCacheHelper,
-            $this->signalementsSansAffectationAccepteeQuery,
-            $this->dossiersSuivisUsagerQuery,
-            $this->dossiersQuery,
-            $this->dossiersSansSuivisPartenaireQuery,
-            $this->dossiersUndeliverableEmailQuery,
         );
     }
 
@@ -65,8 +40,8 @@ class TabCountKpiBuilderTest extends TestCase
         $params = new TabQueryParameters(
             territoireId: $territoryId,
             partners: [],
-            mesDossiersAverifier: $mesDossiers,
             mesDossiersMessagesUsagers: $mesDossiers,
+            mesDossiersAverifier: $mesDossiers,
             mesDossiersActiviteRecente: $mesDossiers,
         );
 
@@ -83,41 +58,25 @@ class TabCountKpiBuilderTest extends TestCase
         $countAfermer = new CountAfermer(1, 1, 1, 1);
         $countAverifier = new CountDossiersAVerifier(3, 2, 9);
 
-        $this->nouveauxDossiersKpiQuery
-            ->expects($this->never())
-            ->method('countNouveauxDossiersKpi')
-            ->with($territories)
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countNouveauxDossiers')
             ->willReturn($countNouveaux);
 
-        $this->dossiersQuery
-            ->expects($this->never())
-            ->method('countAllDossiersAferme')
-            ->with($user, $params)
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countDossiersAFermer')
             ->willReturn($countAfermer);
 
-        $this->dossiersSuivisUsagerQuery
-            ->expects($this->never())
-            ->method('countAllMessagesUsagers')
-            ->with($user, $params)
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countDossiersMessagesUsagers')
             ->willReturn($countMessages);
 
-        $this->dossiersSansSuivisPartenaireQuery
-            ->expects($this->never())
-            ->method('countSignalements')
-            ->with($user, $params)
-            ->willReturn(3);
-
-        $this->tabCountKpiCacheHelper
-            ->method('getOrSet')
-            ->willReturnCallback(static function ($kpiName) use ($countNouveaux, $countAfermer, $countMessages, $countAverifier) {
-                return match ($kpiName) {
-                    TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS => $countNouveaux,
-                    TabCountKpiCacheHelper::DOSSIERS_A_FERMER => $countAfermer,
-                    TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS => $countMessages,
-                    TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER => $countAverifier,
-                    default => null,
-                };
-            });
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countDossiersAVerifier')
+            ->willReturn($countAverifier);
 
         $tabCountKpi = $this->tabCountKpiBuilder
             ->setTerritories($territories, $territoryId)
@@ -126,7 +85,6 @@ class TabCountKpiBuilderTest extends TestCase
             ->withTabCountKpi()
             ->build();
 
-        $this->assertInstanceOf(TabCountKpi::class, $tabCountKpi);
         $this->assertSame(10, $tabCountKpi->countNouveauxDossiers);
         $this->assertSame(6, $tabCountKpi->countDossiersMessagesUsagers);
         $this->assertSame(4, $tabCountKpi->countDossiersAFermer);
@@ -139,13 +97,6 @@ class TabCountKpiBuilderTest extends TestCase
         $territories = [42];
         $territoryId = null;
         $mesDossiers = null;
-        $params = new TabQueryParameters(
-            territoireId: $territoryId,
-            partners: [],
-            mesDossiersAverifier: $mesDossiers,
-            mesDossiersMessagesUsagers: $mesDossiers,
-            mesDossiersActiviteRecente: $mesDossiers,
-        );
 
         $this->security
             ->method('getUser')
@@ -160,41 +111,25 @@ class TabCountKpiBuilderTest extends TestCase
         $countAfermer = new CountAfermer(1, 0, 0, 2);
         $countAverifier = new CountDossiersAVerifier(2, 2);
 
-        $this->nouveauxDossiersKpiQuery
-            ->expects($this->never())
-            ->method('countNouveauxDossiersKpi')
-            ->with($territories, $user)
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countNouveauxDossiers')
             ->willReturn($countNouveaux);
 
-        $this->dossiersSuivisUsagerQuery
-            ->expects($this->never())
-            ->method('countAllMessagesUsagers')
-            ->with($user, $params)
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countDossiersMessagesUsagers')
             ->willReturn($countMessages);
 
-        $this->dossiersQuery
-            ->expects($this->never())
-            ->method('countAllDossiersAferme')
-            ->with($user, $params)
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countDossiersAFermer')
             ->willReturn($countAfermer);
 
-        $this->dossiersSansSuivisPartenaireQuery
-            ->expects($this->never())
-            ->method('countSignalements')
-            ->with($user, $params)
-            ->willReturn(2);
-
-        $this->tabCountKpiCacheHelper
-            ->method('getOrSet')
-            ->willReturnCallback(static function ($kpiName) use ($countNouveaux, $countAfermer, $countMessages, $countAverifier) {
-                return match ($kpiName) {
-                    TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS => $countNouveaux,
-                    TabCountKpiCacheHelper::DOSSIERS_A_FERMER => $countAfermer,
-                    TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS => $countMessages,
-                    TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER => $countAverifier,
-                    default => null,
-                };
-            });
+        $this->tabCountKpiCalculator
+            ->expects($this->once())
+            ->method('countDossiersAVerifier')
+            ->willReturn($countAverifier);
         $tabCountKpi = $this->tabCountKpiBuilder
             ->setTerritories($territories, $territoryId)
             ->setMesDossiers($mesDossiers, $mesDossiers, $mesDossiers)

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelperTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelperTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
+
+use App\Entity\Partner;
+use App\Entity\Territory;
+use App\Entity\User;
+use App\Entity\UserPartner;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCacheHelper;
+use App\Service\DashboardTabPanel\TabQueryParameters;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+class TabCountKpiCacheHelperTest extends TestCase
+{
+    private TabCountKpiCacheHelper $cacheHelper;
+
+    protected function setUp(): void
+    {
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $this->cacheHelper = new TabCountKpiCacheHelper($cache, $parameterBag);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testGenerateKeyForSuperAdmin(): void
+    {
+        $user = new User();
+        $user->setRoles(['ROLE_ADMIN']);
+        $user->setEmail('superadmin@test.fr');
+
+        $params = new TabQueryParameters();
+
+        $reflection = new \ReflectionClass(TabCountKpiCacheHelper::class);
+        $method = $reflection->getMethod('generateKey');
+
+        $key = $method->invoke($this->cacheHelper, TabCountKpiCacheHelper::NOUVEAUX_DOSSIERS, $user, $params);
+
+        // Expected format: tab_kpi_nouveaux_dossiers-ROLE_ADMIN-territory_all-partner_all
+        $this->assertStringContainsString('tab_kpi_nouveaux_dossiers', $key);
+        $this->assertStringContainsString('ROLE_ADMIN', $key);
+        $this->assertStringContainsString('territory_all', $key);
+        $this->assertStringContainsString('partner_all', $key);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testGenerateKeyIncludesFilters(): void
+    {
+        $user = new User();
+        $user->setRoles(['ROLE_USER_PARTNER']);
+        $user->setEmail('partner@test.fr');
+
+        $territory = new Territory();
+        $partner = new Partner();
+        $partner->setTerritory($territory);
+        $userPartner = new UserPartner()->setUser($user)->setPartner($partner);
+        $user->addUserPartner($userPartner);
+
+        $params = new TabQueryParameters(
+            mesDossiersAverifier: '1',
+            queryCommune: 'Marseille'
+        );
+
+        $reflection = new \ReflectionClass(TabCountKpiCacheHelper::class);
+        $method = $reflection->getMethod('generateKey');
+
+        $key = $method->invoke($this->cacheHelper, TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER, $user, $params);
+
+        $this->assertStringContainsString('commune_Marseille', $key);
+        $this->assertStringContainsString('mesDossiersAverifier_', $key);
+    }
+}

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorTest.php
@@ -53,6 +53,7 @@ class TabCountKpiCalculatorTest extends TestCase
     public function testCountNouveauxDossiersForAdminTerritory(): void
     {
         $user = new User();
+        $params = new TabQueryParameters();
         $territories = [1, 2];
         $count = new CountNouveauxDossiers(1, 2, 3, 4, 5);
 
@@ -62,13 +63,14 @@ class TabCountKpiCalculatorTest extends TestCase
             ->with($territories)
             ->willReturn($count);
 
-        $result = $this->calculator->countNouveauxDossiers($territories, $user);
+        $result = $this->calculator->countNouveauxDossiers($territories, $user, $params);
         $this->assertSame($count, $result);
     }
 
     public function testCountNouveauxDossiersForNonAdmin(): void
     {
         $user = new User();
+        $params = new TabQueryParameters();
         $territories = [1, 2];
         $count = new CountNouveauxDossiers(1, 2, 3, 4, 5);
 
@@ -78,7 +80,7 @@ class TabCountKpiCalculatorTest extends TestCase
             ->with($territories, $user)
             ->willReturn($count);
 
-        $result = $this->calculator->countNouveauxDossiers($territories, $user);
+        $result = $this->calculator->countNouveauxDossiers($territories, $user, $params);
         $this->assertSame($count, $result);
     }
 

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiCalculatorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
+
+use App\Entity\User;
+use App\Repository\Query\Dashboard\DossiersQuery;
+use App\Repository\Query\Dashboard\DossiersSansSuivisPartenaireQuery;
+use App\Repository\Query\Dashboard\DossiersSuivisUsagerQuery;
+use App\Repository\Query\Dashboard\DossiersUndeliverableEmailQuery;
+use App\Repository\Query\Dashboard\NouveauxDossiersKpiQuery;
+use App\Repository\Query\Dashboard\SignalementsSansAffectationAccepteeQuery;
+use App\Service\DashboardTabPanel\Kpi\CountAfermer;
+use App\Service\DashboardTabPanel\Kpi\CountDossiersMessagesUsagers;
+use App\Service\DashboardTabPanel\Kpi\CountNouveauxDossiers;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCalculator;
+use App\Service\DashboardTabPanel\TabQueryParameters;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class TabCountKpiCalculatorTest extends TestCase
+{
+    private MockObject&NouveauxDossiersKpiQuery $nouveauxDossiersKpiQuery;
+    private MockObject&SignalementsSansAffectationAccepteeQuery $signalementsSansAffectationAccepteeQuery;
+    private MockObject&DossiersSuivisUsagerQuery $dossiersSuivisUsagerQuery;
+    private MockObject&DossiersQuery $dossiersQuery;
+    private MockObject&DossiersSansSuivisPartenaireQuery $dossiersSansSuivisPartenaireQuery;
+    private MockObject&DossiersUndeliverableEmailQuery $dossiersUndeliverableEmailQuery;
+    private MockObject&Security $security;
+    private TabCountKpiCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->nouveauxDossiersKpiQuery = $this->createMock(NouveauxDossiersKpiQuery::class);
+        $this->signalementsSansAffectationAccepteeQuery = $this->createMock(SignalementsSansAffectationAccepteeQuery::class);
+        $this->dossiersSuivisUsagerQuery = $this->createMock(DossiersSuivisUsagerQuery::class);
+        $this->dossiersQuery = $this->createMock(DossiersQuery::class);
+        $this->dossiersSansSuivisPartenaireQuery = $this->createMock(DossiersSansSuivisPartenaireQuery::class);
+        $this->dossiersUndeliverableEmailQuery = $this->createMock(DossiersUndeliverableEmailQuery::class);
+        $this->security = $this->createMock(Security::class);
+
+        $this->calculator = new TabCountKpiCalculator(
+            $this->nouveauxDossiersKpiQuery,
+            $this->signalementsSansAffectationAccepteeQuery,
+            $this->dossiersSuivisUsagerQuery,
+            $this->dossiersQuery,
+            $this->dossiersSansSuivisPartenaireQuery,
+            $this->dossiersUndeliverableEmailQuery,
+            $this->security
+        );
+    }
+
+    public function testCountNouveauxDossiersForAdminTerritory(): void
+    {
+        $user = new User();
+        $territories = [1, 2];
+        $count = new CountNouveauxDossiers(1, 2, 3, 4, 5);
+
+        $this->security->method('isGranted')->with('ROLE_ADMIN_TERRITORY')->willReturn(true);
+        $this->nouveauxDossiersKpiQuery->expects($this->once())
+            ->method('countNouveauxDossiersKpi')
+            ->with($territories)
+            ->willReturn($count);
+
+        $result = $this->calculator->countNouveauxDossiers($territories, $user);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountNouveauxDossiersForNonAdmin(): void
+    {
+        $user = new User();
+        $territories = [1, 2];
+        $count = new CountNouveauxDossiers(1, 2, 3, 4, 5);
+
+        $this->security->method('isGranted')->with('ROLE_ADMIN_TERRITORY')->willReturn(false);
+        $this->nouveauxDossiersKpiQuery->expects($this->once())
+            ->method('countNouveauxDossiersKpi')
+            ->with($territories, $user)
+            ->willReturn($count);
+
+        $result = $this->calculator->countNouveauxDossiers($territories, $user);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountDossiersAFermer(): void
+    {
+        $user = new User();
+        $params = new TabQueryParameters();
+        $count = new CountAfermer(1, 2, 3, 4);
+
+        $this->dossiersQuery->expects($this->once())
+            ->method('countAllDossiersAferme')
+            ->with($user, $params)
+            ->willReturn($count);
+
+        $result = $this->calculator->countDossiersAFermer($user, $params);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountDossiersMessagesUsagers(): void
+    {
+        $user = new User();
+        $params = new TabQueryParameters();
+        $count = new CountDossiersMessagesUsagers(1, 2, 3);
+
+        $this->dossiersSuivisUsagerQuery->expects($this->once())
+            ->method('countAllMessagesUsagers')
+            ->with($user, $params)
+            ->willReturn($count);
+
+        $result = $this->calculator->countDossiersMessagesUsagers($user, $params);
+        $this->assertSame($count, $result);
+    }
+
+    public function testCountDossiersAVerifier(): void
+    {
+        $user = new User();
+        $params = new TabQueryParameters();
+
+        $this->dossiersSansSuivisPartenaireQuery->expects($this->once())
+            ->method('countSignalements')
+            ->with($user, $params)
+            ->willReturn(10);
+
+        $this->signalementsSansAffectationAccepteeQuery->expects($this->once())
+            ->method('countSignalements')
+            ->with($user, $params)
+            ->willReturn(5);
+
+        $this->dossiersUndeliverableEmailQuery->expects($this->once())
+            ->method('count')
+            ->with($user, $params)
+            ->willReturn(2);
+
+        $result = $this->calculator->countDossiersAVerifier($user, $params);
+        $this->assertSame(10, $result->countSignalementsSansSuiviPartenaireDepuis60Jours);
+        $this->assertSame(5, $result->countSignalementsSansAffectationAcceptee);
+        $this->assertSame(2, $result->countAdresseEmailAVerifier);
+        $this->assertSame(17, $result->total());
+    }
+}


### PR DESCRIPTION
## Ticket

#5872    

## Description
Isolation du calcul des compteurs du tableau de bord via un service dédié et mise en cache via un service décorateur.

Afin de limiter les difficultés de debug et de conserver un comportement simple et prévisible, les tags de cache ne sont volontairement pas granulaires et sont définis au niveau du territoire.

L'invalidation s’appuie sur des événements Doctrine via un listener dédié, qui invalide les tags associés aux KPI impactés par les changements métier.

## Changements apportés
* Création du service dédié de calcul et son décorateur associé pour le cache
* Création d'un listener pour l'invalidation 

## Pré-requis
`make load-data` pour avoir des données dans tous les panels

## Tests
### TNR
- [ ] Vérifier que les compteurs du tableau de bord s’affichent correctement
- [ ] Vérifier qu'un second chargement utilise le cache (moins de requête dans le profiler)

### Onglet nouveaux dossiers
Test à faire en tant super admin, RT et agents
- [ ] Vérifier que le compteur se met à jour lorsqu'un dossier est déposé depuis le formulaire usager, pro
- [ ] Vérifier que le compteur se met à jour lorsqu'un dossier est affecté et accepté par par le super admin ou RT

### Onglet à fermer
- [ ] Vérifier que le compteur se met à jour lorsque le dossier est clôture
- [ ] Vérifier que le compteur se met à jour si on décide de réaffecter le partenaire
- [ ] Vérifier que le compteur se met à jour si la commune affecté ferme son dossier
- [ ] Vérifier que le compteur se met à jour si l'usager demande une fermeture de dossier
- [ ] Vérifier que le compteur se met à jour si après 3 relances usagers sans réponses
- [ ] Vérifier que le compteur se met à jour si un agent répond après 3 relances usagers

### Message usager
- [ ] Vérifier que le compteur se met à jour après un message usager 
- [ ] Vérifier que le compteur se met à jour après un message partenaire partagé
- [ ] Vérifier que le compteur se met à jour après un message usager suite à la clôture
- [ ] Vérifier que le compteur se met à jour après une clôture de dossier


### Dossier à vérifier 
- [ ] Vérifier que le compteur se met à jour après une activité partenaire
- [ ] Vérifier que le compteur se met à jour après une acception partenaire
- [ ] Vérifier que le compteur se met à jour après un changement de mail à vérifier

