### PR TITLE
[BO - Annuaire des agents] Ajouter un espace sous le tri

### DIFF
--- a/templates/back/annuaire/index.html.twig
+++ b/templates/back/annuaire/index.html.twig
@@ -64,7 +64,7 @@
         </div>
     </section>
     
-    <section class="fr-col-12 fr-col-lg-3 fr-pt-0">
+    <section class="fr-col-12 fr-col-lg-3 fr-pt-0 fr-mb-2w">
         {{ form_row(form.orderType) }}
     </section>
 


### PR DESCRIPTION
## Ticket

#5930   

## Description
Il manque un espace sous le tri dans l'annuaire des agents

## Changements apportés
* Ajout d'un espace dans le twig

## Pré-requis

## Tests
- [ ] Tester l'annuaire en responsive ou pas
