### PR TITLE
Espace bailleur - Messagerie] Modifier le champs d'upload de fichier

### DIFF
--- a/assets/scripts/app.ts
+++ b/assets/scripts/app.ts
@@ -9,6 +9,7 @@ import './vanilla/services/component/component_phone_number_row.js';
 import './vanilla/services/component/component_search_address.js';
 import './vanilla/services/component/pick-localisation.js';
 import './vanilla/services/component/component_autocomplete_bailleur.js';
+import './vanilla/services/component/component_file_upload.js';
 import './vanilla/services/cookie/cookie_banner.js';
 import './vanilla/services/file/file_delete.js';
 import './vanilla/services/form/ajax_form_handler.js';

--- a/assets/scripts/vanilla/services/component/component_file_upload.js
+++ b/assets/scripts/vanilla/services/component/component_file_upload.js
@@ -1,0 +1,154 @@
+const uploadedFilesByContainer = new WeakMap();
+
+function initComponentFileUpload() {
+  const containers = document.querySelectorAll('.component-upload-container');
+
+  containers.forEach((container) => {
+    const dropArea = container.querySelector('.component-upload-drop-section');
+    const fileSelector = container.querySelector('.component-upload-files-selector');
+    const fileSelectorInput = container.querySelector('.component-upload-files-selector-input');
+
+    fileSelector.onclick = () => {
+      fileSelectorInput.value = '';
+      fileSelectorInput.click();
+    };
+    fileSelectorInput.onchange = () => {
+      [...fileSelectorInput.files].forEach((file) => {
+        if (typeValidation(file, container)) {
+          handleFile(file, container);
+        }
+      });
+    };
+
+    dropArea.ondragover = (e) => {
+      e.preventDefault();
+      [...e.dataTransfer.items].forEach(() => {
+        dropArea.classList.add('drag-over-effect');
+      });
+    };
+
+    dropArea.ondragleave = () => {
+      dropArea.classList.remove('drag-over-effect');
+    };
+
+    dropArea.ondrop = (e) => {
+      e.preventDefault();
+      dropArea.classList.remove('drag-over-effect');
+      if (e.dataTransfer.items) {
+        [...e.dataTransfer.items].forEach((item) => {
+          if (item.kind === 'file') {
+            const file = item.getAsFile();
+            if (typeValidation(file, container)) {
+              handleFile(file, container);
+            }
+          }
+        });
+      } else {
+        [...e.dataTransfer.files].forEach((file) => {
+          if (typeValidation(file, container)) {
+            handleFile(file, container);
+          }
+        });
+      }
+    };
+  });
+}
+
+function typeValidation(file, container) {
+  const listContainerErrors = container.querySelector('.component-upload-list-errors');
+  const fileSelectorInput = container.querySelector('.component-upload-files-selector-input');
+  const acceptedType = fileSelectorInput.getAttribute('accept');
+  const acceptedTypes = acceptedType ? acceptedType.split(',').map((type) => type.trim()) : [];
+  if (!acceptedTypes.length || acceptedTypes.includes(file.type)) {
+    return true;
+  }
+  const notice = document.createElement('div');
+  notice.classList.add('fr-notice', 'fr-notice--alert', 'fr-mb-5v');
+
+  const containerDiv = document.createElement('div');
+  containerDiv.classList.add('fr-container');
+
+  const body = document.createElement('div');
+  body.classList.add('fr-notice__body');
+
+  const p = document.createElement('p');
+
+  const span = document.createElement('span');
+  span.classList.add('fr-notice__desc');
+  span.textContent =
+    'Impossible d\'ajouter le fichier "' + file.name + '" car le format n\'est pas pris en charge.';
+
+  const btnClose = document.createElement('button');
+  btnClose.classList.add('fr-btn--close', 'fr-btn');
+  btnClose.setAttribute('title', 'Masquer le message');
+  btnClose.textContent = 'Masquer le message';
+
+  p.appendChild(span);
+  body.appendChild(p);
+  body.appendChild(btnClose);
+  containerDiv.appendChild(body);
+  notice.appendChild(containerDiv);
+
+  listContainerErrors.prepend(notice);
+
+  return false;
+}
+
+function handleFile(file, container) {
+  const listContainer = container.querySelector('.component-upload-list');
+  const storedFiles = getStoredFiles(container);
+
+  storedFiles.push(file);
+  syncInputFiles(container);
+
+  const fileItem = document.createElement('div');
+  fileItem.classList.add('component-upload-list-item');
+  fileItem.textContent = file.name;
+
+  const deleteButton = document.createElement('button');
+  deleteButton.classList.add(
+    'fr-link',
+    'fr-icon-close-circle-line',
+    'fr-link--icon-left',
+    'fr-link--error',
+    'fr-pl-2w'
+  );
+  deleteButton.setAttribute('aria-label', 'Supprimer le fichier ' + file.name);
+  deleteButton.setAttribute('title', 'Supprimer le fichier ' + file.name);
+  deleteButton.textContent = 'Supprimer';
+  deleteButton.onclick = () => {
+    const index = storedFiles.findIndex((storedFile) => storedFile === file);
+    if (index !== -1) {
+      storedFiles.splice(index, 1);
+      syncInputFiles(container);
+    }
+
+    if (listContainer.contains(fileItem)) {
+      listContainer.removeChild(fileItem);
+    }
+  };
+
+  fileItem.appendChild(deleteButton);
+  listContainer.appendChild(fileItem);
+}
+
+function getStoredFiles(container) {
+  if (!uploadedFilesByContainer.has(container)) {
+    uploadedFilesByContainer.set(container, []);
+  }
+
+  return uploadedFilesByContainer.get(container);
+}
+
+function syncInputFiles(container) {
+  const fileSelectorInput = container.querySelector('.component-upload-files-selector-input');
+  const dataTransfer = new DataTransfer();
+
+  getStoredFiles(container).forEach((file) => {
+    dataTransfer.items.add(file);
+  });
+
+  fileSelectorInput.files = dataTransfer.files;
+}
+
+initComponentFileUpload();

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -623,24 +623,27 @@ div.photos-album {
         }
     }
 }
-.modal-upload-upload-container{
+.modal-upload-upload-container, .component-upload-container {
     text-align: center;
 }
-.modal-upload-upload-container input{
+.modal-upload-upload-container input, .component-upload-container input{
     display: none;
 }
-.modal-upload-drop-section {
+.modal-upload-drop-section, .component-upload-drop-section {
     border: 1px dashed #929292;
     font-size: 1.4rem;
     padding: 4rem 0;
     margin: .5rem 0;
     font-weight: bold;
 }
-.modal-upload-drop-section.drag-over-effect {
+.modal-upload-drop-section.drag-over-effect, .component-upload-drop-section.drag-over-effect {
     border: 2px dashed #929292;
     color: #929292;
 }
-.modal-upload-list-section{
+.component-upload-list, .component-upload-list-errors {
+    text-align: left;
+}
+.modal-upload-list-section {
     font-weight: lighter;
     .file-name{
         font-weight: bold;

--- a/src/Form/MessageBailleurType.php
+++ b/src/Form/MessageBailleurType.php
@@ -34,10 +34,13 @@ class MessageBailleurType extends AbstractType
                 ],
             ])
             ->add('files', FileType::class, [
-                'label' => 'Ajouter des documents (facultatif)',
+                'label' => false,
                 'help' => 'Taille maximale par document : 10 Mo, Formats supportés : '.UploadHandlerService::getAcceptedExtensions(),
                 'required' => false,
                 'multiple' => true,
+                'attr' => [
+                    'accept' => implode(',', File::DOCUMENT_MIME_TYPES),
+                ],
                 'constraints' => [
                     new Assert\All([
                         new Assert\File(

--- a/src/Form/MessageBailleurType.php
+++ b/src/Form/MessageBailleurType.php
@@ -34,7 +34,7 @@ class MessageBailleurType extends AbstractType
                 ],
             ])
             ->add('files', FileType::class, [
-                'label' => false,
+                'label' => 'Ajouter des documents (facultatif)',
                 'help' => 'Taille maximale par document : 10 Mo, Formats supportés : '.UploadHandlerService::getAcceptedExtensions(),
                 'required' => false,
                 'multiple' => true,

--- a/templates/front/dossier_bailleur/dossier_bailleur.html.twig
+++ b/templates/front/dossier_bailleur/dossier_bailleur.html.twig
@@ -399,7 +399,7 @@
 								Nous invitons chaque partie à adopter une attitude courtoise et bienveillante.
 							</p>
 							{{ form_row(formMessage.description) }}
-
+							{{form_label(formMessage.files, 'Ajouter des documents (facultatif)')}}
 							<div class="component-upload-container fr-mb-4w">
 								<div class="component-upload-drop-section">
 									<span class="fr-icon-upload-2-line fr-icon--lg fr-text-label--blue-france"></span>
@@ -408,8 +408,8 @@
 									</div>
 								</div>
 								<p class="fr-mb-1w">ou</p>
-								<button type="button" class="component-upload-files-selector fr-btn fr-icon-search-line fr-btn--icon-left fr-btn--secondary">Parcourir les fichiers de l'appareil</button>
-								{{ form_row(formMessage.files, {'attr': {'class': 'component-upload-files-selector-input'}}) }}
+								<button type="button" class="component-upload-files-selector fr-btn fr-icon-search-line fr-btn--icon-left fr-btn--secondary fr-mb-2v">Parcourir les fichiers de l'appareil</button>
+								{{ form_widget(formMessage.files, {'attr': {'class': 'component-upload-files-selector-input'}}) }}
 								<div class="component-upload-list-errors"></div>
 								<div class="component-upload-list"></div>
 							</div>

--- a/templates/front/dossier_bailleur/dossier_bailleur.html.twig
+++ b/templates/front/dossier_bailleur/dossier_bailleur.html.twig
@@ -399,7 +399,20 @@
 								Nous invitons chaque partie à adopter une attitude courtoise et bienveillante.
 							</p>
 							{{ form_row(formMessage.description) }}
-							{{ form_row(formMessage.files) }}
+
+							<div class="component-upload-container fr-mb-4w">
+								<div class="component-upload-drop-section">
+									<span class="fr-icon-upload-2-line fr-icon--lg fr-text-label--blue-france"></span>
+									<div class="component-upload-drop-section-label fr-mt-1w">
+										Faites glisser vos documents ici
+									</div>
+								</div>
+								<p class="fr-mb-1w">ou</p>
+								<button type="button" class="component-upload-files-selector fr-btn fr-icon-search-line fr-btn--icon-left fr-btn--secondary">Parcourir les fichiers de l'appareil</button>
+								{{ form_row(formMessage.files, {'attr': {'class': 'component-upload-files-selector-input'}}) }}
+								<div class="component-upload-list-errors"></div>
+								<div class="component-upload-list"></div>
+							</div>
 
 							{{ form_end(formMessage) }}
 							<ul class="fr-btns-group fr-btns-group--icon-left">


### PR DESCRIPTION
## Ticket

#5890

## Description
Remplacement du champs d'upload multiple natif de la messagerie bailleur par un nouveau composant pour améliorer l'ux : 
<img width="564" height="515" alt="Screenshot 2026-06-04 at 16-00-48 Détails du dossier #INJ-2364 - Signal-Logement" src="https://github.com/user-attachments/assets/13402c30-5ff2-4110-bc9d-c66470354a19" />
- Support du glisser déposer et ou de la sélection classique
- Support de l'affichage des éléments ajouté et possibilité de les supprimer
- Support de l'ajout de document en plusieurs étapes (1 fichier après l'autre)

## Changements apportés
* Création du componsant js `component_file_upload.js`

## Pré-requis
`make npm-watch`

## Tests
- [ ] Se connecter à l'espace bailleur pour un dossier en injonction ayant une réponse bailleur et jouer avec le champs d'upload
