### PR TITLE
[Signalement] Déterminer l'occupation du logement plus sustématiquement et corriger l'affichage dans la fiche BO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,11 @@ clean-tasks: ## Clean & Reset task
 	@$(DOCKER_COMP) exec signal_logement_phpfpm sh ./scripts/clean.sh
 
 ## Quality
-test: ## Run all tests
-	@$(DOCKER_COMP) exec signal_logement_phpfpm sh -c "$(PHPUNIT) $(FILE) --stop-on-failure --testdox -d memory_limit=-1"
+VERBOSE       ?=
+PHPUNIT_EXTRA = $(if $(VERBOSE),--display-notices --display-phpunit-notices --display-deprecations)
+
+test: ## Run all tests — use VERBOSE=1 to display notices and deprecations
+	@$(DOCKER_COMP) exec signal_logement_phpfpm sh -c "$(PHPUNIT) $(FILE) --stop-on-failure --testdox -d memory_limit=-1 $(PHPUNIT_EXTRA)"
 
 test-all: ## Run all tests
 	@$(DOCKER_COMP) exec signal_logement_phpfpm sh -c "$(PHPUNIT) $(FILE) --testdox -d memory_limit=-1"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ OVH_SCW_SYNC_DOCKERFILE=.docker/rclone-job/Dockerfile
 OVH_SCW_SYNC_IMAGE_NAME=rclone-sync-ovh-scaleway
 SCW_REGISTRY   = rg.fr-par.scw.cloud
 SCW_NAMESPACE  = signal-logement
+VERBOSE       ?=
+PHPUNIT_EXTRA = $(if $(VERBOSE),--display-notices --display-phpunit-notices --display-deprecations)
 
 help:
 	@grep -E '(^[a-zA-Z0-9_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}{printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
@@ -227,9 +229,6 @@ clean-tasks: ## Clean & Reset task
 	@$(DOCKER_COMP) exec signal_logement_phpfpm sh ./scripts/clean.sh
 
 ## Quality
-VERBOSE       ?=
-PHPUNIT_EXTRA = $(if $(VERBOSE),--display-notices --display-phpunit-notices --display-deprecations)
-
 test: ## Run all tests — use VERBOSE=1 to display notices and deprecations
 	@$(DOCKER_COMP) exec signal_logement_phpfpm sh -c "$(PHPUNIT) $(FILE) --stop-on-failure --testdox -d memory_limit=-1 $(PHPUNIT_EXTRA)"
 

--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -459,3 +459,33 @@ document.addEventListener('click', (event) => {
     }
   });
 });
+
+const logementVacantModal = document.querySelector('#fr-modal-edit-logement-vacant');
+
+logementVacantModal?.addEventListener('change', (event) => {
+  const radio = event.target.closest('input[name="logementVacant"]');
+  if (!radio) return;
+
+  const isVacant = radio.value === '1';
+  document.getElementById('logement-vacant-warning')?.classList.toggle('fr-hidden', !isVacant);
+  document
+    .getElementById('logement-vacant-bailleur-warning')
+    ?.classList.toggle('fr-hidden', !isVacant);
+
+  // Reset DSFR error state when user makes a selection
+  const fieldset = document.getElementById('logement-vacant-fieldset');
+  fieldset?.classList.remove('fr-fieldset--error');
+  document.getElementById('logement-vacant-fieldset-error')?.classList.add('fr-hidden');
+});
+
+logementVacantModal?.querySelector('form')?.addEventListener('submit', (event) => {
+  const fieldset = document.getElementById('logement-vacant-fieldset');
+  if (!fieldset) return;
+
+  const isChecked = fieldset.querySelector('input[name="logementVacant"]:checked');
+  if (!isChecked) {
+    event.preventDefault();
+    fieldset.classList.add('fr-fieldset--error');
+    document.getElementById('logement-vacant-fieldset-error')?.classList.remove('fr-hidden');
+  }
+});

--- a/migrations/Version20260527082841.php
+++ b/migrations/Version20260527082841.php
@@ -22,7 +22,8 @@ final class Version20260527082841 extends AbstractMigration
              WHERE is_logement_vacant IS NULL
                AND creation_source <> 'FORM_SERVICE_SECOURS'
                AND nom_occupant IS NOT NULL
-               AND nom_occupant != ''"
+               AND nom_occupant != ''
+               AND nom_occupant != 'inconnu'"
         );
     }
 

--- a/migrations/Version20260527082841.php
+++ b/migrations/Version20260527082841.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260527082841 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set isLogementVacant to false on signalements not from service secours form, where isLogementVacant is null and occupant name is known';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            "UPDATE signalement
+             SET is_logement_vacant = false
+             WHERE is_logement_vacant IS NULL
+               AND creation_source <> 'FORM_SERVICE_SECOURS'
+               AND nom_occupant IS NOT NULL
+               AND nom_occupant != ''"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -697,7 +697,7 @@ class SignalementEditController extends AbstractController
         $token = is_scalar($request->request->get('_token')) ? (string) $request->request->get('_token') : '';
         $logementVacant = (bool) $request->request->get('logementVacant');
         if ($this->isCsrfTokenValid('signalement_switch_logement_vacant', $token)) {
-            if ($logementVacant != $signalement->getIsLogementVacant()) {
+            if ($logementVacant !== $signalement->getIsLogementVacant()) {
                 $signalement->setIsLogementVacant($logementVacant);
                 /** @var User $user */
                 $user = $this->getUser();

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -167,6 +167,9 @@ class SignalementImportLoader
                     $signalement->setProfileDeclarant(ProfileDeclarant::TIERS_PARTICULIER);
                 }
             }
+            if (null === $signalement->getIsLogementVacant() && !empty($signalement->getNomOccupant())) {
+                $signalement->setIsLogementVacant(false);
+            }
             $this->entityManager->persist($signalement);
 
             $this->loadTags($signalement, $territory, $dataMapped);

--- a/src/Service/Import/Signalement/SignalementImportMapper.php
+++ b/src/Service/Import/Signalement/SignalementImportMapper.php
@@ -142,7 +142,7 @@ class SignalementImportMapper
         foreach ($this->getMapping() as $fileColumn => $fieldColumn) {
             if (\in_array($fileColumn, $columns)) {
                 $fieldValue = 'NSP' !== $data[$fileColumn] ? $data[$fileColumn] : '';
-                $fieldValue = trim($fieldValue, '"');
+                $fieldValue = trim($fieldValue ?? '', '"');
                 switch ($fieldColumn) {
                     case 'reference':
                         // TODO que fait-on si on n'a pas de date de création du signalement ?

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -48,10 +48,7 @@ class SignalementBoManager
             $signalement->setIsLogementVacant(true);
             $signalement->setProfileOccupant(null);
         } else {
-            if (!empty($form->get('profileOccupant')->getData())) {
-                $signalement->setIsLogementVacant(false);
-            }
-
+            $signalement->setIsLogementVacant(false);
             $signalement->setProfileOccupant(SignalementProfileOccupantMapper::map($form->get('profileOccupant')->getData(), $profileDeclarant));
         }
 

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -532,10 +532,10 @@ class SignalementBuilder
         ));
 
         if (
-            !empty($this->signalement->getNomOccupant()) || 
-            !empty($this->signalement->getPrenomOccupant()) || 
-            !empty($this->signalement->getMailOccupant()) || 
-            !empty($this->signalement->getTelOccupant())
+            !empty($this->signalement->getNomOccupant())
+            || !empty($this->signalement->getPrenomOccupant())
+            || !empty($this->signalement->getMailOccupant())
+            || !empty($this->signalement->getTelOccupant())
         ) {
             $this->signalement->setIsLogementVacant(false);
         }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -531,7 +531,12 @@ class SignalementBuilder
             profileDeclarant: $this->signalement->getProfileDeclarant()
         ));
 
-        if (!empty($this->signalement->getNomOccupant())) {
+        if (
+            !empty($this->signalement->getNomOccupant()) || 
+            !empty($this->signalement->getPrenomOccupant()) || 
+            !empty($this->signalement->getMailOccupant()) || 
+            !empty($this->signalement->getTelOccupant())
+        ) {
             $this->signalement->setIsLogementVacant(false);
         }
     }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -527,9 +527,13 @@ class SignalementBuilder
     private function setOccupantProfileData(): void
     {
         $this->signalement->setProfileOccupant(SignalementProfileOccupantMapper::map(
-            profileOccupant: strtoupper($this->signalementDraftRequest->getSignalementConcerneProfilDetailProfilOccupant()),
+            profileOccupant: strtoupper($this->signalementDraftRequest->getSignalementConcerneProfilDetailProfilOccupant() ?? ''),
             profileDeclarant: $this->signalement->getProfileDeclarant()
         ));
+
+        if (!empty($this->signalement->getNomOccupant())) {
+            $this->signalement->setIsLogementVacant(false);
+        }
     }
 
     private function isOccupant(): bool

--- a/templates/back/signalement/view/edit-modals/edit-logement-vacant.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-logement-vacant.html.twig
@@ -12,16 +12,16 @@
                                 <h1 class="fr-modal__title">Sortir du statut de logement vacant</h1>
                                 <div class="fr-alert fr-alert--warning fr-my-2v">
                                     <p>
-                                        Si vous sortez le logement du statut de vacant, les usagers (occupant et tiers déclarant) recevront à nouveau des mises à jour sur le dossier, 
+                                        Si vous sortez le logement du statut de vacant, les usagers (occupant et tiers déclarant) recevront à nouveau des mises à jour sur le dossier,
                                         et vous pourrez à nouveau partager des suivis aux usagers.
                                     </p>
                                 </div>
                                 <input type="hidden" name="logementVacant" value="0">
-                            {% else %}
+                            {% elseif signalement.isLogementVacant is same as false %}
                                 <h1 class="fr-modal__title">Enregistrer comme logement vacant</h1>
                                 <div class="fr-alert fr-alert--warning fr-my-2v">
                                     <p>
-                                        Si vous indiquez que le logement est vacant, les usagers (occupant et tiers déclarant) ne recevront plus de mises à jour sur le dossier, 
+                                        Si vous indiquez que le logement est vacant, les usagers (occupant et tiers déclarant) ne recevront plus de mises à jour sur le dossier,
                                         et vous ne pourrez plus partager de suivis aux usagers. Vous pourrez toujours effectuer des actions sur le dossier.
                                         <br>
                                         Les usagers pourront continuer à accéder au dossier mais ne pourront plus interagir.
@@ -35,6 +35,45 @@
                                     </div>
                                 {% endif %}
                                 <input type="hidden" name="logementVacant" value="1">
+                            {% else %}
+                                <h1 class="fr-modal__title">Enregistrer l'occupation du logement</h1>
+                                <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-2v" id="logement-vacant-fieldset" aria-labelledby="logement-vacant-fieldset-legend logement-vacant-fieldset-error">
+                                    <legend class="fr-fieldset__legend fr-text--regular" id="logement-vacant-fieldset-legend">
+                                        Le logement est-il actuellement occupé ou vacant ?
+                                    </legend>
+                                    <div class="fr-fieldset__element fr-fieldset__element--inline">
+                                        <div class="fr-radio-group">
+                                            <input type="radio" id="logement-occupe" name="logementVacant" value="0">
+                                            <label for="logement-occupe">Logement occupé</label>
+                                        </div>
+                                    </div>
+                                    <div class="fr-fieldset__element fr-fieldset__element--inline">
+                                        <div class="fr-radio-group">
+                                            <input type="radio" id="logement-vacant-radio" name="logementVacant" value="1">
+                                            <label for="logement-vacant-radio">Logement vacant</label>
+                                        </div>
+                                    </div>
+                                    <div class="fr-fieldset__element">
+                                        <p id="logement-vacant-fieldset-error" class="fr-error-text fr-hidden">
+                                            Veuillez préciser si le logement est occupé ou vacant.
+                                        </p>
+                                    </div>
+                                </fieldset>
+                                <div id="logement-vacant-warning" class="fr-alert fr-alert--warning fr-my-2v fr-hidden">
+                                    <p>
+                                        Si vous indiquez que le logement est vacant, les usagers (occupant et tiers déclarant) ne recevront plus de mises à jour sur le dossier,
+                                        et vous ne pourrez plus partager de suivis aux usagers. Vous pourrez toujours effectuer des actions sur le dossier.
+                                        <br>
+                                        Les usagers pourront continuer à accéder au dossier mais ne pourront plus interagir.
+                                    </p>
+                                </div>
+                                {% if signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
+                                    <div id="logement-vacant-bailleur-warning" class="fr-alert fr-alert--error fr-my-2v fr-hidden">
+                                        <p>
+                                            Le déclarant tiers bailleur ne recevra plus de mise à jour sur le dossier et ne pourra plus interagir avec le dossier.
+                                        </p>
+                                    </div>
+                                {% endif %}
                             {% endif %}
                             <input type="hidden" name="_token" value="{{ csrf_token('signalement_switch_logement_vacant') }}">
                         </div>
@@ -44,8 +83,10 @@
                                     <button class="fr-btn fr-icon-check-line" type="submit">
                                         {% if signalement.isLogementVacant %}
                                             Enregistrer comme logement occupé
-                                        {% else %}
+                                        {% elseif signalement.isLogementVacant is same as false %}
                                             Enregistrer comme logement vacant
+                                        {% else %}
+                                            Enregistrer
                                         {% endif %}
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/header/_logement-vacant.html.twig
+++ b/templates/back/signalement/view/header/_logement-vacant.html.twig
@@ -1,8 +1,10 @@
 <div class="fr-mb-4v fr-m-1v">
     {% if signalement.isLogementVacant %}
         <span class="fr-badge fr-badge--warning">Logement vacant</span>
-    {% else %}
+    {% elseif signalement.isLogementVacant is same as false %}
         <span class="fr-badge fr-badge--info">Logement occupé</span>
+    {% else %}
+        <span class="fr-badge fr-badge--info">Occupation du logement non précisée</span>
     {% endif %}
     {% if is_granted('SIGN_SWITCH_LOGEMENT_VACANT', signalement) %}
         <button data-fr-opened="false" aria-controls="fr-modal-edit-logement-vacant" class="fr-btn--icon-left fr-icon-edit-line fr-btn fr-btn--sm fr-btn--tertiary-no-outline">

--- a/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
+++ b/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Service\Import\Signalement;
 
+use App\Entity\Signalement;
 use App\Entity\Territory;
 use App\EventListener\SuiviCreatedListener;
 use App\Manager\AffectationManager;
@@ -27,7 +28,6 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Persistence\ManagerRegistry;
 use Faker\Factory;
 use League\Flysystem\FilesystemOperator;
-use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -47,7 +47,7 @@ class SignalementImportLoaderTest extends KernelTestCase
     private CriticiteCalculator $criticiteCalculator;
     private SignalementQualificationUpdater $signalementQualificationUpdater;
     private FileManager $fileManager;
-    private MockObject&FilesystemOperator $filesystemOperator;
+    private FilesystemOperator $filesystemOperator;
     private HtmlSanitizerInterface $htmlSanitizerInterface;
     private UserSignalementSubscriptionManager $userSignalementSubscriptionManager;
     private CritereRepository $critereRepository;
@@ -71,7 +71,7 @@ class SignalementImportLoaderTest extends KernelTestCase
         $this->criticiteCalculator = static::getContainer()->get(CriticiteCalculator::class);
         $this->signalementQualificationUpdater = static::getContainer()->get(SignalementQualificationUpdater::class);
         $this->fileManager = static::getContainer()->get(FileManager::class);
-        $this->filesystemOperator = $this->createMock(FilesystemOperator::class);
+        $this->filesystemOperator = $this->createStub(FilesystemOperator::class);
         $this->critereRepository = static::getContainer()->get(CritereRepository::class);
         $this->criticiteRepository = static::getContainer()->get(CriticiteRepository::class);
         $this->partnerRepository = static::getContainer()->get(PartnerRepository::class);
@@ -125,6 +125,72 @@ class SignalementImportLoaderTest extends KernelTestCase
 
         $this->assertArrayHasKey('count_signalement', $signalementImportLoader->getMetadata());
         $this->assertEquals(10, $signalementImportLoader->getMetadata()['count_signalement']);
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    public function testLoadSignalementImportIsLogementVacant(): void
+    {
+        $this->entityManager->getEventManager()->removeEventListener([Events::onFlush], new SuiviCreatedListener());
+        $this->entityManager->beginTransaction();
+
+        $signalementImportLoader = new SignalementImportLoader(
+            $this->signalementImportMapper,
+            $this->signalementManager,
+            $this->interventionManager,
+            $this->tagManager,
+            $this->affectationManager,
+            $this->suiviManager,
+            $this->entityManager,
+            $this->parameterBag,
+            $this->logger,
+            $this->criticiteCalculator,
+            $this->signalementQualificationUpdater,
+            $this->fileManager,
+            $this->filesystemOperator,
+            $this->htmlSanitizerInterface,
+            $this->userSignalementSubscriptionManager,
+            $this->critereRepository,
+            $this->criticiteRepository,
+            $this->partnerRepository,
+            $this->userRepository,
+            $this->fileRepository,
+            $this->suiviRepository,
+        );
+
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '01']);
+
+        $dataWithOccupant = $this->getDataWithNomOccupant('Dupont');
+        $headers = array_map('strval', array_keys($dataWithOccupant[0]));
+        $signalementImportLoader->load($territory, $dataWithOccupant, $headers);
+
+        $signalement = $this->entityManager->getRepository(Signalement::class)->findOneBy([], ['id' => 'DESC']);
+        $this->assertNotNull($signalement);
+        $this->assertFalse($signalement->getIsLogementVacant());
+
+        $dataWithoutOccupant = $this->getDataWithNomOccupant(null);
+        $signalementImportLoader->load($territory, $dataWithoutOccupant, $headers);
+
+        $signalement = $this->entityManager->getRepository(Signalement::class)->findOneBy([], ['id' => 'DESC']);
+        $this->assertNotNull($signalement);
+        $this->assertNull($signalement->getIsLogementVacant());
+
+        $this->entityManager->rollback();
+        $this->entityManager->clear();
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function getDataWithNomOccupant(?string $nomOccupant): array
+    {
+        $data = $this->getData();
+        $data[0]['nom occupant'] = $nomOccupant;
+        $data[0]['Déclarant est l occupant?'] = false;
+        $data[0]['nom du declarant'] = null === $nomOccupant ? 'Dupont' : 'Tiers';
+
+        return [$data[0]];
     }
 
     /**

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -187,6 +187,7 @@ class SignalementBuilderTest extends KernelTestCase
         $this->assertEquals(45, $signalement->getSuperficie());
         $this->assertEquals(5, $signalement->getNbNiveauxLogement());
         $this->assertFalse($signalement->getIsConstructionAvant1949());
+        $this->assertFalse($signalement->getIsLogementVacant());
 
         $this->assertEquals(new \DateTimeImmutable('1970-10-01'), $signalement->getDateNaissanceOccupant());
         $this->assertEquals(new \DateTimeImmutable('2020-10-01'), $signalement->getDateEntree());
@@ -417,6 +418,89 @@ class SignalementBuilderTest extends KernelTestCase
         $this->entityManager->commit();
     }
 
+    public static function provideIsLogementVacantCases(): \Generator
+    {
+        yield 'locataire avec nom occupant' => [
+            'locataire.json',
+            ProfileDeclarant::LOCATAIRE,
+            'vos_coordonnees_occupant_email',
+            false,
+        ];
+        yield 'bailleur avec nom occupant' => [
+            'bailleur.json',
+            ProfileDeclarant::BAILLEUR,
+            'vos_coordonnees_tiers_email',
+            false,
+        ];
+        yield 'tiers_particulier avec nom occupant' => [
+            'tiers_particulier.json',
+            ProfileDeclarant::TIERS_PARTICULIER,
+            'vos_coordonnees_tiers_email',
+            false,
+        ];
+        yield 'service_secours avec nom occupant' => [
+            'service_secours.json',
+            ProfileDeclarant::SERVICE_SECOURS,
+            'vos_coordonnees_tiers_email',
+            false,
+        ];
+    }
+
+    #[DataProvider('provideIsLogementVacantCases')]
+    public function testBuildSignalementIsLogementVacantFalseWhenNomOccupant(
+        string $payloadFile,
+        ProfileDeclarant $profileDeclarant,
+        string $emailKey,
+        bool $expected,
+    ): void {
+        $payload = json_decode(
+            (string) file_get_contents(__DIR__.'../../../../../src/DataFixtures/Files/signalement_draft_payload/'.$payloadFile),
+            true
+        );
+
+        $signalementDraft = (new SignalementDraft())
+            ->setPayload($payload)
+            ->setProfileDeclarant($profileDeclarant)
+            ->setStatus(SignalementDraftStatus::EN_COURS)
+            ->setCurrentStep('informations_complementaires')
+            ->setEmailDeclarant($payload[$emailKey] ?? null);
+
+        // isLogementVacant est défini dans setOccupantProfileData(), appelé par withAdressesCoordonnees().
+        // Certains profils (bailleur, service_secours) n'ont pas de désordres dans leur fixture,
+        // ce qui ferait retourner null à build(). On accède directement au signalement via réflexion.
+        $builder = $this->signalementBuilder
+            ->createSignalementBuilderFrom($signalementDraft)
+            ->withAdressesCoordonnees();
+
+        $signalement = (new \ReflectionProperty(SignalementBuilder::class, 'signalement'))->getValue($builder);
+
+        $this->assertEquals($expected, $signalement->getIsLogementVacant());
+    }
+
+    public function testBuildSignalementIsLogementVacantNullWhenNomOccupantAbsent(): void
+    {
+        $payload = json_decode(
+            (string) file_get_contents(__DIR__.'../../../../../src/DataFixtures/Files/signalement_draft_payload/locataire.json'),
+            true
+        );
+        $payload['vos_coordonnees_occupant_nom'] = null;
+
+        $signalementDraft = (new SignalementDraft())
+            ->setPayload($payload)
+            ->setProfileDeclarant(ProfileDeclarant::LOCATAIRE)
+            ->setStatus(SignalementDraftStatus::EN_COURS)
+            ->setCurrentStep('informations_complementaires')
+            ->setEmailDeclarant($payload['vos_coordonnees_occupant_email']);
+
+        $builder = $this->signalementBuilder
+            ->createSignalementBuilderFrom($signalementDraft)
+            ->withAdressesCoordonnees();
+
+        $signalement = (new \ReflectionProperty(SignalementBuilder::class, 'signalement'))->getValue($builder);
+
+        $this->assertNull($signalement->getIsLogementVacant());
+    }
+
     public static function provideAllocataireCases(): \Generator
     {
         // certains cas ne sont pas sensés arriver
@@ -457,7 +541,7 @@ class SignalementBuilderTest extends KernelTestCase
         ?string $logementSocialCaisse,
         string|bool|null $expectedResult,
     ): void {
-        $signalementDraftRequestMock = $this->createMock(SignalementDraftRequest::class);
+        $signalementDraftRequestMock = $this->createStub(SignalementDraftRequest::class);
 
         $signalementDraftRequestMock->method('getLogementSocialAllocation')
             ->willReturn($logementSocialAllocation);

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -483,14 +483,18 @@ class SignalementBuilderTest extends KernelTestCase
             (string) file_get_contents(__DIR__.'../../../../../src/DataFixtures/Files/signalement_draft_payload/locataire.json'),
             true
         );
+        $email = $payload['vos_coordonnees_occupant_email'];
         $payload['vos_coordonnees_occupant_nom'] = null;
+        $payload['vos_coordonnees_occupant_prenom'] = null;
+        $payload['vos_coordonnees_occupant_tel'] = null;
+        $payload['vos_coordonnees_occupant_email'] = null;
 
         $signalementDraft = (new SignalementDraft())
             ->setPayload($payload)
             ->setProfileDeclarant(ProfileDeclarant::LOCATAIRE)
             ->setStatus(SignalementDraftStatus::EN_COURS)
             ->setCurrentStep('informations_complementaires')
-            ->setEmailDeclarant($payload['vos_coordonnees_occupant_email']);
+            ->setEmailDeclarant($email);
 
         $builder = $this->signalementBuilder
             ->createSignalementBuilderFrom($signalementDraft)


### PR DESCRIPTION
## Ticket

#5903   

## Description
Le filtre `Occupation Non Renseigne` remonte 35 000 dossiers, mais dans la fiche signalement sur presque tous on a "logement occupé"
2 raisons :
- si l'info "logement vacant" n'est pas renseignée, la fiche BO affiche `Logement occupé`
- Cette information n'est pas renseignée à tous les endroits où elle devrait l'être. (elle n'est renseignée exhaustivement que dans l'API et dans le form service secours)

## Changements apportés
On ne peut pas rendre cette donnée obligatoire car dans le form Service Secours on peut la laisser à NULL. Mais on peut la renseigner beaucoup plus souvent que ça.

- faire une migration pour mettre false à isLogementVacant sur tous les signalements où c'est NULL et où on a le nom des occupants, et où ce n'est pas créé par le form service secours
- dans le form pro, on met systématiquement false si ce n'est pas coché logement vacant
- dans le form usager, on met systématiquement false si on a le nom des occupants
- dans l'import de signalement, on met false si on met false si on a le nom des occupants
- dans la fiche signalement si c'est indéterminé, on affiche indéterminé (ou occupation du logement non renseignée) et on change la modale

## Pré-requis
Se mettre sur base de prod

## Tests
- [ ] Tester la migration sur base de prod, et vérifier le nb de dossiers en Occupation du logement non renseignée avant et après et vérifier qu'on diminue drastiquement le nombre
- [ ] Ouvrir un des dossiers restants, et vérifier l'affichage puis tester la modale pour enregistrer l'occupation du logement. Vérifier que c'est bien pris en compte, que les suivis sont créés
- [ ] Faire un signalement sur le form BO, avec un profil qui ne permet pas de choisir "logement vacant" (locataire par exemple), et vérifier en base qu'on a bien 0 pour is_logement_vacant
- [ ] Créer un signalement sur le form usager avec des noms pour l'occupant, et vérifier en base que le signalement est bien indiqué comme logement non vacant
