### PR TITLE
[Démarche Accélérée] Mini Dashboard

### DIFF
--- a/src/DataFixtures/Files/Notification.yml
+++ b/src/DataFixtures/Files/Notification.yml
@@ -54,3 +54,8 @@ notifications:
   type: "SUIVI_USAGER"
   signalement: "2023-15"
   suivi: 'Ceci est le dernier suivi de partenaire 13-01'
+-
+  user: "admin-01@signal-logement.fr"
+  type: "NOUVEAU_SUIVI"
+  signalement: "2023-12"
+  suivi: "Le bailleur est vraiment casse pied, Je n'en peux plus de lui !"

--- a/src/Form/SearchSignalementInjonctionType.php
+++ b/src/Form/SearchSignalementInjonctionType.php
@@ -66,8 +66,8 @@ class SearchSignalementInjonctionType extends AbstractType
                     'du bailleur' => 'bailleur',
                 ],
                 'required' => false,
-                'placeholder' => 'Aucun',
-                'label' => 'Nouveau message',
+                'placeholder' => 'Tous',
+                'label' => 'Nouveau message (sur les 30 derniers jours)',
             ]);
         }
 

--- a/src/Form/SearchSignalementInjonctionType.php
+++ b/src/Form/SearchSignalementInjonctionType.php
@@ -59,6 +59,18 @@ class SearchSignalementInjonctionType extends AbstractType
             'label' => 'Statut de la démarche',
         ]);
 
+        if ($this->isAdmin) {
+            $builder->add('messages', ChoiceType::class, [
+                'choices' => [
+                    'de l\'usager' => 'usager',
+                    'du bailleur' => 'bailleur',
+                ],
+                'required' => false,
+                'placeholder' => 'Aucun',
+                'label' => 'Nouveau message',
+            ]);
+        }
+
         $builder->add('orderType', ChoiceType::class, [
             'choices' => [
                 'Ordre croissant' => 's.id-ASC',

--- a/src/Repository/Query/Dashboard/KpiQuery.php
+++ b/src/Repository/Query/Dashboard/KpiQuery.php
@@ -4,7 +4,9 @@ namespace App\Repository\Query\Dashboard;
 
 use App\Dto\CountPartner;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\SuiviCategory;
 use App\Entity\Enum\UserStatus;
+use App\Entity\Notification;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
@@ -43,6 +45,51 @@ class KpiQuery
                 ->andWhere('s.territory IN (:territories)')
                 ->setParameter('territories', $user->getPartnersTerritories());
         }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    public function countInjonctionsNouveauxMessages(
+        User $user,
+        ?TabQueryParameters $params,
+        string $messageType,
+    ): int {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->from(Signalement::class, 's')
+            ->where('s.statut IN (:statut)')
+            ->setParameter('statut', [SignalementStatus::INJONCTION_BAILLEUR, SignalementStatus::INJONCTION_CLOSED]);
+
+        $qb->select('COUNT(s.id)');
+
+        if ($params?->territoireId) {
+            $qb
+                ->andWhere('s.territory = :territoireId')
+                ->setParameter('territoireId', $params->territoireId);
+        } elseif (!$user->isSuperAdmin()) {
+            $qb
+                ->andWhere('s.territory IN (:territories)')
+                ->setParameter('territories', $user->getPartnersTerritories());
+        }
+
+        $categories = 'usager' === $messageType
+            ? SuiviCategory::categoriesSubmittedByUsager()
+            : SuiviCategory::categoriesSubmittedByBailleur();
+
+        $notificationQueryBuilder = $this->entityManager->createQueryBuilder()
+                ->select('1')
+                ->from(Notification::class, 'n')
+                ->join('n.suivi', 'n_suivi')
+                ->where('n.signalement = s')
+                ->andWhere('n.user = :currentUser')
+                ->andWhere('n.isSeen = false')
+                ->andWhere('n.deleted = false')
+                ->andWhere('n_suivi.category IN (:messageCategories)');
+
+        $qb->andWhere(
+            $qb->expr()->exists($notificationQueryBuilder->getDQL())
+        )
+        ->setParameter('currentUser', $user)
+        ->setParameter('messageCategories', $categories);
 
         return (int) $qb->getQuery()->getSingleScalarResult();
     }

--- a/src/Repository/Query/Dashboard/KpiQuery.php
+++ b/src/Repository/Query/Dashboard/KpiQuery.php
@@ -56,8 +56,8 @@ class KpiQuery
     ): int {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(Signalement::class, 's')
-            ->where('s.statut IN (:statut)')
-            ->setParameter('statut', [SignalementStatus::INJONCTION_BAILLEUR, SignalementStatus::INJONCTION_CLOSED]);
+            ->where('s.statut IN (:signalementStatusList)')
+            ->setParameter('signalementStatusList', SignalementStatus::injonctionStatuses());
 
         $qb->select('COUNT(s.id)');
 
@@ -75,6 +75,7 @@ class KpiQuery
             ? SuiviCategory::categoriesSubmittedByUsager()
             : SuiviCategory::categoriesSubmittedByBailleur();
 
+        // ne renvoie les messages non lus que pour les 30 derniers jours, car les notifications sont supprimées automatiquement au-delà de 30 jours
         $notificationQueryBuilder = $this->entityManager->createQueryBuilder()
                 ->select('1')
                 ->from(Notification::class, 'n')

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Commune;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
+use App\Entity\Notification;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
@@ -714,6 +715,28 @@ class SignalementRepository extends ServiceEntityRepository
         if (!empty($searchSignalementInjonction->getStatutSignalement())) {
             $queryBuilder->andWhere('s.statut = :statutSignalement')
                 ->setParameter('statutSignalement', $searchSignalementInjonction->getStatutSignalement());
+        }
+
+        if (!empty($searchSignalementInjonction->getMessages())) {
+            $categories = 'usager' === $searchSignalementInjonction->getMessages()
+                ? SuiviCategory::categoriesSubmittedByUsager()
+                : SuiviCategory::categoriesSubmittedByBailleur();
+
+            $notificationQueryBuilder = $this->getEntityManager()->createQueryBuilder()
+                    ->select('1')
+                    ->from(Notification::class, 'n')
+                    ->join('n.suivi', 'n_suivi')
+                    ->where('n.signalement = s')
+                    ->andWhere('n.user = :currentUser')
+                    ->andWhere('n.isSeen = false')
+                    ->andWhere('n.deleted = false')
+                    ->andWhere('n_suivi.category IN (:messageCategories)');
+
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->exists($notificationQueryBuilder->getDQL())
+            )
+            ->setParameter('currentUser', $searchSignalementInjonction->getUser())
+            ->setParameter('messageCategories', $categories);
         }
 
         if (!empty($searchSignalementInjonction->getOrderType())) {

--- a/src/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoader.php
+++ b/src/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoader.php
@@ -44,6 +44,10 @@ class DossiersDernierActionTabBodyLoader extends AbstractTabBodyLoader
             if ($this->security->isGranted(InjonctionBailleurVoter::INJONCTION_BAILLEUR_SEE)) {
                 $data['data_kpi']['injonctions'] = $this->tabDataManager->countInjonctions($this->tabQueryParameters);
             }
+            if ($user->isSuperAdmin()) {
+                $data['data_kpi']['injonctions_nouveaux_messages_usager'] = $this->tabDataManager->countInjonctionsNouveauxMessages($this->tabQueryParameters, 'usager');
+                $data['data_kpi']['injonctions_nouveaux_messages_bailleur'] = $this->tabDataManager->countInjonctionsNouveauxMessages($this->tabQueryParameters, 'bailleur');
+            }
         }
         if ($user->isSuperAdmin()) {
             $data['data_interconnexion'] = $this->tabDataManager->getInterconnexions($this->tabQueryParameters);

--- a/src/Service/DashboardTabPanel/TabDataManager.php
+++ b/src/Service/DashboardTabPanel/TabDataManager.php
@@ -147,6 +147,16 @@ class TabDataManager
         return $injonctions;
     }
 
+    public function countInjonctionsNouveauxMessages(?TabQueryParameters $tabQueryParameters = null, string $messageType = 'usager'): int
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        $injonctions = $this->kpiQuery->countInjonctionsNouveauxMessages($user, $tabQueryParameters, $messageType);
+
+        return $injonctions;
+    }
+
     public function countUsersPendingToArchive(?TabQueryParameters $tabQueryParameters = null): int
     {
         /** @var User $user */

--- a/src/Service/ListFilters/SearchSignalementInjonction.php
+++ b/src/Service/ListFilters/SearchSignalementInjonction.php
@@ -17,6 +17,7 @@ class SearchSignalementInjonction
     private ?string $orderType = null;
     private ?string $reponseBailleur = null;
     private ?string $statutSignalement = null;
+    private ?string $messages = null;
 
     public function __construct(User $user)
     {
@@ -59,6 +60,16 @@ class SearchSignalementInjonction
     public function setStatutSignalement(?string $statutSignalement): void
     {
         $this->statutSignalement = $statutSignalement;
+    }
+
+    public function getMessages(): ?string
+    {
+        return $this->messages;
+    }
+
+    public function setMessages(?string $messages): void
+    {
+        $this->messages = $messages;
     }
 
     public function getOrderType(): ?string

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -76,7 +76,7 @@
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/mail-send.svg',
                         title: 'Démarches accélérées : nouveaux messages usager',
-                        badge_class: 'fr-badge--info',
+                        badge_class: 'fr-badge--green-tilleul-verveine',
                         badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_usager, ' nouveau message usager', 'nouveaux messages usager'),
                         link: path('back_injonction_signalement_index', linkInjonction)
                     } %}
@@ -87,7 +87,7 @@
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/mail-send.svg',
                         title: 'Démarches accélérées : nouveaux messages bailleur',
-                        badge_class: 'fr-badge--info',
+                        badge_class: 'fr-badge--green-tilleul-verveine',
                         badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_bailleur, ' nouveau message bailleur', 'nouveaux messages bailleur'),
                         link: path('back_injonction_signalement_index', linkInjonction)
                     } %}

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -70,6 +70,28 @@
                         } %}
                     {% endif %}
                 {% endif %}
+                {% if is_granted('ROLE_ADMIN') %}
+                    {% set linkInjonction = {messages: 'usager'} %}
+                    {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
+                    {% include 'back/dashboard/components/_tuile.html.twig' with {
+                        icon_path: 'img/picto-dsfr/paint.svg',
+                        title: 'Démarches accélérées : nouveaux messages usager',
+                        badge_class: 'fr-badge--info',
+                        badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_usager, ' nouveau message usager', 'nouveaux messages usager'),
+                        link: path('back_injonction_signalement_index', linkInjonction)
+                    } %}
+                {% endif %}
+                {% if is_granted('ROLE_ADMIN') %}
+                    {% set linkInjonction = {messages: 'bailleur'} %}
+                    {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
+                    {% include 'back/dashboard/components/_tuile.html.twig' with {
+                        icon_path: 'img/picto-dsfr/paint.svg',
+                        title: 'Démarches accélérées : nouveaux messages bailleur',
+                        badge_class: 'fr-badge--info',
+                        badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_bailleur, ' nouveau message bailleur', 'nouveaux messages bailleur'),
+                        link: path('back_injonction_signalement_index', linkInjonction)
+                    } %}
+                {% endif %}
                 {% if items.nextClubEvent %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/calendar.svg',

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -74,7 +74,7 @@
                     {% set linkInjonction = {messages: 'usager'} %}
                     {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
-                        icon_path: 'img/picto-dsfr/paint.svg',
+                        icon_path: 'img/picto-dsfr/mail-send.svg',
                         title: 'Démarches accélérées : nouveaux messages usager',
                         badge_class: 'fr-badge--info',
                         badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_usager, ' nouveau message usager', 'nouveaux messages usager'),
@@ -85,7 +85,7 @@
                     {% set linkInjonction = {messages: 'bailleur'} %}
                     {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
-                        icon_path: 'img/picto-dsfr/paint.svg',
+                        icon_path: 'img/picto-dsfr/mail-send.svg',
                         title: 'Démarches accélérées : nouveaux messages bailleur',
                         badge_class: 'fr-badge--info',
                         badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_bailleur, ' nouveau message bailleur', 'nouveaux messages bailleur'),

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -71,25 +71,21 @@
                     {% endif %}
                 {% endif %}
                 {% if is_granted('ROLE_ADMIN') %}
-                    {% set linkInjonction = {messages: 'usager'} %}
-                    {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/mail-send.svg',
                         title: 'Démarches accélérées : nouveaux messages usager',
                         badge_class: 'fr-badge--green-tilleul-verveine',
                         badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_usager, ' nouveau message usager', 'nouveaux messages usager'),
-                        link: path('back_injonction_signalement_index', linkInjonction)
+                        link: path('back_injonction_signalement_index',  {territoire: items.territory_id, messages: 'usager' })
                     } %}
                 {% endif %}
                 {% if is_granted('ROLE_ADMIN') %}
-                    {% set linkInjonction = {messages: 'bailleur'} %}
-                    {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/mail-send.svg',
                         title: 'Démarches accélérées : nouveaux messages bailleur',
                         badge_class: 'fr-badge--green-tilleul-verveine',
                         badge_label: singular_or_plural(items.data_kpi.injonctions_nouveaux_messages_bailleur, ' nouveau message bailleur', 'nouveaux messages bailleur'),
-                        link: path('back_injonction_signalement_index', linkInjonction)
+                        link: path('back_injonction_signalement_index',  {territoire: items.territory_id, messages: 'bailleur' })
                     } %}
                 {% endif %}
                 {% if items.nextClubEvent %}

--- a/templates/back/signalement-injonction/index.html.twig
+++ b/templates/back/signalement-injonction/index.html.twig
@@ -44,17 +44,22 @@
         {{ form_errors(form) }}
         <div class="fr-grid-row fr-grid-row--bottom fr-grid-row--gutters">        
             {% if is_granted('ROLE_ADMIN') %}
-                <div class="fr-col-12 fr-col-lg-4">
+                <div class="fr-col-12 fr-col-lg-3">
                     {{ form_row(form.territoire) }}
                 </div>
             {% endif %}
-            <div class="fr-col-12 fr-col-lg-4">
+            <div class="fr-col-12 fr-col-lg-3">
                 {{ form_row(form.reponseBailleur) }}
             </div>
-            <div class="fr-col-12 fr-col-lg-4">
+            <div class="fr-col-12 fr-col-lg-3">
                 {{ form_row(form.statutSignalement) }}
-            </div>
-            <div class="fr-col-12 fr-col-lg-4">
+            </div>     
+            {% if is_granted('ROLE_ADMIN') %}
+                <div class="fr-col-12 fr-col-lg-3">
+                    {{ form_row(form.messages) }}
+                </div>
+            {% endif %}
+            <div class="fr-col-12 fr-col-lg-3">
                 <a href="{{ path('back_injonction_signalement_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser les résultats</a>
             </div>
         </div>

--- a/tests/Functional/Repository/Query/Dashboard/KpiQueryTest.php
+++ b/tests/Functional/Repository/Query/Dashboard/KpiQueryTest.php
@@ -5,13 +5,13 @@ namespace App\Tests\Functional\Repository\Query\Dashboard;
 use App\Entity\Territory;
 use App\Entity\User;
 use App\Repository\Query\Dashboard\KpiQuery;
+use App\Repository\UserRepository;
 use App\Service\DashboardTabPanel\TabQueryParameters;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class KpiQueryTest extends KernelTestCase
 {
@@ -37,10 +37,9 @@ class KpiQueryTest extends KernelTestCase
      */
     public function testCountInjonctions(): void
     {
-        $user = new User();
-        $user->setRoles(['ROLE_ADMIN']);
-        $token = new UsernamePasswordToken($user, 'main', $user->getRoles());
-        static::getContainer()->get('security.token_storage')->setToken($token);
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
 
         $tabQueryParameter = new TabQueryParameters(
             sortBy: 'createdAt',
@@ -53,6 +52,30 @@ class KpiQueryTest extends KernelTestCase
         );
 
         $this->assertEquals(2, $countInjonctions);
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function testCountInjonctionsNouveauxMessages(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
+
+        $tabQueryParameter = new TabQueryParameters(
+            sortBy: 'createdAt',
+            orderBy: 'DESC',
+        );
+
+        $countInjonctions = $this->kpiQuery->countInjonctionsNouveauxMessages(
+            user: $user,
+            params: $tabQueryParameter,
+            messageType: 'usager',
+        );
+
+        $this->assertEquals(1, $countInjonctions);
     }
 
     public function testCountPartnerNonNotifiables(): void

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -479,4 +479,23 @@ class SignalementRepositoryTest extends KernelTestCase
         );
         $this->assertEquals(1, $paginator->count());
     }
+
+    public function testFindInjonctionFilteredPaginatedWithMessageUsager(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
+        /** @var SignalementRepository $repository */
+        $repository = $this->entityManager->getRepository(Signalement::class);
+
+        $search = new SearchSignalementInjonction($user);
+        $search->setMessages('usager');
+
+        $paginator = $repository->findInjonctionFilteredPaginated(
+            $search,
+            10,
+            null
+        );
+        $this->assertEquals(1, $paginator->count());
+    }
 }

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -36,6 +36,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(9, $notificationCount);
+        $this->assertEquals(10, $notificationCount);
     }
 }

--- a/tests/Unit/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoaderTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoaderTest.php
@@ -46,6 +46,8 @@ class DossiersDernierActionTabBodyLoaderTest extends KernelTestCase
             'partenaires_non_notifiables' => 2,
             'partenaires_interfaces' => 1,
             'injonctions' => 2,
+            'injonctions_nouveaux_messages_usager' => 0,
+            'injonctions_nouveaux_messages_bailleur' => 0,
         ];
         $expectedInterconnexion = ['hasErrorsLastDay' => false];
 
@@ -57,6 +59,13 @@ class DossiersDernierActionTabBodyLoaderTest extends KernelTestCase
             ->method('countInjonctions')
             ->with($tabQueryParameters)
             ->willReturn($expectedKpi['injonctions']);
+        $tabDataManager->expects($this->exactly(2))
+            ->method('countInjonctionsNouveauxMessages')
+            ->willReturnCallback(static fn ($_params, string $type) => match ($type) {
+                'usager' => $expectedKpi['injonctions_nouveaux_messages_usager'],
+                'bailleur' => $expectedKpi['injonctions_nouveaux_messages_bailleur'],
+                default => '',
+            });
         $tabDataManager->expects($this->once())
             ->method('countUsersPendingToArchive')
             ->with($tabQueryParameters)
@@ -114,6 +123,9 @@ class DossiersDernierActionTabBodyLoaderTest extends KernelTestCase
             ->method('getDernierActionDossiers')
             ->with($tabQueryParameters)
             ->willReturn($expectedData);
+
+        $tabDataManager->expects($this->never())
+            ->method('countInjonctionsNouveauxMessages');
 
         $loader = new DossiersDernierActionTabBodyLoader($security, $tabDataManager, $this->clubEventService);
         $tabBody = new TabBody(

--- a/tests/Unit/Service/DashboardTabPanel/TabDataManagerTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/TabDataManagerTest.php
@@ -162,6 +162,19 @@ class TabDataManagerTest extends WebTestCase
         $this->assertSame(5, $result);
     }
 
+    public function testCountInjonctionsNouveauxMessages(): void
+    {
+        /** @var MockObject&User $user */
+        $user = $this->createMock(User::class);
+        $this->security->method('getUser')->willReturn($user);
+        $this->kpiQuery->method('countInjonctionsNouveauxMessages')->willReturn(5);
+
+        $tabDataManager = $this->getTabDataManager();
+
+        $result = $tabDataManager->countInjonctionsNouveauxMessages();
+        $this->assertSame(5, $result);
+    }
+
     public function testCountUsersPendingToArchiveReturnsCount(): void
     {
         /** @var MockObject&User $user */


### PR DESCRIPTION
## Ticket

#5920   

## Description
Ajout de 2 tuiles pour les SA dans le dashboard, un pour les nouveaux messages usager sur les signalements en injonction, et un pour les nouveaux messages bailleur sur les signalements en injonction.
Ajout d'un filtre pour les SA dans la liste des signalements en injonction

## Changements apportés
* Ajout des 2 tuiles pour les SA sur le premier onglet du dashbaord
* Ajout d'une condition dans `findInjonctionFilteredPaginated`
* Ajout d'une fonction `countInjonctionsNouveauxMessages` dans `KpiQuery`
* Ajout du filtre message pour les SA dans la liste des signalements (avec le formType )
* Ajout de tests

## Pré-requis

## Tests
- [ ] Se connecter en RT et en agent, le dashboard n'a pas changé, ni la liste des signalements en injonction, pas de régression
- [ ] Sur un signalement en injonction, mettre un message usager, sur un autre signalement en injonction, mettre un message bailleur
- [ ] Se connecter en SA, vérifier l'affichage des 2 tuiles sur le tableau de bord, vérifier que les liens amènent bien vers la liste des signalements en injonction filtrée
- [ ] Jouer avec les filtres sur la liste des signalement
- [ ] Ouvrir un des signalement concernés, vérifier qu'il n'apparait plus ensuite dans la tuile sur le dashboard, ni dans la liste en filtrant par nouveau message
