### PR TITLE
[API] Ajout du type partenaire dans l'objet affectation sur la route api/signalements

### DIFF
--- a/src/Dto/Api/Model/Affectation.php
+++ b/src/Dto/Api/Model/Affectation.php
@@ -5,6 +5,7 @@ namespace App\Dto\Api\Model;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\MotifRefus;
+use App\Entity\Enum\PartnerType;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(
@@ -31,6 +32,12 @@ class Affectation
         example: 'Ville de Marseille'
     )]
     public ?string $partenaireNom;
+
+    #[OA\Property(
+        description: 'Le type du partenaire.',
+        example: 'ADIL'
+    )]
+    public PartnerType $partenaireType;
 
     #[OA\Property(
         description: 'Le statut d\'affectation',

--- a/src/Dto/Api/Response/AffectationResponse.php
+++ b/src/Dto/Api/Response/AffectationResponse.php
@@ -11,6 +11,7 @@ class AffectationResponse extends Affectation
         $this->uuid = $affectation->getUuid();
         $this->partenaireUuid = $affectation->getPartner()->getUuid();
         $this->partenaireNom = $affectation->getPartner()->getNom();
+        $this->partenaireType = $affectation->getPartner()->getType();
         $this->statut = $affectation->getStatut();
         $this->dateAffectation = $affectation->getCreatedAt()->format(\DATE_ATOM);
         $this->dateAcceptation = $affectation->getAnsweredAt()->format(\DATE_ATOM);

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -76,6 +76,7 @@ readonly class SignalementResponseFactory
             $affectationModel->uuid = $affectation->getUuid();
             $affectationModel->partenaireUuid = $affectation->getPartner()->getUuid();
             $affectationModel->partenaireNom = $affectation->getPartner()->getNom();
+            $affectationModel->partenaireType = $affectation->getPartner()->getType();
             $affectationModel->statut = $affectation->getStatut();
             $affectationModel->dateAffectation = $affectation->getCreatedAt()->format(\DATE_ATOM);
             $affectationModel->dateAcceptation = $affectation->getAnsweredAt()?->format(\DATE_ATOM);

--- a/tests/Functional/Controller/Api/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementListControllerTest.php
@@ -113,6 +113,7 @@ class SignalementListControllerTest extends WebTestCase
         $this->assertArrayHasKey('affectations', $response);
         $this->assertCount($nbDesordres, $response['desordres']);
         $this->assertCount($nbAffectations, $response['affectations']);
+        $this->assertArrayHasKey('partenaireType', $response['affectations'][0]);
         $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 


### PR DESCRIPTION
## Ticket

#5905   

## Description
Ajout du type partenaire dans l'objet affectation sur la route api/signalements

## Changements apportés
* Ajout du type partenaire dans l'objet affectation sur la route api/signalements

## Pré-requis

## Tests
- [ ] Tester la route api/signalements et aussi la route sur la mise à jour d'une affectation pour voir qu'on a bien le type du partenaire dans la réponse
