### PR TITLE
[Désordres] Ajout de la qualification Insalubrité quand pas d'eau chaude dans le logement

### DIFF
--- a/migrations/Version20260605134053.php
+++ b/migrations/Version20260605134053.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260605134053 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add insalubrite to desordre precisions manque eau chaude';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE desordre_precision SET is_insalubrite = 1, qualification = :qualification WHERE desordre_precision_slug = :slug', [
+            'qualification' => json_encode(['RSD', 'NON_DECENCE', 'INSALUBRITE']),
+            'slug' => 'desordres_logement_eau_eau_chaude',
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE desordre_precision SET is_insalubrite = 0, qualification = :qualification WHERE desordre_precision_slug = :slug', [
+            'qualification' => json_encode(['RSD', 'NON_DECENCE']),
+            'slug' => 'desordres_logement_eau_eau_chaude',
+        ]);
+    }
+}

--- a/src/DataFixtures/Files/DesordrePrecision.yml
+++ b/src/DataFixtures/Files/DesordrePrecision.yml
@@ -476,9 +476,10 @@ desordre_precision:
     coef: 2
     is_danger: 0
     label: ""
-    qualification: ['NON_DECENCE', 'RSD']
+    qualification: ['NON_DECENCE', 'RSD', 'INSALUBRITE']
     desordre_precision_slug: "desordres_logement_eau_eau_chaude"
     is_suroccupation: 0
+    is_insalubrite: 1
   -
     desordre_critere_slug: "desordres_logement_aeration_aucune_aeration" 
     coef: 6


### PR DESCRIPTION
## Ticket

#5908   

## Description
Ajout de la qualification Insalubrité quand pas d'eau chaude dans le logement

## Changements apportés
* Migration
* Modification fixtures 

## Pré-requis
`make execute-migration name=Version20260605134053 direction=up`

## Tests
- [ ] Vérifier qu'un nouveau signalement avec `Pas d'eau chaude` dans le `Logement` soit bien qualifié en `Insalubrité`
