### PR TITLE
[BO - Affect Auto] Upload des règles

### DIFF
--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -18,7 +18,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -192,26 +191,14 @@ class AutoAffectationRuleController extends AbstractController
         $form = $this->createForm(AutoAffectationRuleImportType::class);
         $form->handleRequest($request);
 
-        if (!$form->isSubmitted()) {
-            return $this->renderImport($form, []);
-        }
-
-        if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
-            return $this->renderImport($form, [MessageHelper::ERROR_MESSAGE_CSRF]);
-        }
-
-        /** @var UploadedFile|null $csvFile */
-        $csvFile = $form->get('csvFile')->getData();
-        if (null === $csvFile) {
-            $form->get('csvFile')->addError(new FormError('Veuillez sélectionner un fichier CSV.'));
-        }
-
-        if (!$form->isValid()) {
+        if (!$form->isSubmitted() || !$form->isValid()) {
             return $this->renderImport($form, []);
         }
 
         /** @var Territory $territory */
         $territory = $form->get('territory')->getData();
+        /** @var UploadedFile $csvFile */
+        $csvFile = $form->get('csvFile')->getData();
 
         [$parseErrors, $data] = $this->parseCsvFile($csvFile);
         if (!empty($parseErrors)) {
@@ -243,12 +230,8 @@ class AutoAffectationRuleController extends AbstractController
     /**
      * @return array{0: string[], 1: array<int, array<string, string>>}
      */
-    private function parseCsvFile(?UploadedFile $file): array
+    private function parseCsvFile(UploadedFile $file): array
     {
-        if (null === $file) {
-            return [['Veuillez sélectionner un fichier CSV.'], []];
-        }
-
         $csvParser = new CsvParser(['first_line' => 1, 'delimiter' => ';', 'enclosure' => '"', 'escape' => '\\']);
         $headers = $csvParser->getHeaders($file->getPathname());
         $missingHeaders = array_diff(AutoAffectationRuleHeader::REQUIRED_HEADERS, $headers);
@@ -256,14 +239,7 @@ class AutoAffectationRuleController extends AbstractController
             return [[sprintf('Le fichier CSV ne contient pas les colonnes attendues. Colonnes manquantes : "%s".', implode('", "', $missingHeaders))], []];
         }
 
-        $rows = $csvParser->parse($file->getPathname());
-        $data = array_filter(
-            array_map(
-                static fn (array $row) => \count($row) === \count($headers) ? array_combine($headers, $row) : null,
-                $rows,
-            ),
-        );
-
+        $data = $csvParser->parseAsDict($file->getPathname());
         if (empty($data)) {
             return [['Le fichier CSV est vide ou ne contient pas de données.'], []];
         }

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -198,13 +198,15 @@ class AutoAffectationRuleController extends AbstractController
         if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
             return $this->renderImport($form, [MessageHelper::ERROR_MESSAGE_CSRF]);
         }
-
         if (!$form->isValid()) {
             return $this->renderImport($form, []);
         }
 
         /** @var Territory $territory */
         $territory = $form->get('territory')->getData();
+        if (empty($territory)) {
+            return $this->renderImport($form, ['Veuillez sélectionner un territoire.']);
+        }
         /** @var UploadedFile|null $csvFile */
         $csvFile = $form->get('csvFile')->getData();
 

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -3,6 +3,8 @@
 namespace App\Controller\Back;
 
 use App\Entity\AutoAffectationRule;
+use App\Entity\Territory;
+use App\Form\AutoAffectationRuleImportType;
 use App\Form\AutoAffectationRuleType;
 use App\Form\SearchAutoAffectationRuleType;
 use App\Repository\AutoAffectationRuleRepository;
@@ -17,6 +19,7 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -185,43 +188,58 @@ class AutoAffectationRuleController extends AbstractController
         Request $request,
         AutoAffectationRuleLoader $loader,
     ): Response {
-        if (!$request->isMethod('POST')) {
-            return $this->renderImport([]);
+        $form = $this->createForm(AutoAffectationRuleImportType::class);
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted()) {
+            return $this->renderImport($form, []);
         }
 
         if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
-            return $this->renderImport([MessageHelper::ERROR_MESSAGE_CSRF]);
+            return $this->renderImport($form, [MessageHelper::ERROR_MESSAGE_CSRF]);
         }
 
-        [$parseErrors, $data] = $this->parseCsvFile($request);
+        if (!$form->isValid()) {
+            return $this->renderImport($form, []);
+        }
+
+        /** @var Territory $territory */
+        $territory = $form->get('territory')->getData();
+        /** @var UploadedFile|null $csvFile */
+        $csvFile = $form->get('csvFile')->getData();
+
+        [$parseErrors, $data] = $this->parseCsvFile($csvFile);
         if (!empty($parseErrors)) {
-            return $this->renderImport($parseErrors);
+            return $this->renderImport($form, $parseErrors);
         }
 
-        $errors = $loader->validate($data);
+        $errors = $loader->validate($data, $territory);
         if (!empty($errors)) {
-            return $this->renderImport($errors);
+            return $this->renderImport($form, $errors);
         }
 
-        $loader->load($data);
+        $loader->load($data, $territory);
         $metadata = $loader->getMetadata();
         $this->addFlash('success', [
             'title' => 'Import réussi',
-            'message' => sprintf('%d règle(s) d\'auto-affectation importée(s) avec succès.', $metadata['nb_rules_created']),
+            'message' => sprintf(
+                '%d règle(s) créée(s) sur le territoire %s. %s',
+                $metadata['nb_rules_created'],
+                $territory->getZipAndName(),
+                $metadata['nb_rules_archived'] > 0
+                    ? sprintf('%d règle(s) existante(s) archivée(s).', $metadata['nb_rules_archived'])
+                    : '',
+            ),
         ]);
 
-        $territoryIds = $metadata['imported_territory_ids'];
-        $redirectParams = 1 === \count($territoryIds) ? ['territory' => $territoryIds[0]] : [];
-
-        return $this->redirectToRoute('back_auto_affectation_rule_index', $redirectParams, Response::HTTP_SEE_OTHER);
+        return $this->redirectToRoute('back_auto_affectation_rule_index', ['territory' => $territory->getId()], Response::HTTP_SEE_OTHER);
     }
 
     /**
      * @return array{0: string[], 1: array<int, array<string, string>>}
      */
-    private function parseCsvFile(Request $request): array
+    private function parseCsvFile(?UploadedFile $file): array
     {
-        $file = $request->files->get('csv_file');
         if (null === $file) {
             return [['Veuillez sélectionner un fichier CSV.'], []];
         }
@@ -249,10 +267,11 @@ class AutoAffectationRuleController extends AbstractController
     }
 
     /**
-     * @param string[] $errors
+     * @param FormInterface<mixed> $form
+     * @param string[]             $errors
      */
-    private function renderImport(array $errors): Response
+    private function renderImport(FormInterface $form, array $errors): Response
     {
-        return $this->render('back/auto-affectation-rule/import.html.twig', ['errors' => $errors]);
+        return $this->render('back/auto-affectation-rule/import.html.twig', ['form' => $form, 'errors' => $errors]);
     }
 }

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -6,6 +6,8 @@ use App\Entity\AutoAffectationRule;
 use App\Form\AutoAffectationRuleType;
 use App\Form\SearchAutoAffectationRuleType;
 use App\Repository\AutoAffectationRuleRepository;
+use App\Service\Import\AutoAffectationRule\AutoAffectationRuleLoader;
+use App\Service\Import\CsvParser;
 use App\Service\ListFilters\SearchAutoAffectationRule;
 use App\Service\MessageHelper;
 use App\Utils\FormHelper;
@@ -174,6 +176,56 @@ class AutoAffectationRuleController extends AbstractController
             'autoAffectationRule' => $autoAffectationRule,
             'form' => $form,
             'create' => true,
+        ]);
+    }
+
+    #[Route('/importer', name: 'back_auto_affectation_rule_import', methods: ['GET', 'POST'])]
+    public function import(
+        Request $request,
+        AutoAffectationRuleLoader $loader,
+    ): Response {
+        $errors = [];
+
+        if ($request->isMethod('POST')) {
+            if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
+                $errors[] = MessageHelper::ERROR_MESSAGE_CSRF;
+            } else {
+                $file = $request->files->get('csv_file');
+                if (null === $file) {
+                    $errors[] = 'Veuillez sélectionner un fichier CSV.';
+                } else {
+                    $csvParser = new CsvParser(['first_line' => 1, 'delimiter' => ';', 'enclosure' => '"', 'escape' => '\\']);
+                    $headers = $csvParser->getHeaders($file->getPathname());
+                    $rows = $csvParser->parse($file->getPathname());
+                    $data = array_map(
+                        static fn (array $row) => array_combine($headers, $row),
+                        array_filter($rows, static fn (array $row) => \count($row) === \count($headers)),
+                    );
+
+                    if (empty($data)) {
+                        $errors[] = 'Le fichier CSV est vide ou ne contient pas de données.';
+                    } else {
+                        $errors = $loader->validate($data);
+                        if (empty($errors)) {
+                            $loader->load($data);
+                            $metadata = $loader->getMetadata();
+                            $this->addFlash('success', [
+                                'title' => 'Import réussi',
+                                'message' => sprintf('%d règle(s) d\'auto-affectation importée(s) avec succès.', $metadata['nb_rules_created']),
+                            ]);
+
+                            $territoryIds = $metadata['imported_territory_ids'];
+                            $redirectParams = 1 === \count($territoryIds) ? ['territory' => $territoryIds[0]] : [];
+
+                            return $this->redirectToRoute('back_auto_affectation_rule_index', $redirectParams, Response::HTTP_SEE_OTHER);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $this->render('back/auto-affectation-rule/import.html.twig', [
+            'errors' => $errors,
         ]);
     }
 }

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -198,17 +199,19 @@ class AutoAffectationRuleController extends AbstractController
         if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
             return $this->renderImport($form, [MessageHelper::ERROR_MESSAGE_CSRF]);
         }
+
+        /** @var UploadedFile|null $csvFile */
+        $csvFile = $form->get('csvFile')->getData();
+        if (null === $csvFile) {
+            $form->get('csvFile')->addError(new FormError('Veuillez sélectionner un fichier CSV.'));
+        }
+
         if (!$form->isValid()) {
             return $this->renderImport($form, []);
         }
 
         /** @var Territory $territory */
         $territory = $form->get('territory')->getData();
-        if (empty($territory)) {
-            return $this->renderImport($form, ['Veuillez sélectionner un territoire.']);
-        }
-        /** @var UploadedFile|null $csvFile */
-        $csvFile = $form->get('csvFile')->getData();
 
         [$parseErrors, $data] = $this->parseCsvFile($csvFile);
         if (!empty($parseErrors)) {

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -6,6 +6,7 @@ use App\Entity\AutoAffectationRule;
 use App\Form\AutoAffectationRuleType;
 use App\Form\SearchAutoAffectationRuleType;
 use App\Repository\AutoAffectationRuleRepository;
+use App\Service\Import\AutoAffectationRule\AutoAffectationRuleHeader;
 use App\Service\Import\AutoAffectationRule\AutoAffectationRuleLoader;
 use App\Service\Import\CsvParser;
 use App\Service\ListFilters\SearchAutoAffectationRule;
@@ -184,48 +185,74 @@ class AutoAffectationRuleController extends AbstractController
         Request $request,
         AutoAffectationRuleLoader $loader,
     ): Response {
-        $errors = [];
-
-        if ($request->isMethod('POST')) {
-            if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
-                $errors[] = MessageHelper::ERROR_MESSAGE_CSRF;
-            } else {
-                $file = $request->files->get('csv_file');
-                if (null === $file) {
-                    $errors[] = 'Veuillez sélectionner un fichier CSV.';
-                } else {
-                    $csvParser = new CsvParser(['first_line' => 1, 'delimiter' => ';', 'enclosure' => '"', 'escape' => '\\']);
-                    $headers = $csvParser->getHeaders($file->getPathname());
-                    $rows = $csvParser->parse($file->getPathname());
-                    $data = array_map(
-                        static fn (array $row) => array_combine($headers, $row),
-                        array_filter($rows, static fn (array $row) => \count($row) === \count($headers)),
-                    );
-
-                    if (empty($data)) {
-                        $errors[] = 'Le fichier CSV est vide ou ne contient pas de données.';
-                    } else {
-                        $errors = $loader->validate($data);
-                        if (empty($errors)) {
-                            $loader->load($data);
-                            $metadata = $loader->getMetadata();
-                            $this->addFlash('success', [
-                                'title' => 'Import réussi',
-                                'message' => sprintf('%d règle(s) d\'auto-affectation importée(s) avec succès.', $metadata['nb_rules_created']),
-                            ]);
-
-                            $territoryIds = $metadata['imported_territory_ids'];
-                            $redirectParams = 1 === \count($territoryIds) ? ['territory' => $territoryIds[0]] : [];
-
-                            return $this->redirectToRoute('back_auto_affectation_rule_index', $redirectParams, Response::HTTP_SEE_OTHER);
-                        }
-                    }
-                }
-            }
+        if (!$request->isMethod('POST')) {
+            return $this->renderImport([]);
         }
 
-        return $this->render('back/auto-affectation-rule/import.html.twig', [
-            'errors' => $errors,
+        if (!$this->isCsrfTokenValid('auto_affectation_rule_import', (string) $request->request->get('_token'))) {
+            return $this->renderImport([MessageHelper::ERROR_MESSAGE_CSRF]);
+        }
+
+        [$parseErrors, $data] = $this->parseCsvFile($request);
+        if (!empty($parseErrors)) {
+            return $this->renderImport($parseErrors);
+        }
+
+        $errors = $loader->validate($data);
+        if (!empty($errors)) {
+            return $this->renderImport($errors);
+        }
+
+        $loader->load($data);
+        $metadata = $loader->getMetadata();
+        $this->addFlash('success', [
+            'title' => 'Import réussi',
+            'message' => sprintf('%d règle(s) d\'auto-affectation importée(s) avec succès.', $metadata['nb_rules_created']),
         ]);
+
+        $territoryIds = $metadata['imported_territory_ids'];
+        $redirectParams = 1 === \count($territoryIds) ? ['territory' => $territoryIds[0]] : [];
+
+        return $this->redirectToRoute('back_auto_affectation_rule_index', $redirectParams, Response::HTTP_SEE_OTHER);
+    }
+
+    /**
+     * @return array{0: string[], 1: array<int, array<string, string>>}
+     */
+    private function parseCsvFile(Request $request): array
+    {
+        $file = $request->files->get('csv_file');
+        if (null === $file) {
+            return [['Veuillez sélectionner un fichier CSV.'], []];
+        }
+
+        $csvParser = new CsvParser(['first_line' => 1, 'delimiter' => ';', 'enclosure' => '"', 'escape' => '\\']);
+        $headers = $csvParser->getHeaders($file->getPathname());
+        $missingHeaders = array_diff(AutoAffectationRuleHeader::REQUIRED_HEADERS, $headers);
+        if (!empty($missingHeaders)) {
+            return [[sprintf('Le fichier CSV ne contient pas les colonnes attendues. Colonnes manquantes : "%s".', implode('", "', $missingHeaders))], []];
+        }
+
+        $rows = $csvParser->parse($file->getPathname());
+        $data = array_filter(
+            array_map(
+                static fn (array $row) => \count($row) === \count($headers) ? array_combine($headers, $row) : null,
+                $rows,
+            ),
+        );
+
+        if (empty($data)) {
+            return [['Le fichier CSV est vide ou ne contient pas de données.'], []];
+        }
+
+        return [[], $data];
+    }
+
+    /**
+     * @param string[] $errors
+     */
+    private function renderImport(array $errors): Response
+    {
+        return $this->render('back/auto-affectation-rule/import.html.twig', ['errors' => $errors]);
     }
 }

--- a/src/Form/AutoAffectationRuleImportType.php
+++ b/src/Form/AutoAffectationRuleImportType.php
@@ -31,6 +31,7 @@ class AutoAffectationRuleImportType extends AbstractType
                 'help' => 'Format accepté : .csv — Séparateur : point-virgule (;)',
                 'mapped' => false,
                 'required' => false,
+                'constraints' => [new NotNull(message: 'Veuillez sélectionner un fichier CSV.')],
             ]);
     }
 
@@ -38,7 +39,7 @@ class AutoAffectationRuleImportType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => null,
-            'csrf_protection' => false,
+            'csrf_token_id' => 'auto_affectation_rule_import',
         ]);
     }
 }

--- a/src/Form/AutoAffectationRuleImportType.php
+++ b/src/Form/AutoAffectationRuleImportType.php
@@ -20,7 +20,7 @@ class AutoAffectationRuleImportType extends AbstractType
     {
         $builder
             ->add('territory', TerritoryChoiceType::class, [
-                'required' => true,
+                'required' => false,
                 'label' => 'Territoire',
                 'placeholder' => 'Sélectionnez un territoire',
             ])

--- a/src/Form/AutoAffectationRuleImportType.php
+++ b/src/Form/AutoAffectationRuleImportType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Form;
+
+use App\Form\Type\TerritoryChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<mixed>
+ */
+class AutoAffectationRuleImportType extends AbstractType
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('territory', TerritoryChoiceType::class, [
+                'required' => true,
+                'label' => 'Territoire',
+                'placeholder' => 'Sélectionnez un territoire',
+            ])
+            ->add('csvFile', FileType::class, [
+                'label' => 'Fichier CSV',
+                'help' => 'Format accepté : .csv — Séparateur : point-virgule (;)',
+                'mapped' => false,
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => null,
+            'csrf_protection' => false,
+        ]);
+    }
+}

--- a/src/Form/AutoAffectationRuleImportType.php
+++ b/src/Form/AutoAffectationRuleImportType.php
@@ -7,6 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotNull;
 
 /**
  * @extends AbstractType<mixed>
@@ -23,6 +24,7 @@ class AutoAffectationRuleImportType extends AbstractType
                 'required' => false,
                 'label' => 'Territoire',
                 'placeholder' => 'Sélectionnez un territoire',
+                'constraints' => [new NotNull(message: 'Veuillez sélectionner un territoire.')],
             ])
             ->add('csvFile', FileType::class, [
                 'label' => 'Fichier CSV',

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleHeader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleHeader.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service\Import\AutoAffectationRule;
+
+class AutoAffectationRuleHeader
+{
+    public const string TERRITORY = 'Territoire';
+    public const string STATUS = 'Statut';
+    public const string PARTNER_TYPE = 'Type de partenaire';
+    public const string PROFILE_DECLARANT = 'Profil déclarant';
+    public const string PARC = 'Parc';
+    public const string ALLOCATAIRE = 'Allocataire';
+    public const string INSEE_TO_INCLUDE = 'Code insee inclus';
+    public const string INSEE_TO_EXCLUDE = 'Code insee exclus';
+    public const string PARTNER_TO_EXCLUDE = 'Id partenaires exclus';
+    public const string PROCEDURES_SUSPECTEES = 'Procédures suspectées';
+
+    public const array REQUIRED_HEADERS = [
+        self::TERRITORY,
+        self::STATUS,
+        self::PARTNER_TYPE,
+        self::PROFILE_DECLARANT,
+        self::PARC,
+        self::ALLOCATAIRE,
+        self::INSEE_TO_INCLUDE,
+        self::INSEE_TO_EXCLUDE,
+        self::PARTNER_TO_EXCLUDE,
+        self::PROCEDURES_SUSPECTEES,
+    ];
+}

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleHeader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleHeader.php
@@ -16,7 +16,6 @@ class AutoAffectationRuleHeader
     public const string PROCEDURES_SUSPECTEES = 'Procédures suspectées';
 
     public const array REQUIRED_HEADERS = [
-        self::TERRITORY,
         self::STATUS,
         self::PARTNER_TYPE,
         self::PROFILE_DECLARANT,

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
@@ -48,180 +48,29 @@ class AutoAffectationRuleLoader
 
         foreach ($data as $index => $row) {
             $lineNumber = $index + 2;
-            $rowErrors = '';
-
-            $territoryValue = trim($row[AutoAffectationRuleHeader::TERRITORY] ?? '');
-            $territory = $this->findTerritory($territoryValue);
-            if (null === $territory) {
-                $rowErrors .= sprintf('<li>Territoire "%s" introuvable </li>', $territoryValue);
-            }
-
-            $status = trim($row[AutoAffectationRuleHeader::STATUS] ?? '');
-            if (!\in_array($status, [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED])) {
-                $rowErrors .= sprintf(
-                    '<li>Statut "%s" invalide (valeurs acceptées : ACTIVE, ARCHIVED) </li>',
-                    $status,
-                );
-            }
-
-            $partnerTypeLabel = trim($row[AutoAffectationRuleHeader::PARTNER_TYPE] ?? '');
-            $partnerType = PartnerType::tryFromLabel($partnerTypeLabel);
-            if (null === $partnerType) {
-                // $rowErrors[] = sprintf(
-                $rowErrors .= sprintf(
-                    '<li>Type de partenaire "%s" invalide (valeurs acceptées : %s) </li>',
-                    $partnerTypeLabel,
-                    implode(', ', PartnerType::names()),
-                );
-            }
-
-            $profileDeclarant = trim($row[AutoAffectationRuleHeader::PROFILE_DECLARANT] ?? '');
-            if (!$this->isValidProfileDeclarant($profileDeclarant)) {
-                $rowErrors .= sprintf(
-                    '<li>Profil déclarant "%s" invalide (valeurs acceptées : all, tiers, occupant, %s) </li>',
-                    $profileDeclarant,
-                    implode(', ', ProfileDeclarant::names()),
-                );
-            }
-
-            $parc = trim($row[AutoAffectationRuleHeader::PARC] ?? '');
-            if (!\in_array($parc, self::VALID_PARC)) {
-                $rowErrors .= sprintf(
-                    '<li>Parc "%s" invalide (valeurs acceptées : %s) </li>',
-                    $parc,
-                    implode(', ', self::VALID_PARC),
-                );
-            }
-
-            $allocataire = trim($row[AutoAffectationRuleHeader::ALLOCATAIRE] ?? '');
-            if (!\in_array($allocataire, self::VALID_ALLOCATAIRE)) {
-                $rowErrors .= sprintf(
-                    '<li>Allocataire "%s" invalide (valeurs acceptées : %s) </li>',
-                    $allocataire,
-                    implode(', ', self::VALID_ALLOCATAIRE),
-                );
-            }
-
-            $inseeToInclude = $this->parseInseeToInclude($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE] ?? '');
-            $inseeToExclude = $this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_EXCLUDE] ?? '');
-            $partnerToExclude = $this->parseArrayField($row[AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE] ?? '');
-            $rawProcedures = $row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES] ?? '';
-            $proceduresSuspectees = $this->parseProceduresSuspectees($rawProcedures);
-
-            if ('' !== $inseeToInclude) {
-                $invalidCodes = array_filter(
-                    array_map('trim', explode(',', $inseeToInclude)),
-                    static fn (string $code) => !preg_match('/^\d{5}$/', $code),
-                );
-                if (!empty($invalidCodes)) {
-                    $rowErrors .= sprintf(
-                        '<li>Codes INSEE à inclure invalides : "%s" (format attendu :  liste de codes insee à 5 chiffres séparés par des virgules)</li>',
-                        implode('", "', $invalidCodes),
-                    );
-                }
-            }
-
-            if (null !== $inseeToExclude) {
-                $invalidCodes = array_filter(
-                    $inseeToExclude,
-                    static fn (string $code) => !preg_match('/^\d{5}$/', $code),
-                );
-                if (!empty($invalidCodes)) {
-                    $rowErrors .= sprintf(
-                        '<li>Codes INSEE à exclure invalides : "%s" (format attendu :  liste de codes insee à 5 chiffres séparés par des virgules)</li>',
-                        implode('", "', $invalidCodes),
-                    );
-                }
-            }
-
-            if (null !== $partnerToExclude) {
-                $invalidIds = array_filter(
-                    $partnerToExclude,
-                    static fn (string $id) => !preg_match('/^\d+$/', $id),
-                );
-                if (!empty($invalidIds)) {
-                    $rowErrors .= sprintf(
-                        '<li>IDs partenaires à exclure invalides : "%s" (entiers séparés par des virgules attendus)</li>',
-                        implode('", "', $invalidIds),
-                    );
-                } elseif (null !== $territory && null !== $partnerType) {
-                    foreach ($partnerToExclude as $partnerId) {
-                        // $partner = $this->partnerRepository->findOneBy([
-                        //     'id' => (int) $partnerId,
-                        //     'territory' => $territory,
-                        //     'type' => $partnerType,
-                        //     'isArchive' => false,
-                        // ]);
-                        // if (null === $partner) {
-                        //     $rowErrors .= sprintf(
-                        //         '<li>Partenaire à exclure ID %s introuvable, archivé, ou n\'appartenant pas au territoire "%s" avec le type "%s"</li>',
-                        //         $partnerId,
-                        //         $territory->getZipAndName(),
-                        //         $partnerType->label(),
-                        //     );
-                        // }
-                        $partner = $this->partnerRepository->findOneBy([
-                            'id' => (int) $partnerId,
-                        ]);
-                        if (null === $partner) {
-                            $rowErrors .= sprintf(
-                                '<li>Partenaire à exclure ID %s introuvable</li>',
-                                $partnerId,
-                            );
-                        } elseif ($partner->getIsArchive()) {
-                            $rowErrors .= sprintf(
-                                '<li>Partenaire à exclure ID %s est archivé</li>',
-                                $partnerId,
-                            );
-                        } elseif ($partner->getTerritory()->getId() !== $territory->getId()) {
-                            $rowErrors .= sprintf(
-                                '<li>Partenaire à exclure ID %s n\'appartient pas au territoire "%s" </li>',
-                                $partnerId,
-                                $territory->getZipAndName(),
-                            );
-                        } elseif ($partner->getType() !== $partnerType) {
-                            $rowErrors .= sprintf(
-                                '<li>Partenaire à exclure ID %s n\'a pas le type "%s"</li>',
-                                $partnerId,
-                                $partnerType->label(),
-                            );
-                        }
-                    }
-                }
-            }
-
-            $rawProcedures = trim($rawProcedures);
-            if ('' !== $rawProcedures && self::EMPTY_FIELD_MARKER !== $rawProcedures) {
-                $validProcedures = Qualification::getProcedureSuspecteeList();
-                foreach (explode(',', $rawProcedures) as $label) {
-                    $label = trim($label);
-                    $qualification = Qualification::tryFromLabel($label);
-                    if (null === $qualification || !\in_array($qualification, $validProcedures)) {
-                        $rowErrors .= sprintf(
-                            '<li>Procédure suspectée "%s" invalide (valeurs acceptées : %s séparées par des virgules)</li>',
-                            $label,
-                            implode(', ', array_map(static fn (Qualification $q) => $q->label(), $validProcedures)),
-                        );
-                    }
-                }
-            }
+            $parsed = $this->parseRow($row);
+            $rowErrors = $this->buildRowErrors($parsed);
 
             if (!empty($rowErrors)) {
-                $errors[] = sprintf('Ligne %d : <ul>%s</ul>', $lineNumber, rtrim($rowErrors, ' / '));
+                $errors[] = sprintf('Ligne %d : <ul>%s</ul>', $lineNumber, $rowErrors);
                 continue;
             }
 
             /** @var Territory $territory */
+            $territory = $parsed['territory'];
+            /** @var PartnerType $partnerType */
+            $partnerType = $parsed['partnerType'];
+
             $ruleKey = $this->buildRuleKey(
                 $territory,
                 $partnerType,
-                $profileDeclarant,
-                $parc,
-                $allocataire,
-                $inseeToInclude,
-                $inseeToExclude,
-                $partnerToExclude,
-                $proceduresSuspectees,
+                $parsed['profileDeclarant'],
+                $parsed['parc'],
+                $parsed['allocataire'],
+                $parsed['inseeToInclude'],
+                $parsed['inseeToExclude'],
+                $parsed['partnerToExclude'],
+                $parsed['proceduresSuspectees'],
             );
 
             if (\in_array($ruleKey, $seenRuleKeys)) {
@@ -230,15 +79,15 @@ class AutoAffectationRuleLoader
             }
             $seenRuleKeys[] = $ruleKey;
 
-            if ($this->ruleExistsInDatabase($territory, $partnerType, $profileDeclarant, $parc, $allocataire, $inseeToInclude, $inseeToExclude, $partnerToExclude, $proceduresSuspectees)) {
+            if ($this->ruleExistsInDatabase($territory, $partnerType, $parsed['profileDeclarant'], $parsed['parc'], $parsed['allocataire'], $parsed['inseeToInclude'], $parsed['inseeToExclude'], $parsed['partnerToExclude'], $parsed['proceduresSuspectees'])) {
                 $errors[] = sprintf(
                     'Ligne %d : Une règle identique existe déjà pour le territoire "%s" (type : %s, profil : %s, parc : %s, allocataire : %s).',
                     $lineNumber,
                     $territory->getZipAndName(),
                     $partnerType->label(),
-                    $profileDeclarant,
-                    $parc,
-                    $allocataire,
+                    $parsed['profileDeclarant'],
+                    $parsed['parc'],
+                    $parsed['allocataire'],
                 );
             }
         }
@@ -291,6 +140,187 @@ class AutoAffectationRuleLoader
     public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    /**
+     * @param array<string, string> $row
+     *
+     * @return array{territoryValue: string, territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>}
+     */
+    private function parseRow(array $row): array
+    {
+        $territoryValue = trim($row[AutoAffectationRuleHeader::TERRITORY] ?? '');
+        $partnerTypeLabel = trim($row[AutoAffectationRuleHeader::PARTNER_TYPE] ?? '');
+        $rawProcedures = trim($row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES] ?? '');
+
+        return [
+            'territoryValue' => $territoryValue,
+            'territory' => $this->findTerritory($territoryValue),
+            'status' => trim($row[AutoAffectationRuleHeader::STATUS] ?? ''),
+            'partnerTypeLabel' => $partnerTypeLabel,
+            'partnerType' => PartnerType::tryFromLabel($partnerTypeLabel),
+            'profileDeclarant' => trim($row[AutoAffectationRuleHeader::PROFILE_DECLARANT] ?? ''),
+            'parc' => trim($row[AutoAffectationRuleHeader::PARC] ?? ''),
+            'allocataire' => trim($row[AutoAffectationRuleHeader::ALLOCATAIRE] ?? ''),
+            'inseeToInclude' => $this->parseInseeToInclude($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE] ?? ''),
+            'inseeToExclude' => $this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_EXCLUDE] ?? ''),
+            'partnerToExclude' => $this->parseArrayField($row[AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE] ?? ''),
+            'rawProcedures' => $rawProcedures,
+            'proceduresSuspectees' => $this->parseProceduresSuspectees($rawProcedures),
+        ];
+    }
+
+    /**
+     * @param array{territoryValue: string, territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>} $parsed
+     */
+    private function buildRowErrors(array $parsed): string
+    {
+        return $this->validateCoreFields($parsed)
+            . $this->validateInseeToInclude($parsed['inseeToInclude'])
+            . $this->validateInseeToExclude($parsed['inseeToExclude'])
+            . $this->validatePartnersToExclude($parsed['partnerToExclude'], $parsed['territory'], $parsed['partnerType'])
+            . $this->validateProceduresSuspectees($parsed['rawProcedures']);
+    }
+
+    /**
+     * @param array{territoryValue: string, territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string} $parsed
+     */
+    private function validateCoreFields(array $parsed): string
+    {
+        $errors = '';
+
+        if (null === $parsed['territory']) {
+            $errors .= sprintf('<li>Territoire "%s" introuvable</li>', $parsed['territoryValue']);
+        }
+        if (!\in_array($parsed['status'], [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED])) {
+            $errors .= sprintf('<li>Statut "%s" invalide (valeurs acceptées : ACTIVE, ARCHIVED)</li>', $parsed['status']);
+        }
+        if (null === $parsed['partnerType']) {
+            $errors .= sprintf('<li>Type de partenaire "%s" invalide (valeurs acceptées : %s)</li>', $parsed['partnerTypeLabel'], implode(', ', PartnerType::names()));
+        }
+        if (!$this->isValidProfileDeclarant($parsed['profileDeclarant'])) {
+            $errors .= sprintf('<li>Profil déclarant "%s" invalide (valeurs acceptées : all, tiers, occupant, %s)</li>', $parsed['profileDeclarant'], implode(', ', ProfileDeclarant::names()));
+        }
+        if (!\in_array($parsed['parc'], self::VALID_PARC)) {
+            $errors .= sprintf('<li>Parc "%s" invalide (valeurs acceptées : %s)</li>', $parsed['parc'], implode(', ', self::VALID_PARC));
+        }
+        if (!\in_array($parsed['allocataire'], self::VALID_ALLOCATAIRE)) {
+            $errors .= sprintf('<li>Allocataire "%s" invalide (valeurs acceptées : %s)</li>', $parsed['allocataire'], implode(', ', self::VALID_ALLOCATAIRE));
+        }
+
+        return $errors;
+    }
+
+    private function validateInseeToInclude(string $inseeToInclude): string
+    {
+        if ('' === $inseeToInclude) {
+            return '';
+        }
+
+        $invalidCodes = array_filter(
+            array_map('trim', explode(',', $inseeToInclude)),
+            static fn (string $code) => !preg_match('/^\d{5}$/', $code),
+        );
+
+        if (empty($invalidCodes)) {
+            return '';
+        }
+
+        return sprintf(
+            '<li>Codes INSEE à inclure invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
+            implode('", "', $invalidCodes),
+        );
+    }
+
+    /**
+     * @param array<string>|null $inseeToExclude
+     */
+    private function validateInseeToExclude(?array $inseeToExclude): string
+    {
+        if (null === $inseeToExclude) {
+            return '';
+        }
+
+        $invalidCodes = array_filter(
+            $inseeToExclude,
+            static fn (string $code) => !preg_match('/^\d{5}$/', $code),
+        );
+
+        if (empty($invalidCodes)) {
+            return '';
+        }
+
+        return sprintf(
+            '<li>Codes INSEE à exclure invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
+            implode('", "', $invalidCodes),
+        );
+    }
+
+    /**
+     * @param array<string>|null $partnerToExclude
+     */
+    private function validatePartnersToExclude(?array $partnerToExclude, ?Territory $territory, ?PartnerType $partnerType): string
+    {
+        if (null === $partnerToExclude) {
+            return '';
+        }
+
+        $invalidIds = array_filter($partnerToExclude, static fn (string $id) => !preg_match('/^\d+$/', $id));
+        if (!empty($invalidIds)) {
+            return sprintf('<li>IDs partenaires à exclure invalides : "%s" (entiers séparés par des virgules attendus)</li>', implode('", "', $invalidIds));
+        }
+
+        if (null === $territory || null === $partnerType) {
+            return '';
+        }
+
+        $errors = '';
+        foreach ($partnerToExclude as $partnerId) {
+            $errors .= $this->validatePartnerToExclude($partnerId, $territory, $partnerType);
+        }
+
+        return $errors;
+    }
+
+    private function validatePartnerToExclude(string $partnerId, Territory $territory, PartnerType $partnerType): string
+    {
+        $partner = $this->partnerRepository->findOneBy(['id' => (int) $partnerId]);
+
+        if (null === $partner) {
+            return sprintf('<li>Partenaire à exclure ID %s introuvable</li>', $partnerId);
+        }
+        if ($partner->getIsArchive()) {
+            return sprintf('<li>Partenaire à exclure ID %s est archivé</li>', $partnerId);
+        }
+        if ($partner->getTerritory()->getId() !== $territory->getId()) {
+            return sprintf('<li>Partenaire à exclure ID %s n\'appartient pas au territoire "%s"</li>', $partnerId, $territory->getZipAndName());
+        }
+        if ($partner->getType() !== $partnerType) {
+            return sprintf('<li>Partenaire à exclure ID %s n\'a pas le type "%s"</li>', $partnerId, $partnerType->label());
+        }
+
+        return '';
+    }
+
+    private function validateProceduresSuspectees(string $rawProcedures): string
+    {
+        if ('' === $rawProcedures || self::EMPTY_FIELD_MARKER === $rawProcedures) {
+            return '';
+        }
+
+        $validProcedures = Qualification::getProcedureSuspecteeList();
+        $validLabels = implode(', ', array_map(static fn (Qualification $q) => $q->label(), $validProcedures));
+        $errors = '';
+
+        foreach (explode(',', $rawProcedures) as $label) {
+            $label = trim($label);
+            $qualification = Qualification::tryFromLabel($label);
+            if (null === $qualification || !\in_array($qualification, $validProcedures)) {
+                $errors .= sprintf('<li>Procédure suspectée "%s" invalide (valeurs acceptées : %s)</li>', $label, $validLabels);
+            }
+        }
+
+        return $errors;
     }
 
     private function findTerritory(string $value): ?Territory
@@ -432,17 +462,7 @@ class AutoAffectationRuleLoader
             'inseeToInclude' => $inseeToInclude,
         ]);
 
-        $newKey = $this->buildRuleKey(
-            $territory,
-            $partnerType,
-            $profileDeclarant,
-            $parc,
-            $allocataire,
-            $inseeToInclude,
-            $inseeToExclude,
-            $partnerToExclude,
-            $proceduresSuspectees,
-        );
+        $newKey = $this->buildRuleKey($territory, $partnerType, $profileDeclarant, $parc, $allocataire, $inseeToInclude, $inseeToExclude, $partnerToExclude, $proceduresSuspectees);
 
         foreach ($existingRules as $existingRule) {
             $existingKey = $this->buildRuleKey(

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
@@ -3,11 +3,13 @@
 namespace App\Service\Import\AutoAffectationRule;
 
 use App\Entity\AutoAffectationRule;
+use App\Entity\Commune;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\Qualification;
 use App\Entity\Territory;
 use App\Repository\AutoAffectationRuleRepository;
+use App\Repository\CommuneRepository;
 use App\Repository\PartnerRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -29,6 +31,7 @@ class AutoAffectationRuleLoader
     public function __construct(
         private readonly AutoAffectationRuleRepository $autoAffectationRuleRepository,
         private readonly PartnerRepository $partnerRepository,
+        private readonly CommuneRepository $communeRepository,
         private readonly EntityManagerInterface $entityManager,
     ) {
     }
@@ -161,11 +164,24 @@ class AutoAffectationRuleLoader
      */
     private function buildRowErrors(array $parsed, Territory $territory): string
     {
+        $territoryInseeCodes = $this->getTerritoryInseeCodes($territory);
+
         return $this->validateCoreFields($parsed)
-            .$this->validateInseeCodes($parsed['inseeToInclude'] ?? [], 'inclure')
-            .$this->validateInseeCodes($parsed['inseeToExclude'] ?? [], 'exclure')
+            .$this->validateInseeCodes($parsed['inseeToInclude'] ?? [], 'inclure', $territory, $territoryInseeCodes)
+            .$this->validateInseeCodes($parsed['inseeToExclude'] ?? [], 'exclure', $territory, $territoryInseeCodes)
             .$this->validatePartnersToExclude($parsed['partnerToExclude'], $territory, $parsed['partnerType'])
             .$this->validateProceduresSuspectees($parsed['rawProcedures']);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getTerritoryInseeCodes(Territory $territory): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (Commune $commune): string => $commune->getCodeInsee(),
+            $this->communeRepository->findBy(['territory' => $territory]),
+        )));
     }
 
     /**
@@ -196,20 +212,34 @@ class AutoAffectationRuleLoader
 
     /**
      * @param array<string> $codes
+     * @param string[]      $territoryInseeCodes
      */
-    private function validateInseeCodes(array $codes, string $direction): string
+    private function validateInseeCodes(array $codes, string $direction, Territory $territory, array $territoryInseeCodes): string
     {
-        $invalidCodes = array_filter($codes, static fn (string $code) => !preg_match('/^\d{5}$/', $code));
+        $invalidCodes = array_filter($codes, static fn (string $code) => !(bool) preg_match('/^\d{5}$/', $code));
+        $errors = '';
 
-        if (empty($invalidCodes)) {
-            return '';
+        if (!empty($invalidCodes)) {
+            $errors .= sprintf(
+                '<li>Codes INSEE %s invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
+                $direction,
+                implode('", "', $invalidCodes),
+            );
         }
 
-        return sprintf(
-            '<li>Codes INSEE à %s invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
-            $direction,
-            implode('", "', $invalidCodes),
-        );
+        $validCodes = array_filter($codes, static fn (string $code) => (bool) preg_match('/^\d{5}$/', $code));
+        $unknownCodes = array_filter($validCodes, static fn (string $code) => !\in_array($code, $territoryInseeCodes, true));
+
+        if (!empty($unknownCodes)) {
+            $errors .= sprintf(
+                '<li>Codes INSEE à %s hors du territoire %s : "%s"</li>',
+                $direction,
+                $territory->getZipAndName(),
+                implode('", "', $unknownCodes),
+            );
+        }
+
+        return $errors;
     }
 
     /**

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
@@ -1,0 +1,467 @@
+<?php
+
+namespace App\Service\Import\AutoAffectationRule;
+
+use App\Entity\AutoAffectationRule;
+use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Enum\Qualification;
+use App\Entity\Territory;
+use App\Repository\AutoAffectationRuleRepository;
+use App\Repository\PartnerRepository;
+use App\Repository\TerritoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class AutoAffectationRuleLoader
+{
+    private const string EMPTY_FIELD_MARKER = '/';
+
+    private const array VALID_PARC = ['all', 'prive', 'public', 'non_renseigne'];
+    private const array VALID_ALLOCATAIRE = ['all', 'oui', 'non', 'caf', 'msa', 'nsp'];
+
+    /**
+     * @var array{nb_rules_created: int, imported_territory_ids: int[], errors: string[]}
+     */
+    private array $metadata = [
+        'nb_rules_created' => 0,
+        'imported_territory_ids' => [],
+        'errors' => [],
+    ];
+
+    public function __construct(
+        private readonly TerritoryRepository $territoryRepository,
+        private readonly AutoAffectationRuleRepository $autoAffectationRuleRepository,
+        private readonly PartnerRepository $partnerRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param array<int, array<string, string>> $data
+     *
+     * @return string[]
+     */
+    public function validate(array $data): array
+    {
+        $errors = [];
+        $seenRuleKeys = [];
+
+        foreach ($data as $index => $row) {
+            $lineNumber = $index + 2;
+            $rowErrors = '';
+
+            $territoryValue = trim($row[AutoAffectationRuleHeader::TERRITORY] ?? '');
+            $territory = $this->findTerritory($territoryValue);
+            if (null === $territory) {
+                $rowErrors .= sprintf('<li>Territoire "%s" introuvable </li>', $territoryValue);
+            }
+
+            $status = trim($row[AutoAffectationRuleHeader::STATUS] ?? '');
+            if (!\in_array($status, [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED])) {
+                $rowErrors .= sprintf(
+                    '<li>Statut "%s" invalide (valeurs acceptées : ACTIVE, ARCHIVED) </li>',
+                    $status,
+                );
+            }
+
+            $partnerTypeLabel = trim($row[AutoAffectationRuleHeader::PARTNER_TYPE] ?? '');
+            $partnerType = PartnerType::tryFromLabel($partnerTypeLabel);
+            if (null === $partnerType) {
+                // $rowErrors[] = sprintf(
+                $rowErrors .= sprintf(
+                    '<li>Type de partenaire "%s" invalide (valeurs acceptées : %s) </li>',
+                    $partnerTypeLabel,
+                    implode(', ', PartnerType::names()),
+                );
+            }
+
+            $profileDeclarant = trim($row[AutoAffectationRuleHeader::PROFILE_DECLARANT] ?? '');
+            if (!$this->isValidProfileDeclarant($profileDeclarant)) {
+                $rowErrors .= sprintf(
+                    '<li>Profil déclarant "%s" invalide (valeurs acceptées : all, tiers, occupant, %s) </li>',
+                    $profileDeclarant,
+                    implode(', ', ProfileDeclarant::names()),
+                );
+            }
+
+            $parc = trim($row[AutoAffectationRuleHeader::PARC] ?? '');
+            if (!\in_array($parc, self::VALID_PARC)) {
+                $rowErrors .= sprintf(
+                    '<li>Parc "%s" invalide (valeurs acceptées : %s) </li>',
+                    $parc,
+                    implode(', ', self::VALID_PARC),
+                );
+            }
+
+            $allocataire = trim($row[AutoAffectationRuleHeader::ALLOCATAIRE] ?? '');
+            if (!\in_array($allocataire, self::VALID_ALLOCATAIRE)) {
+                $rowErrors .= sprintf(
+                    '<li>Allocataire "%s" invalide (valeurs acceptées : %s) </li>',
+                    $allocataire,
+                    implode(', ', self::VALID_ALLOCATAIRE),
+                );
+            }
+
+            $inseeToInclude = $this->parseInseeToInclude($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE] ?? '');
+            $inseeToExclude = $this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_EXCLUDE] ?? '');
+            $partnerToExclude = $this->parseArrayField($row[AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE] ?? '');
+            $rawProcedures = $row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES] ?? '';
+            $proceduresSuspectees = $this->parseProceduresSuspectees($rawProcedures);
+
+            if ('' !== $inseeToInclude) {
+                $invalidCodes = array_filter(
+                    array_map('trim', explode(',', $inseeToInclude)),
+                    static fn (string $code) => !preg_match('/^\d{5}$/', $code),
+                );
+                if (!empty($invalidCodes)) {
+                    $rowErrors .= sprintf(
+                        '<li>Codes INSEE à inclure invalides : "%s" (format attendu :  liste de codes insee à 5 chiffres séparés par des virgules)</li>',
+                        implode('", "', $invalidCodes),
+                    );
+                }
+            }
+
+            if (null !== $inseeToExclude) {
+                $invalidCodes = array_filter(
+                    $inseeToExclude,
+                    static fn (string $code) => !preg_match('/^\d{5}$/', $code),
+                );
+                if (!empty($invalidCodes)) {
+                    $rowErrors .= sprintf(
+                        '<li>Codes INSEE à exclure invalides : "%s" (format attendu :  liste de codes insee à 5 chiffres séparés par des virgules)</li>',
+                        implode('", "', $invalidCodes),
+                    );
+                }
+            }
+
+            if (null !== $partnerToExclude) {
+                $invalidIds = array_filter(
+                    $partnerToExclude,
+                    static fn (string $id) => !preg_match('/^\d+$/', $id),
+                );
+                if (!empty($invalidIds)) {
+                    $rowErrors .= sprintf(
+                        '<li>IDs partenaires à exclure invalides : "%s" (entiers séparés par des virgules attendus)</li>',
+                        implode('", "', $invalidIds),
+                    );
+                } elseif (null !== $territory && null !== $partnerType) {
+                    foreach ($partnerToExclude as $partnerId) {
+                        // $partner = $this->partnerRepository->findOneBy([
+                        //     'id' => (int) $partnerId,
+                        //     'territory' => $territory,
+                        //     'type' => $partnerType,
+                        //     'isArchive' => false,
+                        // ]);
+                        // if (null === $partner) {
+                        //     $rowErrors .= sprintf(
+                        //         '<li>Partenaire à exclure ID %s introuvable, archivé, ou n\'appartenant pas au territoire "%s" avec le type "%s"</li>',
+                        //         $partnerId,
+                        //         $territory->getZipAndName(),
+                        //         $partnerType->label(),
+                        //     );
+                        // }
+                        $partner = $this->partnerRepository->findOneBy([
+                            'id' => (int) $partnerId,
+                        ]);
+                        if (null === $partner) {
+                            $rowErrors .= sprintf(
+                                '<li>Partenaire à exclure ID %s introuvable</li>',
+                                $partnerId,
+                            );
+                        } elseif ($partner->getIsArchive()) {
+                            $rowErrors .= sprintf(
+                                '<li>Partenaire à exclure ID %s est archivé</li>',
+                                $partnerId,
+                            );
+                        } elseif ($partner->getTerritory()->getId() !== $territory->getId()) {
+                            $rowErrors .= sprintf(
+                                '<li>Partenaire à exclure ID %s n\'appartient pas au territoire "%s" </li>',
+                                $partnerId,
+                                $territory->getZipAndName(),
+                            );
+                        } elseif ($partner->getType() !== $partnerType) {
+                            $rowErrors .= sprintf(
+                                '<li>Partenaire à exclure ID %s n\'a pas le type "%s"</li>',
+                                $partnerId,
+                                $partnerType->label(),
+                            );
+                        }
+                    }
+                }
+            }
+
+            $rawProcedures = trim($rawProcedures);
+            if ('' !== $rawProcedures && self::EMPTY_FIELD_MARKER !== $rawProcedures) {
+                $validProcedures = Qualification::getProcedureSuspecteeList();
+                foreach (explode(',', $rawProcedures) as $label) {
+                    $label = trim($label);
+                    $qualification = Qualification::tryFromLabel($label);
+                    if (null === $qualification || !\in_array($qualification, $validProcedures)) {
+                        $rowErrors .= sprintf(
+                            '<li>Procédure suspectée "%s" invalide (valeurs acceptées : %s séparées par des virgules)</li>',
+                            $label,
+                            implode(', ', array_map(static fn (Qualification $q) => $q->label(), $validProcedures)),
+                        );
+                    }
+                }
+            }
+
+            if (!empty($rowErrors)) {
+                $errors[] = sprintf('Ligne %d : <ul>%s</ul>', $lineNumber, rtrim($rowErrors, ' / '));
+                continue;
+            }
+
+            /** @var Territory $territory */
+            $ruleKey = $this->buildRuleKey(
+                $territory,
+                $partnerType,
+                $profileDeclarant,
+                $parc,
+                $allocataire,
+                $inseeToInclude,
+                $inseeToExclude,
+                $partnerToExclude,
+                $proceduresSuspectees,
+            );
+
+            if (\in_array($ruleKey, $seenRuleKeys)) {
+                $errors[] = sprintf('Ligne %d : Cette règle est en doublon dans le fichier CSV.', $lineNumber);
+                continue;
+            }
+            $seenRuleKeys[] = $ruleKey;
+
+            if ($this->ruleExistsInDatabase($territory, $partnerType, $profileDeclarant, $parc, $allocataire, $inseeToInclude, $inseeToExclude, $partnerToExclude, $proceduresSuspectees)) {
+                $errors[] = sprintf(
+                    'Ligne %d : Une règle identique existe déjà pour le territoire "%s" (type : %s, profil : %s, parc : %s, allocataire : %s).',
+                    $lineNumber,
+                    $territory->getZipAndName(),
+                    $partnerType->label(),
+                    $profileDeclarant,
+                    $parc,
+                    $allocataire,
+                );
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<int, array<string, string>> $data
+     */
+    public function load(array $data): void
+    {
+        foreach ($data as $row) {
+            $territory = $this->findTerritory(trim($row[AutoAffectationRuleHeader::TERRITORY]));
+            if (null === $territory) {
+                continue;
+            }
+
+            $partnerType = PartnerType::tryFromLabel(trim($row[AutoAffectationRuleHeader::PARTNER_TYPE]));
+            if (null === $partnerType) {
+                continue;
+            }
+
+            $rule = new AutoAffectationRule();
+            $rule->setTerritory($territory);
+            $rule->setStatus(trim($row[AutoAffectationRuleHeader::STATUS]));
+            $rule->setPartnerType($partnerType);
+            $rule->setProfileDeclarant(trim($row[AutoAffectationRuleHeader::PROFILE_DECLARANT]));
+            $rule->setParc(trim($row[AutoAffectationRuleHeader::PARC]));
+            $rule->setAllocataire(trim($row[AutoAffectationRuleHeader::ALLOCATAIRE]));
+            $rule->setInseeToInclude($this->parseInseeToInclude($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE]));
+            $rule->setInseeToExclude($this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_EXCLUDE]));
+            $rule->setPartnerToExclude($this->parseArrayField($row[AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE]));
+            $rule->setProceduresSuspectees($this->parseProceduresSuspectees($row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES]));
+
+            $this->entityManager->persist($rule);
+            ++$this->metadata['nb_rules_created'];
+            $territoryId = $territory->getId();
+            if (!\in_array($territoryId, $this->metadata['imported_territory_ids'])) {
+                $this->metadata['imported_territory_ids'][] = $territoryId;
+            }
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @return array{nb_rules_created: int, imported_territory_ids: int[], errors: string[]}
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    private function findTerritory(string $value): ?Territory
+    {
+        $parts = explode(' - ', $value, 2);
+        if (2 !== \count($parts)) {
+            return null;
+        }
+
+        return $this->territoryRepository->findOneBy([
+            'zip' => trim($parts[0]),
+            'name' => trim($parts[1]),
+        ]);
+    }
+
+    private function isValidProfileDeclarant(string $value): bool
+    {
+        if (\in_array($value, ['all', 'tiers', 'occupant'])) {
+            return true;
+        }
+
+        if (null !== ProfileDeclarant::tryFrom($value)) {
+            return true;
+        }
+
+        return null !== ProfileDeclarant::tryFromLabel($value);
+    }
+
+    private function parseInseeToInclude(string $value): string
+    {
+        $value = trim($value);
+        if ('' === $value || self::EMPTY_FIELD_MARKER === $value) {
+            return '';
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<string>|null
+     */
+    private function parseArrayField(string $value): ?array
+    {
+        $value = trim($value);
+        if ('' === $value || self::EMPTY_FIELD_MARKER === $value) {
+            return null;
+        }
+
+        return array_filter(
+            array_map('trim', explode(',', $value)),
+            static fn (string $v) => '' !== $v,
+        );
+    }
+
+    /**
+     * @return list<Qualification>|null
+     */
+    private function parseProceduresSuspectees(string $value): ?array
+    {
+        $value = trim($value);
+        if ('' === $value || self::EMPTY_FIELD_MARKER === $value) {
+            return null;
+        }
+
+        $result = [];
+        foreach (explode(',', $value) as $label) {
+            $qualification = Qualification::tryFromLabel(trim($label));
+            if (null !== $qualification) {
+                $result[] = $qualification;
+            }
+        }
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
+     * @param array<string>|null       $inseeToExclude
+     * @param array<string>|null       $partnerToExclude
+     * @param list<Qualification>|null $proceduresSuspectees
+     */
+    private function buildRuleKey(
+        Territory $territory,
+        PartnerType $partnerType,
+        string $profileDeclarant,
+        string $parc,
+        string $allocataire,
+        string $inseeToInclude,
+        ?array $inseeToExclude,
+        ?array $partnerToExclude,
+        ?array $proceduresSuspectees,
+    ): string {
+        $sortedInseeExclude = $inseeToExclude ?? [];
+        sort($sortedInseeExclude);
+
+        $sortedPartnerExclude = $partnerToExclude ?? [];
+        sort($sortedPartnerExclude);
+
+        $sortedProcedures = array_map(
+            static fn (Qualification $q) => $q->value,
+            $proceduresSuspectees ?? [],
+        );
+        sort($sortedProcedures);
+
+        return implode('|', [
+            $territory->getId(),
+            $partnerType->value,
+            $profileDeclarant,
+            $parc,
+            $allocataire,
+            $inseeToInclude,
+            implode(',', $sortedInseeExclude),
+            implode(',', $sortedPartnerExclude),
+            implode(',', $sortedProcedures),
+        ]);
+    }
+
+    /**
+     * @param array<string>|null       $inseeToExclude
+     * @param array<string>|null       $partnerToExclude
+     * @param list<Qualification>|null $proceduresSuspectees
+     */
+    private function ruleExistsInDatabase(
+        Territory $territory,
+        PartnerType $partnerType,
+        string $profileDeclarant,
+        string $parc,
+        string $allocataire,
+        string $inseeToInclude,
+        ?array $inseeToExclude,
+        ?array $partnerToExclude,
+        ?array $proceduresSuspectees,
+    ): bool {
+        $existingRules = $this->autoAffectationRuleRepository->findBy([
+            'territory' => $territory,
+            'partnerType' => $partnerType,
+            'profileDeclarant' => $profileDeclarant,
+            'parc' => $parc,
+            'allocataire' => $allocataire,
+            'inseeToInclude' => $inseeToInclude,
+        ]);
+
+        $newKey = $this->buildRuleKey(
+            $territory,
+            $partnerType,
+            $profileDeclarant,
+            $parc,
+            $allocataire,
+            $inseeToInclude,
+            $inseeToExclude,
+            $partnerToExclude,
+            $proceduresSuspectees,
+        );
+
+        foreach ($existingRules as $existingRule) {
+            $existingKey = $this->buildRuleKey(
+                $existingRule->getTerritory(),
+                $existingRule->getPartnerType(),
+                $existingRule->getProfileDeclarant(),
+                $existingRule->getParc(),
+                $existingRule->getAllocataire(),
+                $existingRule->getInseeToInclude(),
+                $existingRule->getInseeToExclude(),
+                $existingRule->getPartnerToExclude(),
+                $existingRule->getProceduresSuspectees(),
+            );
+
+            if ($existingKey === $newKey) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
@@ -9,7 +9,6 @@ use App\Entity\Enum\Qualification;
 use App\Entity\Territory;
 use App\Repository\AutoAffectationRuleRepository;
 use App\Repository\PartnerRepository;
-use App\Repository\TerritoryRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 class AutoAffectationRuleLoader
@@ -20,16 +19,15 @@ class AutoAffectationRuleLoader
     private const array VALID_ALLOCATAIRE = ['all', 'oui', 'non', 'caf', 'msa', 'nsp'];
 
     /**
-     * @var array{nb_rules_created: int, imported_territory_ids: int[], errors: string[]}
+     * @var array{nb_rules_created: int, nb_rules_archived: int, errors: string[]}
      */
     private array $metadata = [
         'nb_rules_created' => 0,
-        'imported_territory_ids' => [],
+        'nb_rules_archived' => 0,
         'errors' => [],
     ];
 
     public function __construct(
-        private readonly TerritoryRepository $territoryRepository,
         private readonly AutoAffectationRuleRepository $autoAffectationRuleRepository,
         private readonly PartnerRepository $partnerRepository,
         private readonly EntityManagerInterface $entityManager,
@@ -41,14 +39,14 @@ class AutoAffectationRuleLoader
      *
      * @return string[]
      */
-    public function validate(array $data): array
+    public function validate(array $data, Territory $territory): array
     {
         $errors = [];
         $seenRuleKeys = [];
 
         foreach ($data as $index => $row) {
             $lineNumber = $index + 2;
-            $parsed = $this->parseRow($row);
+            $parsed = $this->parseRow($row, $territory);
             $rowErrors = $this->buildRowErrors($parsed);
 
             if (!empty($rowErrors)) {
@@ -56,8 +54,6 @@ class AutoAffectationRuleLoader
                 continue;
             }
 
-            /** @var Territory $territory */
-            $territory = $parsed['territory'];
             /** @var PartnerType $partnerType */
             $partnerType = $parsed['partnerType'];
 
@@ -78,18 +74,6 @@ class AutoAffectationRuleLoader
                 continue;
             }
             $seenRuleKeys[] = $ruleKey;
-
-            if ($this->ruleExistsInDatabase($territory, $partnerType, $parsed['profileDeclarant'], $parsed['parc'], $parsed['allocataire'], $parsed['inseeToInclude'], $parsed['inseeToExclude'], $parsed['partnerToExclude'], $parsed['proceduresSuspectees'])) {
-                $errors[] = sprintf(
-                    'Ligne %d : Une règle identique existe déjà pour le territoire "%s" (type : %s, profil : %s, parc : %s, allocataire : %s).',
-                    $lineNumber,
-                    $territory->getZipAndName(),
-                    $partnerType->label(),
-                    $parsed['profileDeclarant'],
-                    $parsed['parc'],
-                    $parsed['allocataire'],
-                );
-            }
         }
 
         return $errors;
@@ -98,14 +82,11 @@ class AutoAffectationRuleLoader
     /**
      * @param array<int, array<string, string>> $data
      */
-    public function load(array $data): void
+    public function load(array $data, Territory $territory): void
     {
-        foreach ($data as $row) {
-            $territory = $this->findTerritory(trim($row[AutoAffectationRuleHeader::TERRITORY]));
-            if (null === $territory) {
-                continue;
-            }
+        $this->archiveExistingRules($territory);
 
+        foreach ($data as $row) {
             $partnerType = PartnerType::tryFromLabel(trim($row[AutoAffectationRuleHeader::PARTNER_TYPE]));
             if (null === $partnerType) {
                 continue;
@@ -125,17 +106,26 @@ class AutoAffectationRuleLoader
 
             $this->entityManager->persist($rule);
             ++$this->metadata['nb_rules_created'];
-            $territoryId = $territory->getId();
-            if (!\in_array($territoryId, $this->metadata['imported_territory_ids'])) {
-                $this->metadata['imported_territory_ids'][] = $territoryId;
-            }
         }
 
         $this->entityManager->flush();
     }
 
+    private function archiveExistingRules(Territory $territory): void
+    {
+        $existingRules = $this->autoAffectationRuleRepository->findBy([
+            'territory' => $territory,
+            'status' => AutoAffectationRule::STATUS_ACTIVE,
+        ]);
+
+        foreach ($existingRules as $rule) {
+            $rule->setStatus(AutoAffectationRule::STATUS_ARCHIVED);
+            ++$this->metadata['nb_rules_archived'];
+        }
+    }
+
     /**
-     * @return array{nb_rules_created: int, imported_territory_ids: int[], errors: string[]}
+     * @return array{nb_rules_created: int, nb_rules_archived: int, errors: string[]}
      */
     public function getMetadata(): array
     {
@@ -145,17 +135,15 @@ class AutoAffectationRuleLoader
     /**
      * @param array<string, string> $row
      *
-     * @return array{territoryValue: string, territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>}
+     * @return array{territory: Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>}
      */
-    private function parseRow(array $row): array
+    private function parseRow(array $row, Territory $territory): array
     {
-        $territoryValue = trim($row[AutoAffectationRuleHeader::TERRITORY] ?? '');
         $partnerTypeLabel = trim($row[AutoAffectationRuleHeader::PARTNER_TYPE] ?? '');
         $rawProcedures = trim($row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES] ?? '');
 
         return [
-            'territoryValue' => $territoryValue,
-            'territory' => $this->findTerritory($territoryValue),
+            'territory' => $territory,
             'status' => trim($row[AutoAffectationRuleHeader::STATUS] ?? ''),
             'partnerTypeLabel' => $partnerTypeLabel,
             'partnerType' => PartnerType::tryFromLabel($partnerTypeLabel),
@@ -171,7 +159,7 @@ class AutoAffectationRuleLoader
     }
 
     /**
-     * @param array{territoryValue: string, territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>} $parsed
+     * @param array{territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>} $parsed
      */
     private function buildRowErrors(array $parsed): string
     {
@@ -183,20 +171,17 @@ class AutoAffectationRuleLoader
     }
 
     /**
-     * @param array{territoryValue: string, territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string} $parsed
+     * @param array{territory: Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string} $parsed
      */
     private function validateCoreFields(array $parsed): string
     {
         $errors = '';
 
-        if (null === $parsed['territory']) {
-            $errors .= sprintf('<li>Territoire "%s" introuvable</li>', $parsed['territoryValue']);
-        }
         if (!\in_array($parsed['status'], [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED])) {
             $errors .= sprintf('<li>Statut "%s" invalide (valeurs acceptées : ACTIVE, ARCHIVED)</li>', $parsed['status']);
         }
         if (null === $parsed['partnerType']) {
-            $errors .= sprintf('<li>Type de partenaire "%s" invalide (valeurs acceptées : %s)</li>', $parsed['partnerTypeLabel'], implode(', ', PartnerType::names()));
+            $errors .= sprintf('<li>Type de partenaire "%s" invalide (valeurs acceptées : %s)</li>', $parsed['partnerTypeLabel'], implode(', ', PartnerType::getLabelList()));
         }
         if (!$this->isValidProfileDeclarant($parsed['profileDeclarant'])) {
             $errors .= sprintf('<li>Profil déclarant "%s" invalide (valeurs acceptées : all, tiers, occupant, %s)</li>', $parsed['profileDeclarant'], implode(', ', ProfileDeclarant::names()));
@@ -323,19 +308,6 @@ class AutoAffectationRuleLoader
         return $errors;
     }
 
-    private function findTerritory(string $value): ?Territory
-    {
-        $parts = explode(' - ', $value, 2);
-        if (2 !== \count($parts)) {
-            return null;
-        }
-
-        return $this->territoryRepository->findOneBy([
-            'zip' => trim($parts[0]),
-            'name' => trim($parts[1]),
-        ]);
-    }
-
     private function isValidProfileDeclarant(string $value): bool
     {
         if (\in_array($value, ['all', 'tiers', 'occupant'])) {
@@ -435,53 +407,5 @@ class AutoAffectationRuleLoader
             implode(',', $sortedPartnerExclude),
             implode(',', $sortedProcedures),
         ]);
-    }
-
-    /**
-     * @param array<string>|null       $inseeToExclude
-     * @param array<string>|null       $partnerToExclude
-     * @param list<Qualification>|null $proceduresSuspectees
-     */
-    private function ruleExistsInDatabase(
-        Territory $territory,
-        PartnerType $partnerType,
-        string $profileDeclarant,
-        string $parc,
-        string $allocataire,
-        string $inseeToInclude,
-        ?array $inseeToExclude,
-        ?array $partnerToExclude,
-        ?array $proceduresSuspectees,
-    ): bool {
-        $existingRules = $this->autoAffectationRuleRepository->findBy([
-            'territory' => $territory,
-            'partnerType' => $partnerType,
-            'profileDeclarant' => $profileDeclarant,
-            'parc' => $parc,
-            'allocataire' => $allocataire,
-            'inseeToInclude' => $inseeToInclude,
-        ]);
-
-        $newKey = $this->buildRuleKey($territory, $partnerType, $profileDeclarant, $parc, $allocataire, $inseeToInclude, $inseeToExclude, $partnerToExclude, $proceduresSuspectees);
-
-        foreach ($existingRules as $existingRule) {
-            $existingKey = $this->buildRuleKey(
-                $existingRule->getTerritory(),
-                $existingRule->getPartnerType(),
-                $existingRule->getProfileDeclarant(),
-                $existingRule->getParc(),
-                $existingRule->getAllocataire(),
-                $existingRule->getInseeToInclude(),
-                $existingRule->getInseeToExclude(),
-                $existingRule->getPartnerToExclude(),
-                $existingRule->getProceduresSuspectees(),
-            );
-
-            if ($existingKey === $newKey) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
@@ -19,12 +19,11 @@ class AutoAffectationRuleLoader
     private const array VALID_ALLOCATAIRE = ['all', 'oui', 'non', 'caf', 'msa', 'nsp'];
 
     /**
-     * @var array{nb_rules_created: int, nb_rules_archived: int, errors: string[]}
+     * @var array{nb_rules_created: int, nb_rules_archived: int}
      */
     private array $metadata = [
         'nb_rules_created' => 0,
         'nb_rules_archived' => 0,
-        'errors' => [],
     ];
 
     public function __construct(
@@ -46,8 +45,8 @@ class AutoAffectationRuleLoader
 
         foreach ($data as $index => $row) {
             $lineNumber = $index + 2;
-            $parsed = $this->parseRow($row, $territory);
-            $rowErrors = $this->buildRowErrors($parsed);
+            $parsed = $this->parseRow($row);
+            $rowErrors = $this->buildRowErrors($parsed, $territory);
 
             if (!empty($rowErrors)) {
                 $errors[] = sprintf('Ligne %d : <ul>%s</ul>', $lineNumber, $rowErrors);
@@ -99,7 +98,7 @@ class AutoAffectationRuleLoader
             $rule->setProfileDeclarant(trim($row[AutoAffectationRuleHeader::PROFILE_DECLARANT]));
             $rule->setParc(trim($row[AutoAffectationRuleHeader::PARC]));
             $rule->setAllocataire(trim($row[AutoAffectationRuleHeader::ALLOCATAIRE]));
-            $rule->setInseeToInclude($this->parseInseeToInclude($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE]));
+            $rule->setInseeToInclude(implode(',', $this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE]) ?? []));
             $rule->setInseeToExclude($this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_EXCLUDE]));
             $rule->setPartnerToExclude($this->parseArrayField($row[AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE]));
             $rule->setProceduresSuspectees($this->parseProceduresSuspectees($row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES]));
@@ -109,6 +108,14 @@ class AutoAffectationRuleLoader
         }
 
         $this->entityManager->flush();
+    }
+
+    /**
+     * @return array{nb_rules_created: int, nb_rules_archived: int}
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
     }
 
     private function archiveExistingRules(Territory $territory): void
@@ -125,32 +132,23 @@ class AutoAffectationRuleLoader
     }
 
     /**
-     * @return array{nb_rules_created: int, nb_rules_archived: int, errors: string[]}
-     */
-    public function getMetadata(): array
-    {
-        return $this->metadata;
-    }
-
-    /**
      * @param array<string, string> $row
      *
-     * @return array{territory: Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>}
+     * @return array{status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: ?array<string>, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>}
      */
-    private function parseRow(array $row, Territory $territory): array
+    private function parseRow(array $row): array
     {
         $partnerTypeLabel = trim($row[AutoAffectationRuleHeader::PARTNER_TYPE] ?? '');
         $rawProcedures = trim($row[AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES] ?? '');
 
         return [
-            'territory' => $territory,
             'status' => trim($row[AutoAffectationRuleHeader::STATUS] ?? ''),
             'partnerTypeLabel' => $partnerTypeLabel,
             'partnerType' => PartnerType::tryFromLabel($partnerTypeLabel),
             'profileDeclarant' => trim($row[AutoAffectationRuleHeader::PROFILE_DECLARANT] ?? ''),
             'parc' => trim($row[AutoAffectationRuleHeader::PARC] ?? ''),
             'allocataire' => trim($row[AutoAffectationRuleHeader::ALLOCATAIRE] ?? ''),
-            'inseeToInclude' => $this->parseInseeToInclude($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE] ?? ''),
+            'inseeToInclude' => $this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_INCLUDE] ?? ''),
             'inseeToExclude' => $this->parseArrayField($row[AutoAffectationRuleHeader::INSEE_TO_EXCLUDE] ?? ''),
             'partnerToExclude' => $this->parseArrayField($row[AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE] ?? ''),
             'rawProcedures' => $rawProcedures,
@@ -159,19 +157,19 @@ class AutoAffectationRuleLoader
     }
 
     /**
-     * @param array{territory: ?Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string, inseeToInclude: string, inseeToExclude: ?array<string>, partnerToExclude: ?array<string>, rawProcedures: string, proceduresSuspectees: ?list<Qualification>} $parsed
+     * @param array<string, mixed> $parsed
      */
-    private function buildRowErrors(array $parsed): string
+    private function buildRowErrors(array $parsed, Territory $territory): string
     {
         return $this->validateCoreFields($parsed)
-            .$this->validateInseeToInclude($parsed['inseeToInclude'])
-            .$this->validateInseeToExclude($parsed['inseeToExclude'])
-            .$this->validatePartnersToExclude($parsed['partnerToExclude'], $parsed['territory'], $parsed['partnerType'])
+            .$this->validateInseeCodes($parsed['inseeToInclude'] ?? [], 'inclure')
+            .$this->validateInseeCodes($parsed['inseeToExclude'] ?? [], 'exclure')
+            .$this->validatePartnersToExclude($parsed['partnerToExclude'], $territory, $parsed['partnerType'])
             .$this->validateProceduresSuspectees($parsed['rawProcedures']);
     }
 
     /**
-     * @param array{territory: Territory, status: string, partnerTypeLabel: string, partnerType: ?PartnerType, profileDeclarant: string, parc: string, allocataire: string} $parsed
+     * @param array<string, mixed> $parsed
      */
     private function validateCoreFields(array $parsed): string
     {
@@ -196,47 +194,20 @@ class AutoAffectationRuleLoader
         return $errors;
     }
 
-    private function validateInseeToInclude(string $inseeToInclude): string
-    {
-        if ('' === $inseeToInclude) {
-            return '';
-        }
-
-        $invalidCodes = array_filter(
-            array_map('trim', explode(',', $inseeToInclude)),
-            static fn (string $code) => !preg_match('/^\d{5}$/', $code),
-        );
-
-        if (empty($invalidCodes)) {
-            return '';
-        }
-
-        return sprintf(
-            '<li>Codes INSEE à inclure invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
-            implode('", "', $invalidCodes),
-        );
-    }
-
     /**
-     * @param array<string>|null $inseeToExclude
+     * @param array<string> $codes
      */
-    private function validateInseeToExclude(?array $inseeToExclude): string
+    private function validateInseeCodes(array $codes, string $direction): string
     {
-        if (null === $inseeToExclude) {
-            return '';
-        }
-
-        $invalidCodes = array_filter(
-            $inseeToExclude,
-            static fn (string $code) => !preg_match('/^\d{5}$/', $code),
-        );
+        $invalidCodes = array_filter($codes, static fn (string $code) => !preg_match('/^\d{5}$/', $code));
 
         if (empty($invalidCodes)) {
             return '';
         }
 
         return sprintf(
-            '<li>Codes INSEE à exclure invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
+            '<li>Codes INSEE à %s invalides : "%s" (format attendu : liste de codes à 5 chiffres séparés par des virgules)</li>',
+            $direction,
             implode('", "', $invalidCodes),
         );
     }
@@ -244,7 +215,7 @@ class AutoAffectationRuleLoader
     /**
      * @param array<string>|null $partnerToExclude
      */
-    private function validatePartnersToExclude(?array $partnerToExclude, ?Territory $territory, ?PartnerType $partnerType): string
+    private function validatePartnersToExclude(?array $partnerToExclude, Territory $territory, ?PartnerType $partnerType): string
     {
         if (null === $partnerToExclude) {
             return '';
@@ -255,7 +226,7 @@ class AutoAffectationRuleLoader
             return sprintf('<li>IDs partenaires à exclure invalides : "%s" (entiers séparés par des virgules attendus)</li>', implode('", "', $invalidIds));
         }
 
-        if (null === $territory || null === $partnerType) {
+        if (null === $partnerType) {
             return '';
         }
 
@@ -310,25 +281,9 @@ class AutoAffectationRuleLoader
 
     private function isValidProfileDeclarant(string $value): bool
     {
-        if (\in_array($value, ['all', 'tiers', 'occupant'])) {
-            return true;
-        }
-
-        if (null !== ProfileDeclarant::tryFrom($value)) {
-            return true;
-        }
-
-        return null !== ProfileDeclarant::tryFromLabel($value);
-    }
-
-    private function parseInseeToInclude(string $value): string
-    {
-        $value = trim($value);
-        if ('' === $value || self::EMPTY_FIELD_MARKER === $value) {
-            return '';
-        }
-
-        return $value;
+        return \in_array($value, ['all', 'tiers', 'occupant'])
+            || null !== ProfileDeclarant::tryFrom($value)
+            || null !== ProfileDeclarant::tryFromLabel($value);
     }
 
     /**
@@ -365,10 +320,11 @@ class AutoAffectationRuleLoader
             }
         }
 
-        return empty($result) ? null : $result;
+        return $result ?: null;
     }
 
     /**
+     * @param array<string>|null       $inseeToInclude
      * @param array<string>|null       $inseeToExclude
      * @param array<string>|null       $partnerToExclude
      * @param list<Qualification>|null $proceduresSuspectees
@@ -379,21 +335,21 @@ class AutoAffectationRuleLoader
         string $profileDeclarant,
         string $parc,
         string $allocataire,
-        string $inseeToInclude,
+        ?array $inseeToInclude,
         ?array $inseeToExclude,
         ?array $partnerToExclude,
         ?array $proceduresSuspectees,
     ): string {
+        $sortedInseeInclude = $inseeToInclude ?? [];
+        sort($sortedInseeInclude);
+
         $sortedInseeExclude = $inseeToExclude ?? [];
         sort($sortedInseeExclude);
 
         $sortedPartnerExclude = $partnerToExclude ?? [];
         sort($sortedPartnerExclude);
 
-        $sortedProcedures = array_map(
-            static fn (Qualification $q) => $q->value,
-            $proceduresSuspectees ?? [],
-        );
+        $sortedProcedures = array_map(static fn (Qualification $q) => $q->value, $proceduresSuspectees ?? []);
         sort($sortedProcedures);
 
         return implode('|', [
@@ -402,7 +358,7 @@ class AutoAffectationRuleLoader
             $profileDeclarant,
             $parc,
             $allocataire,
-            $inseeToInclude,
+            implode(',', $sortedInseeInclude),
             implode(',', $sortedInseeExclude),
             implode(',', $sortedPartnerExclude),
             implode(',', $sortedProcedures),

--- a/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
+++ b/src/Service/Import/AutoAffectationRule/AutoAffectationRuleLoader.php
@@ -176,10 +176,10 @@ class AutoAffectationRuleLoader
     private function buildRowErrors(array $parsed): string
     {
         return $this->validateCoreFields($parsed)
-            . $this->validateInseeToInclude($parsed['inseeToInclude'])
-            . $this->validateInseeToExclude($parsed['inseeToExclude'])
-            . $this->validatePartnersToExclude($parsed['partnerToExclude'], $parsed['territory'], $parsed['partnerType'])
-            . $this->validateProceduresSuspectees($parsed['rawProcedures']);
+            .$this->validateInseeToInclude($parsed['inseeToInclude'])
+            .$this->validateInseeToExclude($parsed['inseeToExclude'])
+            .$this->validatePartnersToExclude($parsed['partnerToExclude'], $parsed['territory'], $parsed['partnerType'])
+            .$this->validateProceduresSuspectees($parsed['rawProcedures']);
     }
 
     /**

--- a/src/Service/Import/CsvParser.php
+++ b/src/Service/Import/CsvParser.php
@@ -57,9 +57,19 @@ class CsvParser
     {
         $content = $this->getContent($filepath);
         $dataList = [];
+        $nbColonnes = \count($content['headers']);
         foreach ($content['rows'] as $row) {
             $dataItem = [];
-            foreach (str_getcsv($row) as $key => $field) {
+            $fields = str_getcsv(
+                $row,
+                (string) $this->options['delimiter'],
+                (string) $this->options['enclosure'],
+                (string) $this->options['escape'],
+            );
+            if (\count($fields) !== $nbColonnes) {
+                continue;
+            }
+            foreach ($fields as $key => $field) {
                 $dataItem[$content['headers'][$key]] = $field;
             }
             $dataList[] = $dataItem;

--- a/templates/back/auto-affectation-rule/import.html.twig
+++ b/templates/back/auto-affectation-rule/import.html.twig
@@ -86,7 +86,6 @@
                             id="csv_file"
                             name="csv_file"
                             accept=".csv,text/csv"
-                            required
                         >
                     </div>
                 </div>

--- a/templates/back/auto-affectation-rule/import.html.twig
+++ b/templates/back/auto-affectation-rule/import.html.twig
@@ -62,10 +62,10 @@
                         <tr><td>Profil déclarant</td><td>all, tiers, occupant, {{ ProfileDeclarant.names()|join(', ') }}</td><td>all</td></tr>
                         <tr><td>Parc</td><td>all, prive, public ou non_renseigne</td><td>prive</td></tr>
                         <tr><td>Allocataire</td><td>all, oui, non, caf, msa ou nsp</td><td>caf</td></tr>
-                        <tr><td>Code insee inclus</td><td>Codes INSEE séparés par des virgules, ou / si vide</td><td>/</td></tr>
-                        <tr><td>Code insee exclus</td><td>Codes INSEE séparés par des virgules, ou / si vide</td><td>34172</td></tr>
-                        <tr><td>Id partenaires exclus</td><td>IDs partenaires séparés par des virgules, ou / si vide</td><td>1045,1060</td></tr>
-                        <tr><td>Procédures suspectées</td><td>Labels séparés par des virgules, ou / si vide ({{ Qualification.getProcedureSuspecteeList()|map(e => e.label())|join(', ') }})</td><td>/</td></tr>
+                        <tr><td>Code insee inclus</td><td>Codes INSEE séparés par des virgules, laisser vide si non applicable</td><td>34172,34173</td></tr>
+                        <tr><td>Code insee exclus</td><td>Codes INSEE séparés par des virgules, laisser vide si non applicable</td><td>34001</td></tr>
+                        <tr><td>Id partenaires exclus</td><td>IDs partenaires séparés par des virgules, laisser vide si non applicable</td><td>1045,1060</td></tr>
+                        <tr><td>Procédures suspectées</td><td>Labels séparés par des virgules, laisser vide si non applicable</td><td>Insalubrité, Danger</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -87,7 +87,6 @@
 
     <section class="fr-col-12 fr-mt-4v">
         {{ form_start(form, {'attr': {'enctype': 'multipart/form-data'}}) }}
-        <input type="hidden" name="_token" value="{{ csrf_token('auto_affectation_rule_import') }}">
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-md-6">
                 {{ form_row(form.territory) }}

--- a/templates/back/auto-affectation-rule/import.html.twig
+++ b/templates/back/auto-affectation-rule/import.html.twig
@@ -54,16 +54,18 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr><td>Territoire</td><td>Code département - Nom (ex : 34 - Hérault)</td><td>34 - Hérault</td></tr>
+                        {% set PartnerType = enum('\\App\\Entity\\Enum\\PartnerType') %}
+                        {% set ProfileDeclarant = enum('\\App\\Entity\\Enum\\ProfileDeclarant') %}
+                        {% set Qualification = enum('\\App\\Entity\\Enum\\Qualification') %}
                         <tr><td>Statut</td><td>ACTIVE ou ARCHIVED</td><td>ACTIVE</td></tr>
-                        <tr><td>Type de partenaire</td><td>Label du type (ex : CAF / MSA, CCAS, EPCI…)</td><td>CAF / MSA</td></tr>
-                        <tr><td>Profil déclarant</td><td>all, tiers, occupant ou nom de profil (LOCATAIRE, BAILLEUR…)</td><td>all</td></tr>
+                        <tr><td>Type de partenaire</td><td>Label du type ({{ PartnerType.getLabelList()|join(', ') }})</td><td>Dispositif rénovation habitat</td></tr>
+                        <tr><td>Profil déclarant</td><td>all, tiers, occupant, {{ ProfileDeclarant.names()|join(', ') }}</td><td>all</td></tr>
                         <tr><td>Parc</td><td>all, prive, public ou non_renseigne</td><td>prive</td></tr>
                         <tr><td>Allocataire</td><td>all, oui, non, caf, msa ou nsp</td><td>caf</td></tr>
                         <tr><td>Code insee inclus</td><td>Codes INSEE séparés par des virgules, ou / si vide</td><td>/</td></tr>
                         <tr><td>Code insee exclus</td><td>Codes INSEE séparés par des virgules, ou / si vide</td><td>34172</td></tr>
-                        <tr><td>Id partenaires exclus</td><td>IDs partenaires séparés par des virgules, ou / si vide</td><td>1060</td></tr>
-                        <tr><td>Procédures suspectées</td><td>Labels séparés par des virgules, ou / si vide</td><td>/</td></tr>
+                        <tr><td>Id partenaires exclus</td><td>IDs partenaires séparés par des virgules, ou / si vide</td><td>1045,1060</td></tr>
+                        <tr><td>Procédures suspectées</td><td>Labels séparés par des virgules, ou / si vide ({{ Qualification.getProcedureSuspecteeList()|map(e => e.label())|join(', ') }})</td><td>/</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -71,42 +73,46 @@
     </section>
 
     <section class="fr-col-12 fr-mt-4v">
-        <form method="POST" action="{{ path('back_auto_affectation_rule_import') }}" enctype="multipart/form-data">
-            <input type="hidden" name="_token" value="{{ csrf_token('auto_affectation_rule_import') }}">
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12 fr-col-md-6">
-                    <div class="fr-upload-group">
-                        <label class="fr-label" for="csv_file">
-                            Fichier CSV
-                            <span class="fr-hint-text">Format accepté : .csv — Séparateur : point-virgule (;)</span>
-                        </label>
-                        <input
-                            class="fr-upload"
-                            type="file"
-                            id="csv_file"
-                            name="csv_file"
-                            accept=".csv,text/csv"
-                        >
-                    </div>
+        <div class="fr-notice fr-notice--warning">
+            <div class="fr-container">
+                <div class="fr-notice__body">
+                    <p>
+                        <span class="fr-notice__title">Attention</span>
+                        <span class="fr-notice__desc">Si des règles d'auto-affectation actives existent déjà sur le territoire sélectionné, elles seront archivées avant la création des nouvelles règles.</span>
+                    </p>
                 </div>
             </div>
-            <div class="fr-grid-row fr-mt-4w">
-                <div class="fr-col-12">
-                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
-                        <li>
-                            <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-upload-line">
-                                Importer les règles
-                            </button>
-                        </li>
-                        <li>
-                            <a href="{{ path('back_auto_affectation_rule_index') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
-                                Annuler
-                            </a>
-                        </li>
-                    </ul>
-                </div>
+        </div>
+    </section>
+
+    <section class="fr-col-12 fr-mt-4v">
+        {{ form_start(form, {'attr': {'enctype': 'multipart/form-data'}}) }}
+        <input type="hidden" name="_token" value="{{ csrf_token('auto_affectation_rule_import') }}">
+        <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-12 fr-col-md-6">
+                {{ form_row(form.territory) }}
             </div>
-        </form>
+            <div class="fr-col-12 fr-col-md-6">
+                {{ form_row(form.csvFile) }}
+            </div>
+        </div>
+        <div class="fr-grid-row fr-mt-4w">
+            <div class="fr-col-12">
+                <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                    <li>
+                        <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-upload-line">
+                            Importer les règles
+                        </button>
+                    </li>
+                    <li>
+                        <a href="{{ path('back_auto_affectation_rule_index') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
+                            Annuler
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        {{ form_end(form) }}
     </section>
 {% endblock %}
 

--- a/templates/back/auto-affectation-rule/import.html.twig
+++ b/templates/back/auto-affectation-rule/import.html.twig
@@ -1,0 +1,116 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Importer des règles d'auto-affectation{% endblock %}
+
+{% block content %}
+    <section class="fr-pt-4v">
+        {% include 'back/breadcrumb_bo.html.twig' with {
+            'level2Title': 'Outils SA',
+            'level2Link': '',
+            'level2Label': '',
+            'level3Title': 'Règles d\'auto-affectation',
+            'level3Link': path('back_auto_affectation_rule_index'),
+            'level3Label': 'Retour à la liste des règles d\'auto-affectation',
+            'level4Title': 'Importer des règles d\'auto-affectation',
+            'level4Link': '',
+            'level4Label': '',
+        } %}
+        <header>
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    <h1 class="fr-mb-0">Importer des règles d'auto-affectation</h1>
+                    <p class="fr-mt-2v">
+                        Importez un fichier CSV pour créer des règles d'auto-affectation en masse sur un territoire.
+                    </p>
+                </div>
+            </div>
+        </header>
+    </section>
+
+    {% if errors is defined and errors|length > 0 %}
+        <section class="fr-col-12 fr-mt-4v">
+            <div class="fr-alert fr-alert--error">
+                <h3 class="fr-alert__title">Le fichier contient {{ errors|length }} erreur(s)</h3>
+                <ul class="fr-mb-0">
+                    {% for error in errors %}
+                        <li>{{ error|raw }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </section>
+    {% endif %}
+
+    <section class="fr-col-12 fr-mt-4v">
+        <div class="fr-callout">
+            <h3 class="fr-callout__title">Format du fichier CSV attendu</h3>
+            <p>Le fichier doit utiliser le point-virgule <code>;</code> comme séparateur et respecter les colonnes suivantes :</p>
+            <div class="fr-table fr-table--sm fr-mb-2v">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Colonne</th>
+                            <th>Format</th>
+                            <th>Exemple</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>Territoire</td><td>Code département - Nom (ex : 34 - Hérault)</td><td>34 - Hérault</td></tr>
+                        <tr><td>Statut</td><td>ACTIVE ou ARCHIVED</td><td>ACTIVE</td></tr>
+                        <tr><td>Type de partenaire</td><td>Label du type (ex : CAF / MSA, CCAS, EPCI…)</td><td>CAF / MSA</td></tr>
+                        <tr><td>Profil déclarant</td><td>all, tiers, occupant ou nom de profil (LOCATAIRE, BAILLEUR…)</td><td>all</td></tr>
+                        <tr><td>Parc</td><td>all, prive, public ou non_renseigne</td><td>prive</td></tr>
+                        <tr><td>Allocataire</td><td>all, oui, non, caf, msa ou nsp</td><td>caf</td></tr>
+                        <tr><td>Code insee inclus</td><td>Codes INSEE séparés par des virgules, ou / si vide</td><td>/</td></tr>
+                        <tr><td>Code insee exclus</td><td>Codes INSEE séparés par des virgules, ou / si vide</td><td>34172</td></tr>
+                        <tr><td>Id partenaires exclus</td><td>IDs partenaires séparés par des virgules, ou / si vide</td><td>1060</td></tr>
+                        <tr><td>Procédures suspectées</td><td>Labels séparés par des virgules, ou / si vide</td><td>/</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
+    <section class="fr-col-12 fr-mt-4v">
+        <form method="POST" action="{{ path('back_auto_affectation_rule_import') }}" enctype="multipart/form-data">
+            <input type="hidden" name="_token" value="{{ csrf_token('auto_affectation_rule_import') }}">
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12 fr-col-md-6">
+                    <div class="fr-upload-group">
+                        <label class="fr-label" for="csv_file">
+                            Fichier CSV
+                            <span class="fr-hint-text">Format accepté : .csv — Séparateur : point-virgule (;)</span>
+                        </label>
+                        <input
+                            class="fr-upload"
+                            type="file"
+                            id="csv_file"
+                            name="csv_file"
+                            accept=".csv,text/csv"
+                            required
+                        >
+                    </div>
+                </div>
+            </div>
+            <div class="fr-grid-row fr-mt-4w">
+                <div class="fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+                        <li>
+                            <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-upload-line">
+                                Importer les règles
+                            </button>
+                        </li>
+                        <li>
+                            <a href="{{ path('back_auto_affectation_rule_index') }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-close-line">
+                                Annuler
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </form>
+    </section>
+{% endblock %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('app') }}
+{% endblock %}

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -16,12 +16,13 @@
         } %}
         <header>
             <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12 fr-col-md-6 fr-text--left">
+                <div class="fr-col-12 fr-col-md-5 fr-text--left">
                     <h1 class="fr-mb-0">Règles d'auto-affectation</h1>
                 </div>
-                <div class="fr-col-12 fr-col-md-6 fr-text--md-right">
+                <div class="fr-col-12 fr-col-md-7 fr-text--md-right">
                     <a class="fr-btn fr-btn--secondary fr-btn--icon-left fr-fi-eye-line fr-mr-md-2v fr-mb-md-0 fr-mb-2v fr-btn--block fr-btn--md-inline" href="{{ path('back_auto_assigner_simulator_index') }}">Simulateur</a>
-                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-fi-add-circle-line fr-btn--block fr-btn--md-inline" href="{{ path('back_auto_affectation_rule_new') }}">Ajouter une règle d'auto-affection</a>
+                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-fi-add-circle-line fr-mr-md-2v fr-mb-md-0 fr-mb-2v fr-btn--block fr-btn--md-inline" href="{{ path('back_auto_affectation_rule_new') }}">Ajouter une règle d'auto-affection</a>
+                    <a class="fr-btn fr-btn fr-btn--icon-left fr-icon-upload-line fr-btn--block fr-btn--md-inline" href="{{ path('back_auto_affectation_rule_import') }}">Importer des règles d'auto-affection</a>
                 </div>
             </div>
         </header>

--- a/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
@@ -130,12 +130,11 @@ class AutoAffectationRuleControllerTest extends WebTestCase
 
         $this->client->request('POST',
             $this->router->generate('back_auto_affectation_rule_import'),
-            ['_token' => 'invalid_token', 'auto_affectation_rule_import' => ['territory' => $territory->getId()]],
+            ['auto_affectation_rule_import' => ['territory' => $territory->getId(), '_token' => 'invalid_token']],
             ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
         );
 
-        $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists(self::CSS_SELECTOR_ERROR);
+        $this->assertResponseStatusCodeSame(422);
     }
 
     /**
@@ -144,8 +143,10 @@ class AutoAffectationRuleControllerTest extends WebTestCase
     private function buildPostParams(?int $territoryId): array
     {
         return [
-            '_token' => $this->generateCsrfToken($this->client, self::CSRF_TOKEN_ID),
-            'auto_affectation_rule_import' => ['territory' => $territoryId],
+            'auto_affectation_rule_import' => [
+                'territory' => $territoryId,
+                '_token' => $this->generateCsrfToken($this->client, self::CSRF_TOKEN_ID),
+            ],
         ];
     }
 

--- a/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
@@ -16,6 +16,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
 
     private const string ADMIN_EMAIL = 'admin-01@signal-logement.fr';
     private const string CSV_HEADERS = "Territoire;Statut;Type de partenaire;Profil déclarant;Parc;Allocataire;Code insee inclus;Code insee exclus;Id partenaires exclus;Procédures suspectées;Actions\n";
+    private const cssSelectorError = '.fr-alert--error';
 
     private ?KernelBrowser $client = null;
     private RouterInterface $router;
@@ -58,7 +59,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
         $this->client->request('POST', $url, ['_token' => $csrfToken], []);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('.fr-alert--error', 'Veuillez sélectionner un fichier CSV');
+        $this->assertSelectorTextContains(self::cssSelectorError, 'Veuillez sélectionner un fichier CSV');
     }
 
     public function testImportWithInvalidCsvShowsErrors(): void
@@ -74,9 +75,9 @@ class AutoAffectationRuleControllerTest extends WebTestCase
         $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists('.fr-alert--error');
-        $this->assertSelectorTextContains('.fr-alert--error', 'Ligne 2');
-        $this->assertSelectorTextContains('.fr-alert--error', 'Ligne 3');
+        $this->assertSelectorExists(self::cssSelectorError);
+        $this->assertSelectorTextContains(self::cssSelectorError, 'Ligne 2');
+        $this->assertSelectorTextContains(self::cssSelectorError, 'Ligne 3');
     }
 
     public function testImportWithValidSingleTerritoryRedirectsToFilteredList(): void
@@ -133,8 +134,8 @@ class AutoAffectationRuleControllerTest extends WebTestCase
         $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists('.fr-alert--error');
-        $this->assertSelectorTextContains('.fr-alert--error', 'règle identique existe déjà');
+        $this->assertSelectorExists(self::cssSelectorError);
+        $this->assertSelectorTextContains(self::cssSelectorError, 'règle identique existe déjà');
     }
 
     public function testImportWithInvalidCsrfTokenShowsError(): void
@@ -146,7 +147,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
         $this->client->request('POST', $url, ['_token' => 'invalid_token'], ['csv_file' => $uploadedFile]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists('.fr-alert--error');
+        $this->assertSelectorExists(self::cssSelectorError);
     }
 
     private function createUploadedCsv(string $content): UploadedFile

--- a/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Back;
+
+use App\Repository\TerritoryRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Routing\RouterInterface;
+
+class AutoAffectationRuleControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    private const string ADMIN_EMAIL = 'admin-01@signal-logement.fr';
+    private const string CSV_HEADERS = "Territoire;Statut;Type de partenaire;Profil déclarant;Parc;Allocataire;Code insee inclus;Code insee exclus;Id partenaires exclus;Procédures suspectées;Actions\n";
+
+    private ?KernelBrowser $client = null;
+    private RouterInterface $router;
+    private TerritoryRepository $territoryRepository;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->router = static::getContainer()->get(RouterInterface::class);
+        $this->territoryRepository = static::getContainer()->get(TerritoryRepository::class);
+
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::ADMIN_EMAIL]);
+        $this->client->loginUser($user);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        foreach (glob(sys_get_temp_dir().'/test_auto_affectation_rule_*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+
+    public function testImportPageLoadsForAdmin(): void
+    {
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $this->client->request('GET', $url);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Importer des règles d\'auto-affectation');
+    }
+
+    public function testImportWithNoFileShowsError(): void
+    {
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
+
+        $this->client->request('POST', $url, ['_token' => $csrfToken], []);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('.fr-alert--error', 'Veuillez sélectionner un fichier CSV');
+    }
+
+    public function testImportWithInvalidCsvShowsErrors(): void
+    {
+        $csvContent = self::CSV_HEADERS
+            ."TERRITOIRE_INEXISTANT;ACTIVE;CAF / MSA;all;prive;caf;/;/;/;/;\n"
+            ."34 - Hérault;STATUT_INVALIDE;CAF / MSA;all;prive;caf;/;/;/;/;\n";
+
+        $uploadedFile = $this->createUploadedCsv($csvContent);
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
+
+        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('.fr-alert--error');
+        $this->assertSelectorTextContains('.fr-alert--error', 'Ligne 2');
+        $this->assertSelectorTextContains('.fr-alert--error', 'Ligne 3');
+    }
+
+    public function testImportWithValidSingleTerritoryRedirectsToFilteredList(): void
+    {
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $this->assertNotNull($territory);
+
+        // These rules do not exist in fixtures
+        $csvContent = self::CSV_HEADERS
+            ."34 - Hérault;ACTIVE;CAF / MSA;all;prive;nsp;/;/;/;/;\n"
+            ."34 - Hérault;ACTIVE;CCAS;all;all;all;/;/;/;/;\n";
+
+        $uploadedFile = $this->createUploadedCsv($csvContent);
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
+
+        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+
+        $this->assertResponseRedirects();
+        $redirectUrl = $this->client->getResponse()->headers->get('Location');
+        $this->assertStringContainsString('territory='.$territory->getId(), $redirectUrl);
+    }
+
+    public function testImportWithMultipleTerritoriesRedirectsToUnfilteredList(): void
+    {
+        // Rules for two different territories
+        $csvContent = self::CSV_HEADERS
+            ."34 - Hérault;ACTIVE;CAF / MSA;all;prive;nsp;/;/;/;/;\n"
+            ."13 - Bouches-du-Rhône;ACTIVE;DDT/M;all;all;all;/;/;/;/;\n";
+
+        $uploadedFile = $this->createUploadedCsv($csvContent);
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
+
+        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+
+        $this->assertResponseRedirects();
+        $redirectUrl = $this->client->getResponse()->headers->get('Location');
+        $listUrl = $this->router->generate('back_auto_affectation_rule_index');
+        $this->assertStringNotContainsString('territory=', $redirectUrl);
+        $this->assertStringContainsString($listUrl, $redirectUrl);
+    }
+
+    public function testImportWithDuplicateRuleShowsConflictError(): void
+    {
+        // Exactly matches an existing fixture rule: Hérault / CAF_MSA / all / prive / caf
+        $csvContent = self::CSV_HEADERS
+            ."34 - Hérault;ACTIVE;CAF / MSA;all;prive;caf;/;/;/;/;\n";
+
+        $uploadedFile = $this->createUploadedCsv($csvContent);
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
+
+        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('.fr-alert--error');
+        $this->assertSelectorTextContains('.fr-alert--error', 'règle identique existe déjà');
+    }
+
+    public function testImportWithInvalidCsrfTokenShowsError(): void
+    {
+        $csvContent = self::CSV_HEADERS.'34 - Hérault;ACTIVE;CCAS;all;all;nsp;/;/;/;/;';
+        $uploadedFile = $this->createUploadedCsv($csvContent);
+        $url = $this->router->generate('back_auto_affectation_rule_import');
+
+        $this->client->request('POST', $url, ['_token' => 'invalid_token'], ['csv_file' => $uploadedFile]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('.fr-alert--error');
+    }
+
+    private function createUploadedCsv(string $content): UploadedFile
+    {
+        $path = tempnam(sys_get_temp_dir(), 'test_auto_affectation_rule_');
+        file_put_contents($path, $content);
+
+        return new UploadedFile($path, 'import.csv', 'text/csv', null, true);
+    }
+}

--- a/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
@@ -15,8 +15,9 @@ class AutoAffectationRuleControllerTest extends WebTestCase
     use SessionHelper;
 
     private const string ADMIN_EMAIL = 'admin-01@signal-logement.fr';
-    private const string CSV_HEADERS = "Territoire;Statut;Type de partenaire;Profil déclarant;Parc;Allocataire;Code insee inclus;Code insee exclus;Id partenaires exclus;Procédures suspectées;Actions\n";
-    private const cssSelectorError = '.fr-alert--error';
+    private const string CSV_HEADERS = "Statut;Type de partenaire;Profil déclarant;Parc;Allocataire;Code insee inclus;Code insee exclus;Id partenaires exclus;Procédures suspectées;Actions\n";
+    private const string CSS_SELECTOR_ERROR = '.fr-alert--error';
+    private const string CSRF_TOKEN_ID = 'auto_affectation_rule_import';
 
     private ?KernelBrowser $client = null;
     private RouterInterface $router;
@@ -29,8 +30,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
         $this->router = static::getContainer()->get(RouterInterface::class);
         $this->territoryRepository = static::getContainer()->get(TerritoryRepository::class);
 
-        $userRepository = static::getContainer()->get(UserRepository::class);
-        $user = $userRepository->findOneBy(['email' => self::ADMIN_EMAIL]);
+        $user = static::getContainer()->get(UserRepository::class)->findOneBy(['email' => self::ADMIN_EMAIL]);
         $this->client->loginUser($user);
     }
 
@@ -44,110 +44,129 @@ class AutoAffectationRuleControllerTest extends WebTestCase
 
     public function testImportPageLoadsForAdmin(): void
     {
-        $url = $this->router->generate('back_auto_affectation_rule_import');
-        $this->client->request('GET', $url);
+        $this->client->request('GET', $this->router->generate('back_auto_affectation_rule_import'));
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'Importer des règles d\'auto-affectation');
+        $this->assertSelectorExists('select[name="auto_affectation_rule_import[territory]"]');
     }
 
     public function testImportWithNoFileShowsError(): void
     {
-        $url = $this->router->generate('back_auto_affectation_rule_import');
-        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
 
-        $this->client->request('POST', $url, ['_token' => $csrfToken], []);
+        $this->client->request('POST',
+            $this->router->generate('back_auto_affectation_rule_import'),
+            $this->buildPostParams($territory->getId()),
+            [],
+        );
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains(self::cssSelectorError, 'Veuillez sélectionner un fichier CSV');
+        $this->assertSelectorTextContains(self::CSS_SELECTOR_ERROR, 'Veuillez sélectionner un fichier CSV');
+    }
+
+    public function testImportWithNoTerritoryShowsFormError(): void
+    {
+        $uploadedFile = $this->createUploadedCsv(self::CSV_HEADERS.'ACTIVE;CAF / MSA;all;prive;nsp;/;/;/;/;');
+
+        $this->client->request('POST',
+            $this->router->generate('back_auto_affectation_rule_import'),
+            $this->buildPostParams(null),
+            ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
+        );
+
+        $this->assertResponseIsSuccessful();
+        // Form validation error for territory displayed by Symfony form
+        $this->assertSelectorExists('.fr-error-text');
     }
 
     public function testImportWithInvalidCsvShowsErrors(): void
     {
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
         $csvContent = self::CSV_HEADERS
-            ."TERRITOIRE_INEXISTANT;ACTIVE;CAF / MSA;all;prive;caf;/;/;/;/;\n"
-            ."34 - Hérault;STATUT_INVALIDE;CAF / MSA;all;prive;caf;/;/;/;/;\n";
+            ."STATUT_INVALIDE;CAF / MSA;all;prive;caf;/;/;/;/;\n"
+            ."ACTIVE;TYPE INVALIDE;all;prive;caf;/;/;/;/;\n";
 
         $uploadedFile = $this->createUploadedCsv($csvContent);
-        $url = $this->router->generate('back_auto_affectation_rule_import');
-        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
 
-        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+        $this->client->request('POST',
+            $this->router->generate('back_auto_affectation_rule_import'),
+            $this->buildPostParams($territory->getId()),
+            ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
+        );
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists(self::cssSelectorError);
-        $this->assertSelectorTextContains(self::cssSelectorError, 'Ligne 2');
-        $this->assertSelectorTextContains(self::cssSelectorError, 'Ligne 3');
+        $this->assertSelectorExists(self::CSS_SELECTOR_ERROR);
+        $this->assertSelectorTextContains(self::CSS_SELECTOR_ERROR, 'Ligne 2');
+        $this->assertSelectorTextContains(self::CSS_SELECTOR_ERROR, 'Ligne 3');
     }
 
-    public function testImportWithValidSingleTerritoryRedirectsToFilteredList(): void
+    public function testImportWithValidCsvRedirectsToTerritoryFilteredList(): void
     {
         $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
-        $this->assertNotNull($territory);
-
         // These rules do not exist in fixtures
         $csvContent = self::CSV_HEADERS
-            ."34 - Hérault;ACTIVE;CAF / MSA;all;prive;nsp;/;/;/;/;\n"
-            ."34 - Hérault;ACTIVE;CCAS;all;all;all;/;/;/;/;\n";
+            ."ACTIVE;CAF / MSA;all;prive;nsp;/;/;/;/;\n"
+            ."ACTIVE;CCAS;all;all;all;/;/;/;/;\n";
 
         $uploadedFile = $this->createUploadedCsv($csvContent);
-        $url = $this->router->generate('back_auto_affectation_rule_import');
-        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
 
-        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
-
-        $this->assertResponseRedirects();
-        $redirectUrl = $this->client->getResponse()->headers->get('Location');
-        $this->assertStringContainsString('territory='.$territory->getId(), $redirectUrl);
-    }
-
-    public function testImportWithMultipleTerritoriesRedirectsToUnfilteredList(): void
-    {
-        // Rules for two different territories
-        $csvContent = self::CSV_HEADERS
-            ."34 - Hérault;ACTIVE;CAF / MSA;all;prive;nsp;/;/;/;/;\n"
-            ."13 - Bouches-du-Rhône;ACTIVE;DDT/M;all;all;all;/;/;/;/;\n";
-
-        $uploadedFile = $this->createUploadedCsv($csvContent);
-        $url = $this->router->generate('back_auto_affectation_rule_import');
-        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
-
-        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+        $this->client->request('POST',
+            $this->router->generate('back_auto_affectation_rule_import'),
+            $this->buildPostParams($territory->getId()),
+            ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
+        );
 
         $this->assertResponseRedirects();
-        $redirectUrl = $this->client->getResponse()->headers->get('Location');
-        $listUrl = $this->router->generate('back_auto_affectation_rule_index');
-        $this->assertStringNotContainsString('territory=', $redirectUrl);
-        $this->assertStringContainsString($listUrl, $redirectUrl);
+        $this->assertStringContainsString(
+            'territory='.$territory->getId(),
+            $this->client->getResponse()->headers->get('Location'),
+        );
     }
 
     public function testImportWithDuplicateRuleShowsConflictError(): void
     {
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
         // Exactly matches an existing fixture rule: Hérault / CAF_MSA / all / prive / caf
-        $csvContent = self::CSV_HEADERS
-            ."34 - Hérault;ACTIVE;CAF / MSA;all;prive;caf;/;/;/;/;\n";
+        $csvContent = self::CSV_HEADERS.'ACTIVE;CAF / MSA;all;prive;caf;/;/;/;/;';
 
         $uploadedFile = $this->createUploadedCsv($csvContent);
-        $url = $this->router->generate('back_auto_affectation_rule_import');
-        $csrfToken = $this->generateCsrfToken($this->client, 'auto_affectation_rule_import');
 
-        $this->client->request('POST', $url, ['_token' => $csrfToken], ['csv_file' => $uploadedFile]);
+        $this->client->request('POST',
+            $this->router->generate('back_auto_affectation_rule_import'),
+            $this->buildPostParams($territory->getId()),
+            ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
+        );
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists(self::cssSelectorError);
-        $this->assertSelectorTextContains(self::cssSelectorError, 'règle identique existe déjà');
+        $this->assertSelectorExists(self::CSS_SELECTOR_ERROR);
+        $this->assertSelectorTextContains(self::CSS_SELECTOR_ERROR, 'règle identique existe déjà');
     }
 
     public function testImportWithInvalidCsrfTokenShowsError(): void
     {
-        $csvContent = self::CSV_HEADERS.'34 - Hérault;ACTIVE;CCAS;all;all;nsp;/;/;/;/;';
-        $uploadedFile = $this->createUploadedCsv($csvContent);
-        $url = $this->router->generate('back_auto_affectation_rule_import');
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $uploadedFile = $this->createUploadedCsv(self::CSV_HEADERS.'ACTIVE;CCAS;all;all;nsp;/;/;/;/;');
 
-        $this->client->request('POST', $url, ['_token' => 'invalid_token'], ['csv_file' => $uploadedFile]);
+        $this->client->request('POST',
+            $this->router->generate('back_auto_affectation_rule_import'),
+            ['_token' => 'invalid_token', 'auto_affectation_rule_import' => ['territory' => $territory->getId()]],
+            ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
+        );
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists(self::cssSelectorError);
+        $this->assertSelectorExists(self::CSS_SELECTOR_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildPostParams(?int $territoryId): array
+    {
+        return [
+            '_token' => $this->generateCsrfToken($this->client, self::CSRF_TOKEN_ID),
+            'auto_affectation_rule_import' => ['territory' => $territoryId],
+        ];
     }
 
     private function createUploadedCsv(string $content): UploadedFile

--- a/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/Back/AutoAffectationRuleControllerTest.php
@@ -61,8 +61,8 @@ class AutoAffectationRuleControllerTest extends WebTestCase
             [],
         );
 
-        $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains(self::CSS_SELECTOR_ERROR, 'Veuillez sélectionner un fichier CSV');
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSelectorExists('.fr-error-text');
     }
 
     public function testImportWithNoTerritoryShowsFormError(): void
@@ -75,8 +75,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
             ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
         );
 
-        $this->assertResponseIsSuccessful();
-        // Form validation error for territory displayed by Symfony form
+        $this->assertResponseStatusCodeSame(422);
         $this->assertSelectorExists('.fr-error-text');
     }
 
@@ -122,25 +121,6 @@ class AutoAffectationRuleControllerTest extends WebTestCase
             'territory='.$territory->getId(),
             $this->client->getResponse()->headers->get('Location'),
         );
-    }
-
-    public function testImportWithDuplicateRuleShowsConflictError(): void
-    {
-        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
-        // Exactly matches an existing fixture rule: Hérault / CAF_MSA / all / prive / caf
-        $csvContent = self::CSV_HEADERS.'ACTIVE;CAF / MSA;all;prive;caf;/;/;/;/;';
-
-        $uploadedFile = $this->createUploadedCsv($csvContent);
-
-        $this->client->request('POST',
-            $this->router->generate('back_auto_affectation_rule_import'),
-            $this->buildPostParams($territory->getId()),
-            ['auto_affectation_rule_import' => ['csvFile' => $uploadedFile]],
-        );
-
-        $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists(self::CSS_SELECTOR_ERROR);
-        $this->assertSelectorTextContains(self::CSS_SELECTOR_ERROR, 'règle identique existe déjà');
     }
 
     public function testImportWithInvalidCsrfTokenShowsError(): void

--- a/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
+++ b/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Service\Import\AutoAffectationRule;
 
 use App\Entity\AutoAffectationRule;
+use App\Entity\Territory;
 use App\Repository\AutoAffectationRuleRepository;
 use App\Repository\PartnerRepository;
 use App\Repository\TerritoryRepository;
@@ -15,18 +16,20 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 {
     private AutoAffectationRuleLoader $loader;
     private EntityManagerInterface $entityManager;
-    private TerritoryRepository $territoryRepository;
-    private const HERAULT_ZIP = '34';
-    private const HERAULT_NAME = 'Hérault';
+    private Territory $herault;
+    private const string HERAULT_ZIP = '34';
+    private const string HERAULT_NAME = 'Hérault';
 
     protected function setUp(): void
     {
         /** @var EntityManagerInterface $em */
         $em = static::getContainer()->get('doctrine.orm.entity_manager');
         $this->entityManager = $em;
-        $this->territoryRepository = static::getContainer()->get(TerritoryRepository::class);
+        /** @var Territory $herault */
+        $herault = static::getContainer()->get(TerritoryRepository::class)
+            ->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
+        $this->herault = $herault;
         $this->loader = new AutoAffectationRuleLoader(
-            $this->territoryRepository,
             static::getContainer()->get(AutoAffectationRuleRepository::class),
             static::getContainer()->get(PartnerRepository::class),
             $this->entityManager,
@@ -35,30 +38,14 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testValidateReturnsNoErrorsForValidData(): void
     {
-        $errors = $this->loader->validate($this->provideValidData());
+        $errors = $this->loader->validate($this->provideValidData(), $this->herault);
 
         $this->assertEmpty($errors);
     }
 
-    public function testValidateReturnsErrorForUnknownTerritory(): void
-    {
-        $data = [
-            $this->buildRow(territory: 'XX - Territoire Inexistant'),
-        ];
-
-        $errors = $this->loader->validate($data);
-
-        $this->assertCount(1, $errors);
-        $this->assertStringContainsString('Territoire "XX - Territoire Inexistant" introuvable', $errors[0]);
-    }
-
     public function testValidateReturnsErrorForInvalidStatus(): void
     {
-        $data = [
-            $this->buildRow(status: 'INVALIDE'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate([$this->buildRow(status: 'INVALIDE')], $this->herault);
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Statut "INVALIDE" invalide', $errors[0]);
@@ -66,11 +53,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testValidateReturnsErrorForInvalidPartnerType(): void
     {
-        $data = [
-            $this->buildRow(partnerType: 'Type Inconnu'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate([$this->buildRow(partnerType: 'Type Inconnu')], $this->herault);
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Type de partenaire "Type Inconnu" invalide', $errors[0]);
@@ -78,11 +61,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testValidateReturnsErrorForInvalidProfileDeclarant(): void
     {
-        $data = [
-            $this->buildRow(profileDeclarant: 'profil_inconnu'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate([$this->buildRow(profileDeclarant: 'profil_inconnu')], $this->herault);
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Profil déclarant "profil_inconnu" invalide', $errors[0]);
@@ -90,11 +69,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testValidateReturnsErrorForInvalidParc(): void
     {
-        $data = [
-            $this->buildRow(parc: 'inconnu'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate([$this->buildRow(parc: 'inconnu')], $this->herault);
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Parc "inconnu" invalide', $errors[0]);
@@ -102,11 +77,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testValidateReturnsErrorForInvalidAllocataire(): void
     {
-        $data = [
-            $this->buildRow(allocataire: 'inconnu'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate([$this->buildRow(allocataire: 'inconnu')], $this->herault);
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Allocataire "inconnu" invalide', $errors[0]);
@@ -114,11 +85,10 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testValidateAccumulatesMultipleErrorsOnSameLine(): void
     {
-        $data = [
-            $this->buildRow(status: 'INVALIDE', parc: 'inconnu', allocataire: 'inconnu'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate(
+            [$this->buildRow(status: 'INVALIDE', parc: 'inconnu', allocataire: 'inconnu')],
+            $this->herault,
+        );
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Ligne 2', $errors[0]);
@@ -130,45 +100,18 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
     public function testValidateDetectsDuplicateWithinBatch(): void
     {
         $row = $this->buildRow(allocataire: 'nsp');
-        $data = [$row, $row];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate([$row, $row], $this->herault);
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('doublon dans le fichier CSV', $errors[0]);
     }
 
-    public function testValidateDetectsDuplicateWithExistingDatabaseRule(): void
-    {
-        // This exact combination exists in AutoAffectationRule.yml fixtures
-        $data = [
-            $this->buildRow(
-                territory: self::HERAULT_ZIP.' - '.self::HERAULT_NAME,
-                partnerType: 'CAF / MSA',
-                profileDeclarant: 'all',
-                parc: 'prive',
-                allocataire: 'caf',
-                inseeToInclude: '/',
-                inseeToExclude: '/',
-                partnerToExclude: '/',
-            ),
-        ];
-
-        $errors = $this->loader->validate($data);
-
-        $this->assertCount(1, $errors);
-        $this->assertStringContainsString('règle identique existe déjà', $errors[0]);
-        $this->assertStringContainsString('Hérault', $errors[0]);
-    }
-
     public function testValidateErrorLineNumberStartsAtTwo(): void
     {
-        $data = [
-            $this->buildRow(status: 'INVALIDE'),
-            $this->buildRow(parc: 'inconnu'),
-        ];
-
-        $errors = $this->loader->validate($data);
+        $errors = $this->loader->validate(
+            [$this->buildRow(status: 'INVALIDE'), $this->buildRow(parc: 'inconnu')],
+            $this->herault,
+        );
 
         $this->assertStringContainsString('Ligne 2', $errors[0]);
         $this->assertStringContainsString('Ligne 3', $errors[1]);
@@ -176,48 +119,45 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testLoadPersistsRulesInDatabase(): void
     {
-        $territory = $this->territoryRepository->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
-        $this->assertNotNull($territory);
-        $countBefore = $this->entityManager->getRepository(AutoAffectationRule::class)->count(['territory' => $territory]);
+        $countBefore = $this->entityManager->getRepository(AutoAffectationRule::class)
+            ->count(['territory' => $this->herault]);
 
-        $this->loader->load($this->provideValidData());
+        $this->loader->load($this->provideValidData(), $this->herault);
 
-        $countAfter = $this->entityManager->getRepository(AutoAffectationRule::class)->count(['territory' => $territory]);
+        $countAfter = $this->entityManager->getRepository(AutoAffectationRule::class)
+            ->count(['territory' => $this->herault]);
         $this->assertSame($countBefore + 2, $countAfter);
     }
 
     public function testLoadUpdatesNbRulesCreatedMetadata(): void
     {
-        $this->loader->load($this->provideValidData());
+        $this->loader->load($this->provideValidData(), $this->herault);
 
         $this->assertSame(2, $this->loader->getMetadata()['nb_rules_created']);
     }
 
-    public function testLoadTracksImportedTerritoryId(): void
+    public function testLoadArchivesExistingActiveRules(): void
     {
-        $territory = $this->territoryRepository->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
-        $this->assertNotNull($territory);
+        $ruleRepo = $this->entityManager->getRepository(AutoAffectationRule::class);
+        $countActiveBefore = $ruleRepo->count(['territory' => $this->herault, 'status' => AutoAffectationRule::STATUS_ACTIVE]);
+        $this->assertGreaterThan(0, $countActiveBefore);
 
-        $this->loader->load($this->provideValidData());
+        $this->loader->load($this->provideValidData(), $this->herault);
 
-        $importedIds = $this->loader->getMetadata()['imported_territory_ids'];
-        $this->assertCount(1, $importedIds);
-        $this->assertContains($territory->getId(), $importedIds);
+        // All previous active rules are archived; only the 2 newly created ones remain active
+        $this->assertSame(2, $ruleRepo->count(['territory' => $this->herault, 'status' => AutoAffectationRule::STATUS_ACTIVE]));
+        $this->assertSame($countActiveBefore, $this->loader->getMetadata()['nb_rules_archived']);
     }
 
-    public function testLoadTracksMultipleTerritoriesWhenPresent(): void
+    public function testLoadMetadataHasZeroArchivedWhenNoExistingRules(): void
     {
-        $data = array_merge($this->provideValidData(), [
-            $this->buildRow(
-                territory: '13 - Bouches-du-Rhône',
-                partnerType: 'DDT/M',
-                allocataire: 'nsp',
-            ),
-        ]);
+        /** @var Territory $ain */
+        $ain = static::getContainer()->get(TerritoryRepository::class)->findOneBy(['zip' => '01', 'name' => 'Ain']);
+        $this->assertNotNull($ain);
 
-        $this->loader->load($data);
+        $this->loader->load([$this->buildRow()], $ain);
 
-        $this->assertCount(2, $this->loader->getMetadata()['imported_territory_ids']);
+        $this->assertSame(0, $this->loader->getMetadata()['nb_rules_archived']);
     }
 
     public function testLoadSetsAllRuleFieldsCorrectly(): void
@@ -232,11 +172,10 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
             partnerToExclude: '999',
         );
 
-        $this->loader->load([$row]);
+        $this->loader->load([$row], $this->herault);
 
-        $territory = $this->territoryRepository->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
         $rule = $this->entityManager->getRepository(AutoAffectationRule::class)->findOneBy([
-            'territory' => $territory,
+            'territory' => $this->herault,
             'parc' => 'public',
             'allocataire' => 'oui',
         ]);
@@ -264,7 +203,6 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
      * @return array<string, string>
      */
     private function buildRow(
-        string $territory = self::HERAULT_ZIP.' - '.self::HERAULT_NAME,
         string $status = 'ACTIVE',
         string $partnerType = 'CAF / MSA',
         string $profileDeclarant = 'all',
@@ -276,7 +214,6 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
         string $proceduresSuspectees = '/',
     ): array {
         return [
-            AutoAffectationRuleHeader::TERRITORY => $territory,
             AutoAffectationRuleHeader::STATUS => $status,
             AutoAffectationRuleHeader::PARTNER_TYPE => $partnerType,
             AutoAffectationRuleHeader::PROFILE_DECLARANT => $profileDeclarant,

--- a/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
+++ b/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
@@ -143,7 +143,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
         // This exact combination exists in AutoAffectationRule.yml fixtures
         $data = [
             $this->buildRow(
-                territory: self::HERAULT_ZIP . ' - ' . self::HERAULT_NAME,
+                territory: self::HERAULT_ZIP.' - '.self::HERAULT_NAME,
                 partnerType: 'CAF / MSA',
                 profileDeclarant: 'all',
                 parc: 'prive',
@@ -264,7 +264,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
      * @return array<string, string>
      */
     private function buildRow(
-        string $territory = self::HERAULT_ZIP . ' - ' . self::HERAULT_NAME,
+        string $territory = self::HERAULT_ZIP.' - '.self::HERAULT_NAME,
         string $status = 'ACTIVE',
         string $partnerType = 'CAF / MSA',
         string $profileDeclarant = 'all',

--- a/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
+++ b/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
@@ -16,6 +16,8 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
     private AutoAffectationRuleLoader $loader;
     private EntityManagerInterface $entityManager;
     private TerritoryRepository $territoryRepository;
+    private const HERAULT_ZIP = '34';
+    private const HERAULT_NAME = 'Hérault';
 
     protected function setUp(): void
     {
@@ -141,7 +143,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
         // This exact combination exists in AutoAffectationRule.yml fixtures
         $data = [
             $this->buildRow(
-                territory: '34 - Hérault',
+                territory: self::HERAULT_ZIP . ' - ' . self::HERAULT_NAME,
                 partnerType: 'CAF / MSA',
                 profileDeclarant: 'all',
                 parc: 'prive',
@@ -174,7 +176,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testLoadPersistsRulesInDatabase(): void
     {
-        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $territory = $this->territoryRepository->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
         $this->assertNotNull($territory);
         $countBefore = $this->entityManager->getRepository(AutoAffectationRule::class)->count(['territory' => $territory]);
 
@@ -193,7 +195,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
     public function testLoadTracksImportedTerritoryId(): void
     {
-        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $territory = $this->territoryRepository->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
         $this->assertNotNull($territory);
 
         $this->loader->load($this->provideValidData());
@@ -232,7 +234,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
         $this->loader->load([$row]);
 
-        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $territory = $this->territoryRepository->findOneBy(['zip' => self::HERAULT_ZIP, 'name' => self::HERAULT_NAME]);
         $rule = $this->entityManager->getRepository(AutoAffectationRule::class)->findOneBy([
             'territory' => $territory,
             'parc' => 'public',
@@ -262,7 +264,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
      * @return array<string, string>
      */
     private function buildRow(
-        string $territory = '34 - Hérault',
+        string $territory = self::HERAULT_ZIP . ' - ' . self::HERAULT_NAME,
         string $status = 'ACTIVE',
         string $partnerType = 'CAF / MSA',
         string $profileDeclarant = 'all',

--- a/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
+++ b/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Tests\Functional\Service\Import\AutoAffectationRule;
+
+use App\Entity\AutoAffectationRule;
+use App\Repository\AutoAffectationRuleRepository;
+use App\Repository\PartnerRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Import\AutoAffectationRule\AutoAffectationRuleHeader;
+use App\Service\Import\AutoAffectationRule\AutoAffectationRuleLoader;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AutoAffectationRuleLoaderTest extends KernelTestCase
+{
+    private AutoAffectationRuleLoader $loader;
+    private EntityManagerInterface $entityManager;
+    private TerritoryRepository $territoryRepository;
+
+    protected function setUp(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+        $this->entityManager = $em;
+        $this->territoryRepository = static::getContainer()->get(TerritoryRepository::class);
+        $this->loader = new AutoAffectationRuleLoader(
+            $this->territoryRepository,
+            static::getContainer()->get(AutoAffectationRuleRepository::class),
+            static::getContainer()->get(PartnerRepository::class),
+            $this->entityManager,
+        );
+    }
+
+    public function testValidateReturnsNoErrorsForValidData(): void
+    {
+        $errors = $this->loader->validate($this->provideValidData());
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testValidateReturnsErrorForUnknownTerritory(): void
+    {
+        $data = [
+            $this->buildRow(territory: 'XX - Territoire Inexistant'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Territoire "XX - Territoire Inexistant" introuvable', $errors[0]);
+    }
+
+    public function testValidateReturnsErrorForInvalidStatus(): void
+    {
+        $data = [
+            $this->buildRow(status: 'INVALIDE'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Statut "INVALIDE" invalide', $errors[0]);
+    }
+
+    public function testValidateReturnsErrorForInvalidPartnerType(): void
+    {
+        $data = [
+            $this->buildRow(partnerType: 'Type Inconnu'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Type de partenaire "Type Inconnu" invalide', $errors[0]);
+    }
+
+    public function testValidateReturnsErrorForInvalidProfileDeclarant(): void
+    {
+        $data = [
+            $this->buildRow(profileDeclarant: 'profil_inconnu'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Profil déclarant "profil_inconnu" invalide', $errors[0]);
+    }
+
+    public function testValidateReturnsErrorForInvalidParc(): void
+    {
+        $data = [
+            $this->buildRow(parc: 'inconnu'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Parc "inconnu" invalide', $errors[0]);
+    }
+
+    public function testValidateReturnsErrorForInvalidAllocataire(): void
+    {
+        $data = [
+            $this->buildRow(allocataire: 'inconnu'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Allocataire "inconnu" invalide', $errors[0]);
+    }
+
+    public function testValidateAccumulatesMultipleErrorsOnSameLine(): void
+    {
+        $data = [
+            $this->buildRow(status: 'INVALIDE', parc: 'inconnu', allocataire: 'inconnu'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Ligne 2', $errors[0]);
+        $this->assertStringContainsString('Statut', $errors[0]);
+        $this->assertStringContainsString('Parc', $errors[0]);
+        $this->assertStringContainsString('Allocataire', $errors[0]);
+    }
+
+    public function testValidateDetectsDuplicateWithinBatch(): void
+    {
+        $row = $this->buildRow(allocataire: 'nsp');
+        $data = [$row, $row];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('doublon dans le fichier CSV', $errors[0]);
+    }
+
+    public function testValidateDetectsDuplicateWithExistingDatabaseRule(): void
+    {
+        // This exact combination exists in AutoAffectationRule.yml fixtures
+        $data = [
+            $this->buildRow(
+                territory: '34 - Hérault',
+                partnerType: 'CAF / MSA',
+                profileDeclarant: 'all',
+                parc: 'prive',
+                allocataire: 'caf',
+                inseeToInclude: '/',
+                inseeToExclude: '/',
+                partnerToExclude: '/',
+            ),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('règle identique existe déjà', $errors[0]);
+        $this->assertStringContainsString('Hérault', $errors[0]);
+    }
+
+    public function testValidateErrorLineNumberStartsAtTwo(): void
+    {
+        $data = [
+            $this->buildRow(status: 'INVALIDE'),
+            $this->buildRow(parc: 'inconnu'),
+        ];
+
+        $errors = $this->loader->validate($data);
+
+        $this->assertStringContainsString('Ligne 2', $errors[0]);
+        $this->assertStringContainsString('Ligne 3', $errors[1]);
+    }
+
+    public function testLoadPersistsRulesInDatabase(): void
+    {
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $this->assertNotNull($territory);
+        $countBefore = $this->entityManager->getRepository(AutoAffectationRule::class)->count(['territory' => $territory]);
+
+        $this->loader->load($this->provideValidData());
+
+        $countAfter = $this->entityManager->getRepository(AutoAffectationRule::class)->count(['territory' => $territory]);
+        $this->assertSame($countBefore + 2, $countAfter);
+    }
+
+    public function testLoadUpdatesNbRulesCreatedMetadata(): void
+    {
+        $this->loader->load($this->provideValidData());
+
+        $this->assertSame(2, $this->loader->getMetadata()['nb_rules_created']);
+    }
+
+    public function testLoadTracksImportedTerritoryId(): void
+    {
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $this->assertNotNull($territory);
+
+        $this->loader->load($this->provideValidData());
+
+        $importedIds = $this->loader->getMetadata()['imported_territory_ids'];
+        $this->assertCount(1, $importedIds);
+        $this->assertContains($territory->getId(), $importedIds);
+    }
+
+    public function testLoadTracksMultipleTerritoriesWhenPresent(): void
+    {
+        $data = array_merge($this->provideValidData(), [
+            $this->buildRow(
+                territory: '13 - Bouches-du-Rhône',
+                partnerType: 'DDT/M',
+                allocataire: 'nsp',
+            ),
+        ]);
+
+        $this->loader->load($data);
+
+        $this->assertCount(2, $this->loader->getMetadata()['imported_territory_ids']);
+    }
+
+    public function testLoadSetsAllRuleFieldsCorrectly(): void
+    {
+        $row = $this->buildRow(
+            partnerType: 'CCAS',
+            profileDeclarant: 'LOCATAIRE',
+            parc: 'public',
+            allocataire: 'oui',
+            inseeToInclude: '34172,34173',
+            inseeToExclude: '34001',
+            partnerToExclude: '999',
+        );
+
+        $this->loader->load([$row]);
+
+        $territory = $this->territoryRepository->findOneBy(['zip' => '34', 'name' => 'Hérault']);
+        $rule = $this->entityManager->getRepository(AutoAffectationRule::class)->findOneBy([
+            'territory' => $territory,
+            'parc' => 'public',
+            'allocataire' => 'oui',
+        ]);
+
+        $this->assertNotNull($rule);
+        $this->assertSame(AutoAffectationRule::STATUS_ACTIVE, $rule->getStatus());
+        $this->assertSame('LOCATAIRE', $rule->getProfileDeclarant());
+        $this->assertSame('34172,34173', $rule->getInseeToInclude());
+        $this->assertSame(['34001'], $rule->getInseeToExclude());
+        $this->assertSame(['999'], $rule->getPartnerToExclude());
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function provideValidData(): array
+    {
+        return [
+            $this->buildRow(allocataire: 'msa'),
+            $this->buildRow(partnerType: 'CCAS', allocataire: 'all'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildRow(
+        string $territory = '34 - Hérault',
+        string $status = 'ACTIVE',
+        string $partnerType = 'CAF / MSA',
+        string $profileDeclarant = 'all',
+        string $parc = 'prive',
+        string $allocataire = 'all',
+        string $inseeToInclude = '/',
+        string $inseeToExclude = '/',
+        string $partnerToExclude = '/',
+        string $proceduresSuspectees = '/',
+    ): array {
+        return [
+            AutoAffectationRuleHeader::TERRITORY => $territory,
+            AutoAffectationRuleHeader::STATUS => $status,
+            AutoAffectationRuleHeader::PARTNER_TYPE => $partnerType,
+            AutoAffectationRuleHeader::PROFILE_DECLARANT => $profileDeclarant,
+            AutoAffectationRuleHeader::PARC => $parc,
+            AutoAffectationRuleHeader::ALLOCATAIRE => $allocataire,
+            AutoAffectationRuleHeader::INSEE_TO_INCLUDE => $inseeToInclude,
+            AutoAffectationRuleHeader::INSEE_TO_EXCLUDE => $inseeToExclude,
+            AutoAffectationRuleHeader::PARTNER_TO_EXCLUDE => $partnerToExclude,
+            AutoAffectationRuleHeader::PROCEDURES_SUSPECTEES => $proceduresSuspectees,
+        ];
+    }
+}

--- a/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
+++ b/tests/Functional/Service/Import/AutoAffectationRule/AutoAffectationRuleLoaderTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Service\Import\AutoAffectationRule;
 use App\Entity\AutoAffectationRule;
 use App\Entity\Territory;
 use App\Repository\AutoAffectationRuleRepository;
+use App\Repository\CommuneRepository;
 use App\Repository\PartnerRepository;
 use App\Repository\TerritoryRepository;
 use App\Service\Import\AutoAffectationRule\AutoAffectationRuleHeader;
@@ -32,6 +33,7 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
         $this->loader = new AutoAffectationRuleLoader(
             static::getContainer()->get(AutoAffectationRuleRepository::class),
             static::getContainer()->get(PartnerRepository::class),
+            static::getContainer()->get(CommuneRepository::class),
             $this->entityManager,
         );
     }
@@ -81,6 +83,15 @@ class AutoAffectationRuleLoaderTest extends KernelTestCase
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Allocataire "inconnu" invalide', $errors[0]);
+    }
+
+    public function testValidateReturnsErrorForInseeCodesOutsideTerritory(): void
+    {
+        $errors = $this->loader->validate([$this->buildRow(inseeToInclude: '75056')], $this->herault);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Codes INSEE à inclure hors du territoire', $errors[0]);
+        $this->assertStringContainsString('75056', $errors[0]);
     }
 
     public function testValidateAccumulatesMultipleErrorsOnSameLine(): void

--- a/tests/Functional/Service/Import/CsvParserTest.php
+++ b/tests/Functional/Service/Import/CsvParserTest.php
@@ -44,17 +44,34 @@ class CsvParserTest extends KernelTestCase
 
     public function testParseAsDict(): void
     {
-        $options = ['first_line' => 0, 'delimiter' => ',', 'enclosure' => '"', 'escape' => '\\'];
-        $csvParser = new CsvParser($options);
+        $csvParser = new CsvParser();
         $dataList = $csvParser->parseAsDict($this->projectDir.self::FILEPATH);
 
+        $this->assertCount(10, $dataList);
         foreach ($dataList as $dataItem) {
-            if (\count($dataItem) > 1) {
-                $this->assertArrayHasKey('Lastname', $dataItem);
-                $this->assertArrayHasKey('Firstname', $dataItem);
-                $this->assertArrayHasKey('Email', $dataItem);
-            }
+            $this->assertArrayHasKey('Lastname', $dataItem);
+            $this->assertArrayHasKey('Firstname', $dataItem);
+            $this->assertArrayHasKey('Email', $dataItem);
         }
+    }
+
+    public function testParseAsDictWithSemicolonDelimiter(): void
+    {
+        $filepath = $this->projectDir.'/tmp/data_semicolon.csv';
+        $this->createRandomCSV($filepath, 5, ';');
+
+        $csvParser = new CsvParser(['first_line' => 1, 'delimiter' => ';', 'enclosure' => '"', 'escape' => '\\']);
+        $dataList = $csvParser->parseAsDict($filepath);
+
+        $this->assertCount(5, $dataList);
+        foreach ($dataList as $dataItem) {
+            $this->assertArrayHasKey('Lastname', $dataItem);
+            $this->assertArrayHasKey('Firstname', $dataItem);
+            $this->assertArrayHasKey('Email', $dataItem);
+            $this->assertCount(3, $dataItem);
+        }
+
+        unlink($filepath);
     }
 
     public function testGetHeaders(): void
@@ -81,7 +98,7 @@ class CsvParserTest extends KernelTestCase
         unlink($this->projectDir.self::FILEPATH);
     }
 
-    public function createRandomCSV(string $filepath, int $line = 10): void
+    public function createRandomCSV(string $filepath, int $line = 10, string $delimiter = ','): void
     {
         $faker = Factory::create();
         $list = [
@@ -89,8 +106,7 @@ class CsvParserTest extends KernelTestCase
         ];
 
         for ($i = 0; $i < $line; ++$i) {
-            $row = [$faker->lastName(), $faker->firstName(), $faker->email()];
-            $list[] = $row;
+            $list[] = [$faker->lastName(), $faker->firstName(), $faker->email()];
         }
 
         $fileresource = fopen($filepath, 'w');
@@ -99,7 +115,7 @@ class CsvParserTest extends KernelTestCase
             throw new \RuntimeException("Impossible d'ouvrir le fichier $filepath en écriture.");
         }
         foreach ($list as $row) {
-            fputcsv($fileresource, $row);
+            fputcsv($fileresource, $row, $delimiter, '"', '\\');
         }
 
         fclose($fileresource);


### PR DESCRIPTION
## Ticket

#5761   

## Description
Nouvelle fonctionnalité SA
Ajout d'une page pour importer un fichier csv contenant plusieurs règles d'auto-affectation.
Archive toutes les règles existant précédemment sur le territoire
Format du fichier : csv, séparateur de colonne ;

## Changements apportés
* Ajout d'une route dans le controlleur
* Ajout d'un template twig
* Ajout d'un form type
* Ajout de 2 fichiers pour le service d'import
* Ajout de 2 règles de tests

## Pré-requis
Créer des csv pour tester les différents cas, par exemple:

[test_ko.csv](https://github.com/user-attachments/files/28505322/test_ko.csv)
[test_ok.csv](https://github.com/user-attachments/files/28505323/test_ok.csv)

## Tests
- [ ] Tester la page sans choisir de territoire et/ou sans ajouter de fichier
- [ ] Tester l'import avec des règles contenant des erreurs (valeurs invalides, doublon de règle, partenaires d'un autre territoire etc.)
- [ ] Tester l'import sur un territoire contenant déjà des règles, s'il n'y a pas d'erreur, vérifier que les anciennes règles sont archivées et que les nouvelles règles correspondent au csv
