### PR TITLE
[QA] Mettre des contraintes sur superficie et nombre de pièces 

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -578,8 +578,8 @@
           "validate": {
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
-            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0",
-            "expressionMessage": "Merci de saisir une information numérique et supérieure à 0 dans le champs superficie.",
+            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
             "required": false
           }
         },
@@ -595,7 +595,9 @@
           "validate": {
             "message": "Veuillez renseigner le nombre de pièces à vivre.",
             "pattern": "^[0-9]*$",
-            "patternMessage": "Veuillez renseigner un nombre de pièces valide."
+            "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
+            "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -579,7 +579,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -597,7 +597,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -579,7 +579,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -597,7 +597,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -485,8 +485,8 @@
             "message": "Veuillez renseigner la superficie de votre logement",
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
-            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0",
-            "expressionMessage": "Merci de saisir une information numérique et supérieure à 0 dans le champs superficie."
+            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie."
           }
         },
         {
@@ -501,7 +501,9 @@
           "validate": {
             "message": "Veuillez renseigner le nombre de pièces à vivre.",
             "pattern": "^[0-9]*$",
-            "patternMessage": "Veuillez renseigner un nombre de pièces valide."
+            "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
+            "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -486,7 +486,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 9999 dans le champs superficie."
           }
         },
         {
@@ -503,7 +503,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -486,7 +486,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie."
           }
         },
         {
@@ -503,7 +503,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1032,7 +1032,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie."
           }
         },
         {
@@ -1049,7 +1049,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1031,8 +1031,8 @@
             "message": "Veuillez renseigner la superficie de votre logement",
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
-            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0",
-            "expressionMessage": "Merci de saisir une information numérique et supérieure à 0 dans le champs superficie."
+            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie."
           }
         },
         {
@@ -1047,7 +1047,9 @@
           "validate": {
             "message": "Veuillez renseigner le nombre de pièces à vivre.",
             "pattern": "^[0-9]*$",
-            "patternMessage": "Veuillez renseigner un nombre de pièces valide."
+            "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
+            "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1032,7 +1032,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 9999 dans le champs superficie."
           }
         },
         {
@@ -1049,7 +1049,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -984,7 +984,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -1002,7 +1002,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -983,8 +983,8 @@
           "validate": {
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
-            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0",
-            "expressionMessage": "Merci de saisir une information numérique et supérieure à 0 dans le champs superficie.",
+            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
             "required": false
           }
         },
@@ -1000,7 +1000,9 @@
           "validate": {
             "message": "Veuillez renseigner le nombre de pièces à vivre.",
             "pattern": "^[0-9]*$",
-            "patternMessage": "Veuillez renseigner un nombre de pièces valide."
+            "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
+            "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -984,7 +984,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -1002,7 +1002,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -994,7 +994,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -1012,7 +1012,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -994,7 +994,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -1012,7 +1012,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -993,8 +993,8 @@
           "validate": {
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
-            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0",
-            "expressionMessage": "Merci de saisir une information numérique et supérieure à 0 dans le champs superficie.",
+            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
             "required": false
           }
         },
@@ -1010,7 +1010,9 @@
           "validate": {
             "message": "Veuillez renseigner le nombre de pièces à vivre.",
             "pattern": "^[0-9]*$",
-            "patternMessage": "Veuillez renseigner un nombre de pièces valide."
+            "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
+            "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -979,7 +979,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -997,7 +997,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -979,7 +979,7 @@
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
             "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 9999 dans le champs superficie.",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 9999 dans le champs superficie.",
             "required": false
           }
         },
@@ -997,7 +997,7 @@
             "pattern": "^[0-9]*$",
             "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
             "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
-            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 999 dans le champs nombre de pièces."
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 1 et 999 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -978,8 +978,8 @@
           "validate": {
             "pattern": "^[0-9]+$",
             "patternMessage": "Veuillez renseigner une superficie valide.",
-            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0",
-            "expressionMessage": "Merci de saisir une information numérique et supérieure à 0 dans le champs superficie.",
+            "expression": "parseInt(formStore.data.composition_logement_superficie) > 0 && parseInt(formStore.data.composition_logement_superficie) < 10000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 10000 dans le champs superficie.",
             "required": false
           }
         },
@@ -995,7 +995,9 @@
           "validate": {
             "message": "Veuillez renseigner le nombre de pièces à vivre.",
             "pattern": "^[0-9]*$",
-            "patternMessage": "Veuillez renseigner un nombre de pièces valide."
+            "patternMessage": "Veuillez renseigner un nombre de pièces valide.",
+            "expression": "parseInt(formStore.data.composition_logement_nb_pieces) > 0 && parseInt(formStore.data.composition_logement_nb_pieces) < 1000",
+            "expressionMessage": "Merci de saisir une information numérique comprise entre 0 et 1000 dans le champs nombre de pièces."
           }
         }
       ],

--- a/assets/scripts/vanilla/controllers/form_nde.js
+++ b/assets/scripts/vanilla/controllers/form_nde.js
@@ -22,6 +22,8 @@ formBtn?.addEventListener('click', () => {
     document.querySelector('#signalement-edit-nde-dpe-error').classList.add('fr-hidden');
   }
 
+  document.querySelector('#signalement-edit-nde-superficie-error').classList.add('fr-hidden');
+
   // Post form
   if (postForm) {
     const form = document.querySelector('form#signalement-edit-nde-form');
@@ -82,9 +84,14 @@ formBtn?.addEventListener('click', () => {
     };
 
     fetch(url, options)
-      .then((response) => {
+      .then(async (response) => {
         if (response.ok) {
           jsonResponseHandler(response);
+        } else if (response.status === 400) {
+          const data = await response.json();
+          if (data.errors?.superficie) {
+            document.querySelector('#signalement-edit-nde-superficie-error').classList.remove('fr-hidden');
+          }
         }
       })
       .catch((error) => {

--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -9,11 +9,14 @@ use App\Manager\SignalementManager;
 use App\Security\Voter\SignalementVoter;
 use App\Service\MessageHelper;
 use App\Service\Signalement\SignalementQualificationNde;
+use App\Utils\FormHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/bo/signalements')]
 class BackSignalementQualificationController extends AbstractController
@@ -30,6 +33,7 @@ class BackSignalementQualificationController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         SignalementQualificationNde $signalementQualificationNdeService,
+        ValidatorInterface $validator,
     ): JsonResponse {
         $this->denyAccessUnlessGranted(SignalementVoter::SIGN_EDIT_NDE, $signalement);
         $decodedRequest = json_decode($request->getContent());
@@ -39,6 +43,13 @@ class BackSignalementQualificationController extends AbstractController
                 QualificationNDERequest::class,
                 'json'
             );
+            $errorMessage = FormHelper::getErrorsFromRequest($validator, $qualificationNDERequest);
+            if (!empty($errorMessage)) {
+                $response = ['code' => Response::HTTP_BAD_REQUEST];
+                $response = [...$response, ...$errorMessage];
+
+                return $this->json($response, $response['code']);
+            }
             $signalementManager->updateFromSignalementQualification(
                 $signalementQualification,
                 $qualificationNDERequest
@@ -56,7 +67,13 @@ class BackSignalementQualificationController extends AbstractController
             'signalementQualificationNDE' => $signalementQualificationNDE,
             'signalementQualificationNDECriticite' => $signalementQualificationNDECriticites,
         ]);
-        $htmlTargetContents = [['target' => '#signalement-bo-nde-container', 'content' => $nde]];
+        $composition = $this->renderView('back/signalement/view/information/information-composition.html.twig', [
+            'signalement' => $signalement,
+        ]);
+        $htmlTargetContents = [
+            ['target' => '#signalement-bo-nde-container', 'content' => $nde],
+            ['target' => '#signalement-information-composition-container', 'content' => $composition],
+        ];
 
         return $this->json(['stayOnPage' => true, 'flashMessages' => $flashMessages, 'closeModal' => true, 'htmlTargetContents' => $htmlTargetContents]);
     }

--- a/src/Dto/Api/Request/SignalementRequest.php
+++ b/src/Dto/Api/Request/SignalementRequest.php
@@ -241,7 +241,7 @@ class SignalementRequest implements RequestInterface
         example: 4,
     )]
     #[Assert\GreaterThan(value: 0)]
-    #[Assert\LessThan(value: 100)]
+    #[Assert\LessThan(value: 1000)]
     public ?int $nombrePieces = null;
     #[OA\Property(
         description: 'Superficie du logement en m².',

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -37,9 +37,9 @@ class CompositionLogementRequest implements RequestInterface
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs de superficie.')]
         #[Assert\Type(type: 'numeric', message: 'La superficie doit être un nombre.')]
-        #[Assert\Length(
-            max: 10,
-            maxMessage: 'La superficie ne doit pas dépasser {{ limit }} caractères.',
+        #[Assert\LessThan(
+            value: 10000,
+            message: 'Merci de saisir une superficie inférieure à 10000.',
         )]
         private readonly ?string $superficie = null,
         #[Assert\NotBlank(
@@ -53,9 +53,9 @@ class CompositionLogementRequest implements RequestInterface
         )]
         #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
         #[Assert\Type(type: 'numeric', message: 'Le nombre de pièces à vivre doit être un nombre.')]
-        #[Assert\Length(
-            max: 10,
-            maxMessage: 'Le nombre de pièces à vivre ne doit pas dépasser {{ limit }} caractères.',
+        #[Assert\LessThan(
+            value: 1000,
+            message: 'Merci de saisir un nombre de pièces inférieur à 1000.',
         )]
         private readonly ?string $compositionLogementNbPieces = null,
         #[Assert\Type(type: 'numeric', message: 'Le nombre d\'étages doit être un nombre.')]

--- a/src/Dto/Request/Signalement/QualificationNDERequest.php
+++ b/src/Dto/Request/Signalement/QualificationNDERequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Dto\Request\Signalement;
 
-class QualificationNDERequest
+use Symfony\Component\Validator\Constraints as Assert;
+
+class QualificationNDERequest implements RequestInterface
 {
     public const string RADIO_VALUE_BEFORE_2023 = '1970-01-01';
     public const string RADIO_VALUE_AFTER_2023 = '2023-01-02';
@@ -10,6 +12,7 @@ class QualificationNDERequest
     public function __construct(
         private ?string $dateEntree = null,
         private ?string $dateDernierDPE = null,
+        #[Assert\LessThan(value: 10000, message: 'La superficie ne doit pas dépasser 9999 m².')]
         private ?float $superficie = null,
         private ?int $consommationEnergie = null,
         private ?bool $dpe = null,

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -284,9 +284,9 @@ class SignalementDraftRequest
     )]
     #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs superficie.')]
     #[Assert\Type(type: 'numeric', message: 'Le nombre de pièces à vivre doit être un nombre.')]
-    #[Assert\Length(
-        max: 10,
-        maxMessage: 'La superficie ne doit pas dépasser {{ limit }} caractères.',
+    #[Assert\LessThan(
+        value: 10000,
+        message: 'Merci de saisir une superficie inférieure à 10000.',
     )]
     private ?string $compositionLogementSuperficie = null;
 
@@ -303,9 +303,9 @@ class SignalementDraftRequest
     )]
     #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
     #[Assert\Type(type: 'numeric', message: 'Le nombre de pièces à vivre doit être un nombre.')]
-    #[Assert\Length(
-        max: 10,
-        maxMessage: 'Le nombre de pièces à vivre ne doit pas dépasser {{ limit }} caractères.',
+    #[Assert\LessThan(
+        value: 1000,
+        message: 'Merci de saisir un nombre de pièces inférieur à 1000.',
     )]
     private ?string $compositionLogementNbPieces = null;
 

--- a/src/Dto/ServiceSecours/FormServiceSecoursStep2.php
+++ b/src/Dto/ServiceSecours/FormServiceSecoursStep2.php
@@ -47,11 +47,31 @@ class FormServiceSecoursStep2
         message: 'Merci de saisir un nombre entier.',
         groups: ['step2']
     )]
+    #[Assert\GreaterThan(
+        value: 0,
+        message: 'Merci de saisir un nombre entier positif.',
+        groups: ['step2']
+    )]
+    #[Assert\LessThan(
+        value: 1000,
+        message: 'Merci de saisir un nombre de pièces inférieur à 1000.',
+        groups: ['step2']
+    )]
     public ?string $nbPiecesLogement = null;
 
     #[Assert\Regex(
         pattern: '/^\d+$/',
         message: 'Merci de saisir un nombre entier.',
+        groups: ['step2']
+    )]
+    #[Assert\GreaterThan(
+        value: 0,
+        message: 'Merci de saisir un nombre entier positif.',
+        groups: ['step2']
+    )]
+    #[Assert\LessThan(
+        value: 10000,
+        message: 'Merci de saisir une superficie inférieure à 10000.',
         groups: ['step2']
     )]
     public ?string $superficie = null;

--- a/src/Form/SignalementDraftLogementType.php
+++ b/src/Form/SignalementDraftLogementType.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @extends AbstractType<mixed>
@@ -152,11 +153,35 @@ class SignalementDraftLogementType extends AbstractType
                 'required' => false,
                 'mapped' => false,
                 'data' => $nombrePieces,
+                'constraints' => [
+                    new Assert\GreaterThan(
+                        value: 0,
+                        message: 'Veuillez saisir un nombre de pièces supérieur à 0.',
+                        groups: ['bo_step_logement'],
+                    ),
+                    new Assert\LessThan(
+                        value: 1000,
+                        message: 'Veuillez saisir un nombre de pièces inférieur à 1000.',
+                        groups: ['bo_step_logement'],
+                    ),
+                ],
             ])
             ->add('superficie', NumberType::class, [
                 'label' => 'Superficie du logement (en m²)',
                 'help' => 'La superficie permet de calculer le risque de suroccupation du logement. Format attendu : Saisir un nombre entier',
                 'required' => false,
+                'constraints' => [
+                    new Assert\GreaterThan(
+                        value: 0,
+                        message: 'Veuillez saisir une superficie supérieure à 0.',
+                        groups: ['bo_step_logement'],
+                    ),
+                    new Assert\LessThan(
+                        value: 10000,
+                        message: 'Veuillez saisir une superficie inférieure à 10000.',
+                        groups: ['bo_step_logement'],
+                    ),
+                ],
             ])
             ->add('pieceAVivre9m', ChoiceType::class, [
                 'label' => 'Au moins une pièce à vivre supérieure ou égale à 9m²',

--- a/src/Form/SignalementeEditFO/TypeCompositionType.php
+++ b/src/Form/SignalementeEditFO/TypeCompositionType.php
@@ -124,6 +124,10 @@ class TypeCompositionType extends AbstractType
                         value: 0,
                         message: 'Veuillez saisir une superficie supérieure à 0.',
                     ),
+                    new Assert\LessThan(
+                        value: 10000,
+                        message: 'Veuillez saisir une superficie inférieure à 10000.',
+                    ),
                 ],
             ])
             ->add('pieceUnique', ChoiceType::class, [
@@ -156,6 +160,14 @@ class TypeCompositionType extends AbstractType
                     new Assert\Regex(
                         pattern: '/^\d+$/',
                         message: 'Veuillez saisir un nombre entier.',
+                    ),
+                    new Assert\GreaterThan(
+                        value: 0,
+                        message: 'Veuillez saisir un nombre de pièces supérieur à 0.',
+                    ),
+                    new Assert\LessThan(
+                        value: 1000,
+                        message: 'Veuillez saisir un nombre de pièces inférieur à 1000.',
                     ),
                     // Si le logement n'est pas une pièce unique (pieceUnique = 'plusieurs_pieces'), alors le nombre de pièces à vivre doit être supérieur ou égal à 2
                     new Assert\Callback(

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -130,7 +130,8 @@
                                         <label class="fr-label" for="signalement-edit-nde-superficie">
                                             Superficie du logement
                                         </label>
-                                        <input class="fr-input fr-col-10 fr-display-inline" pattern="[0-9]*" type="number" id="signalement-edit-nde-superficie" name="superficie" value="{{signalement.superficie}}"> m²
+                                        <input class="fr-input fr-col-10 fr-display-inline" pattern="[0-9]*" type="number" id="signalement-edit-nde-superficie" name="superficie" value="{{signalement.superficie}}" max="9999"> m²
+                                        <p id="signalement-edit-nde-superficie-error" class="fr-error-text fr-hidden">La superficie ne doit pas dépasser 9999 m².</p>
                                     </div>
                                 </div>
                             </div>                            

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -58,12 +58,12 @@
                                         signalement.isV2)
                                     }}
                                 </label>
-                                <input class="fr-input" type="number" id="compositionLogementSuperficie" name="superficie" value="{{ signalement.superficie }}">
+                                <input class="fr-input" type="number" id="compositionLogementSuperficie" name="superficie" value="{{ signalement.superficie }}" max="9999">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="compositionLogementNbPieces">Nombre de pièces à vivre</label>
-                                <input class="fr-input" type="number" id="compositionLogementNbPieces" name="compositionLogementNbPieces" value="{{ signalement.typeCompositionLogement.compositionLogementNbPieces ?? 0 }}">
+                                <input class="fr-input" type="number" id="compositionLogementNbPieces" name="compositionLogementNbPieces" value="{{ signalement.typeCompositionLogement.compositionLogementNbPieces ?? 0 }}" max="999">
                             </div>
 
                             <div class="fr-input-group">

--- a/tests/Unit/Dto/Request/Signalement/CompositionLogementRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/CompositionLogementRequestTest.php
@@ -75,7 +75,6 @@ class CompositionLogementRequestTest extends KernelTestCase
 
         $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
         $errors = $validator->validate($compositionLogementRequest);
-        var_dump($errors);
         $this->assertCount(18, $errors);
     }
 }

--- a/tests/Unit/Dto/Request/Signalement/CompositionLogementRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/CompositionLogementRequestTest.php
@@ -75,6 +75,7 @@ class CompositionLogementRequestTest extends KernelTestCase
 
         $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
         $errors = $validator->validate($compositionLogementRequest);
-        $this->assertCount(17, $errors);
+        var_dump($errors);
+        $this->assertCount(18, $errors);
     }
 }


### PR DESCRIPTION
## Ticket

#5529    

## Description
Mettre des contraintes sur superficie et nombre de pièces avec un nombre max (plutôt que nombre de caractères)

J'ai choisi arbitrairement 9999 m2 pour la superficie et 999 pièces. Avec ça on couvre largement les plus grandes villas françaises. 

## Changements apportés
* Changement des json du form usager
* Changement du Dto du formulaire service secours
* Changement du formulaire BO
* Edition dans une fiche signalement (et dans la modale NDE, avec une correction de l'affichage de la composition du logement suite au changement de la superficie dans la modale NDE)
* API on monte à 1000 pièces plutôt que 100 (superficie ok) pour être en cohérence
* Edition dans le suivi usager
* :warning: pas de vérification pour l'import de signalement

## Pré-requis

## Tests
- [ ] Tester le form usager avec 1 ou 2 profils
- [ ] Tester le form service secours
- [ ] Tester le form BO
- [ ] Sur une fiche signalement, éditer superficie et nb pièces dans l'onglet situation
- [ ] Sur un signalement en NDE, éditer la NDE, vérifier que la superficie est aussi limitée dans la modale NDE, et que cela met à jour la composition du logement
- [ ] API tester qu'on peut créer un signalement avec un nb de pièces entre 100 et 999
- [ ] Tester l'édition dans la fiche de suivi usager
