### PR TITLE
[BO - Annuaire] Correction export pour les utilisateurs non-RT

### DIFF
--- a/src/Controller/Back/AnnuaireController.php
+++ b/src/Controller/Back/AnnuaireController.php
@@ -55,7 +55,7 @@ class AnnuaireController extends AbstractController
         }
 
         $originalMethod = $request->getMethod();
-        $request->setMethod('GET'); // to prevent Symfony ignoring GET data while handlning the form
+        $request->setMethod('GET'); // to prevent Symfony ignoring GET data while handling the form
         [$form, $search, $userPartners] = $this->handleSearch($request, false);
 
         if ('POST' === $originalMethod) {

--- a/src/Form/SearchAnnuaireAgentType.php
+++ b/src/Form/SearchAnnuaireAgentType.php
@@ -4,9 +4,11 @@ namespace App\Form;
 
 use App\Entity\Partner;
 use App\Entity\Territory;
+use App\Entity\User;
 use App\Form\Type\SearchCheckboxType;
 use App\Form\Type\TerritoryChoiceType;
 use App\Repository\PartnerRepository;
+use App\Service\ListFilters\SearchAnnuaireAgent;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -35,10 +37,14 @@ class SearchAnnuaireAgentType extends AbstractType
         $builder->add('page', HiddenType::class);
         $builder->add('territory', TerritoryChoiceType::class);
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($builder) {
-            $this->addPartnersField($event->getForm(), $builder->getData()->getTerritory());
+            /** @var SearchAnnuaireAgent $data */
+            $data = $builder->getData();
+            $this->addPartnersField($event->getForm(), $data->getTerritory(), $data->getUser());
         });
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
-            $this->addPartnersField($event->getForm(), isset($event->getData()['territory']) ? $event->getData()['territory'] : null);
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($builder) {
+            /** @var SearchAnnuaireAgent $data */
+            $data = $builder->getData();
+            $this->addPartnersField($event->getForm(), isset($event->getData()['territory']) ? $event->getData()['territory'] : null, $data->getUser());
         });
         $builder->add('orderType', ChoiceType::class, [
             'choices' => [
@@ -57,15 +63,22 @@ class SearchAnnuaireAgentType extends AbstractType
     /**
      * @param FormInterface<mixed> $builder
      */
-    private function addPartnersField(FormInterface $builder, string|Territory|null $territory): void
+    private function addPartnersField(FormInterface $builder, string|Territory|null $territory, User $user): void
     {
         $builder->add('partners', SearchCheckboxType::class, [
             'class' => Partner::class,
-            'query_builder' => static function (PartnerRepository $partnerRepository) use ($territory) {
-                $query = $partnerRepository->createQueryBuilder('p')
-                    ->where('p.territory = :territory')
-                    ->setParameter('territory', $territory);
-                $query->orderBy('p.nom', 'ASC');
+            'query_builder' => static function (PartnerRepository $partnerRepository) use ($territory, $user) {
+                $query = $partnerRepository->createQueryBuilder('p');
+
+                if ($territory) {
+                    $query->where('p.territory = :territory')
+                        ->setParameter('territory', $territory);
+                } elseif (!$user->isSuperAdmin()) {
+                    $query->where('p.territory IN (:userTerritories)')
+                        ->setParameter('userTerritories', $user->getPartnersTerritories());
+                }
+
+                $query->orderBy('LOWER(p.nom)', 'ASC');
 
                 return $query;
             },

--- a/src/Form/SearchAnnuaireAgentType.php
+++ b/src/Form/SearchAnnuaireAgentType.php
@@ -70,12 +70,12 @@ class SearchAnnuaireAgentType extends AbstractType
             'query_builder' => static function (PartnerRepository $partnerRepository) use ($territory, $user) {
                 $query = $partnerRepository->createQueryBuilder('p');
 
-                if ($territory) {
-                    $query->where('p.territory = :territory')
-                        ->setParameter('territory', $territory);
-                } elseif (!$user->isSuperAdmin()) {
+                if (!$user->isSuperAdmin()) {
                     $query->where('p.territory IN (:userTerritories)')
                         ->setParameter('userTerritories', $user->getPartnersTerritories());
+                } else {
+                    $query->where('p.territory = :territory')
+                        ->setParameter('territory', $territory);
                 }
 
                 $query->orderBy('LOWER(p.nom)', 'ASC');


### PR DESCRIPTION
## Ticket

#5923   

## Description
Dans l'annuaire, correction de l'export pour les utilisateurs non-RT.
La liste des partenaires n'était plus filtrée correctement, et les partenaires pré-filtrés n'étaient plus disponibles

## Tests
- [ ] En tant que RT : dans l'annuaire : filtrer sur un ou des partenaires, vérifier le nombre de résultats
- [ ] Aller sur l'export et vérifier que les résultats sont toujours les bons
- [ ] TNR : Vérifier que tout fonctionne toujours en tant que SA
