### PR TITLE
[BO - Interconnexion] Mettre en place un worker dédié aux traitements de synchro

### DIFF
--- a/.docker/php-worker/supervisord.conf
+++ b/.docker/php-worker/supervisord.conf
@@ -16,3 +16,11 @@ numprocs=1
 autostart=true
 autorestart=true
 process_name=%(program_name)s_%(process_num)02d
+
+[program:messenger-consume-esabora]
+command=php /app/bin/console messenger:consume async_esabora --time-limit=86400 -vv
+user=root
+numprocs=1
+autostart=true
+autorestart=true
+process_name=%(program_name)s_%(process_num)02d

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ worker-status:## Get status worker
 
 worker-start: ## Start worker
 	@echo -e '\e[1;32mStart worker\032'
-	@bash -l -c '$(DOCKER_COMP) up -d signal_logement_phpworker'
 	@bash -l -c '$(DOCKER_COMP) exec -it signal_logement_phpworker supervisorctl start all'
 
 worker-stop: ## Stop worker
@@ -96,6 +95,11 @@ worker-consume: ## Consume local queue for debug
 scheduler-consume: ## Consume scheduler for debug
 	@echo -e '\e[1;32mConsume scheduler\033[0m'
 	@bash -l -c '$(DOCKER_COMP) exec -it signal_logement_phpworker php bin/console messenger:consume scheduler_esabora -vvv'
+
+esabora-consume: ## Consume scheduler for debug
+	@echo -e '\e[1;32mConsume scheduler\033[0m'
+	@bash -l -c '$(DOCKER_COMP) exec -it signal_logement_phpworker php bin/console messenger:consume async_esabora -vvv'
+
 
 scheduler-debug: ## List cron to schedule
 	@echo -e '\e[1;32mList cron\033[0m'

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 postdeploy: ./scripts/postdeploy.sh
 worker: php bin/console messenger:consume async_priority_high async --time-limit=86400
 clock: php bin/console messenger:consume scheduler_esabora --time-limit=86400
+esabora: php bin/console messenger:consume async_esabora --time-limit=86400

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -6,6 +6,10 @@ framework:
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
             async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            async_esabora:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    queue_name: esabora
             async_priority_high:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 failure_transport: failed_high_priority
@@ -41,5 +45,6 @@ when@test:
                 # replace with your transport name here (e.g., my_transport: 'in-memory://')
                 # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
                 async: 'in-memory://'
+                async_esabora: 'in-memory://'
                 async_priority_high: 'in-memory://'
                 scheduler_esabora: 'in-memory://'

--- a/src/Scheduler/EsaboraScheduleProvider.php
+++ b/src/Scheduler/EsaboraScheduleProvider.php
@@ -74,7 +74,7 @@ final class EsaboraScheduleProvider implements ScheduleProviderInterface
             CronExpressionTrigger::fromSpec($cron),
             new RedispatchMessage(
                 $message,
-                'async'
+                'async_esabora'
             ),
         );
     }


### PR DESCRIPTION
Review app  : https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging-pr5935
App : https://histologe-staging-pr5935.osc-fr1.scalingo.io/

<img width="773" height="325" alt="image" src="https://github.com/user-attachments/assets/63bada9e-56c3-44d6-939a-a5a489755b0e" />

## Ticket

#5934    

## Description
Mettre en place un worker dédié aux traitements longs (SCHS : statuts/événements, SISH : statuts/visites) afin d'éviter le blocage de la file principale.
Le worker principal restera dédié aux traitements métiers et à l'envoi des dossiers vers es partenaires.

Le nouveau worker regardera uniquement les message dont le nom de la queue est esabora
<img width="1143" height="203" alt="image" src="https://github.com/user-attachments/assets/00961518-18ce-46e3-885b-873995ec2cf2" />

## Changements apportés
* Création du nouveau transport async_esabora
* Création du nouveau worker associé a async_esabora (scalingo)

## Pré-requis
Décommenter la planification, passer de `false` a des message stoutes les X minutes

```
ESABORA_CRON_SCHEDULE_SYNC_SCHS=false#'*/1 * * * *'
ESABORA_CRON_SCHEDULE_SYNC_SISH=false#'*/3 * * * *'
ESABORA_CRON_SCHEDULE_SYNC_SISH_INTERVENTION=false#'*/5 * * * *'
```

`make build`

`make worker-stop && make mock-restart`

Vérifier la définition des crons :  `make scheduler-debug`

Vérifier la présence de tous les workers : `make worker-status`

Le nouveau worker dédié se nomme est : `messenger-consume-esabora:messenger-consume-esabora_00`

S'il n'est pas présent, forcer sa création via `docker compose --profile full up -d --build --force-recreate signal_logement_phpworker`


## Tests
- [ ] Ouvir une console et éxécuter `make scheduler-consume` et vérifier que les premierss messages sont prets à consommer (output console, table de message qui se remplit)
- [ ] Ouvrir une seconde console et éxécuter make worker-consume et vérifier qu'il se ne passe rien car ce worker ne traite plus les messages de synchro esabora

<img width="1850" height="1126" alt="image" src="https://github.com/user-attachments/assets/c171514a-9ad3-4952-abfa-f340c3a7b58c" />

- [ ] Ouvrir une nouvelle console et éxécuter make esabora-consume et vérifier que les message sont traité par le nouveau worker. 
<img width="1840" height="1085" alt="image" src="https://github.com/user-attachments/assets/e5d4cacd-33f4-48e5-9910-d2c038124cfb" />


- [ ] Laisser tous les workers actifs et faire quelques taches qui nécessitent un traitement asynchrone (exports, génération de zip, push de dossier, traitement image dans création de dossier, ect...). 
Ces messages ne doivent être uniquement consommé par le worker principale via **make worker-consume**
<img width="1911" height="1071" alt="image" src="https://github.com/user-attachments/assets/b612ca7f-830d-4ff3-a6ef-7cfc006c29a1" />


### Tests scalingo
1. Ouvrer deux consoles
Console 1 : ` scalingo --region osc-fr1 --app histologe-staging-pr5935 logs --follow   | grep -E '\[(clock-1|esabora-1)\]'`
Console 2 : `scalingo --region osc-fr1 --app histologe-staging-pr5935 logs --follow | grep worker-1`

<img width="1863" height="527" alt="image" src="https://github.com/user-attachments/assets/5bcc1a89-00c8-4e26-9348-53142edfc3be" />

2. Faite un export PDF, le traitement est effectué par le worker (voir console 2)
3. Visualiser que sur la console 1, les traitements qui défilent sont ceux dédié à la planification esabora (clock-1) et à son traitement (esabora-1)



