### PR TITLE
[QA - Erreur de mail] Trouver une solution pour mieux traquer les erreurs d'envoi Brevo

### DIFF
--- a/migrations/Version20260609120000.php
+++ b/migrations/Version20260609120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260609120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove email_delivery_issue records caused by disabled Brevo templates (not a recipient issue)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM email_delivery_issue WHERE reason = 'template is disabled'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->warnIf(true, 'Cannot restore deleted email_delivery_issue records.');
+    }
+}

--- a/src/Controller/Webhook/BrevoWebhookController.php
+++ b/src/Controller/Webhook/BrevoWebhookController.php
@@ -55,26 +55,41 @@ class BrevoWebhookController extends AbstractController
 
         $isDeliveryFailure = BrevoEvent::isErrorEvent($event);
 
-        if (!$this->emailExistsInSystem($email)) {
-            \Sentry\configureScope(static function (Scope $scope) use ($email, $payload): void {
-                $scope->setTag('email_recipient', $email);
-                $scope->setExtra('brevo_payload', $payload);
-            });
+        if ($isDeliveryFailure) {
+            if ('template is disabled' === ($payload['reason'] ?? null)) {
+                \Sentry\withScope(static function (Scope $scope) use ($payload): void {
+                    $scope->setLevel(Severity::fatal());
+                    $scope->setTag('brevo_error', 'template_disabled');
+                    $scope->setExtra('template_id', $payload['template_id'] ?? 'unknown');
+                    $scope->setExtra('brevo_payload', $payload);
+                    \Sentry\captureMessage(
+                        '[BREVO] Template désactivé — template_id: '.($payload['template_id'] ?? 'unknown'),
+                        Severity::fatal()
+                    );
+                });
 
-            $severity = match ($event) {
-                BrevoEvent::BLOCKED->value => new Severity(Severity::FATAL),
-                BrevoEvent::HARD_BOUNCE, BrevoEvent::SOFT_BOUNCE, BrevoEvent::SPAM, BrevoEvent::INVALID_EMAIL, BrevoEvent::ERROR => new Severity(Severity::ERROR),
-                default => null,
-            };
-
-            if ($severity) {
-                \Sentry\captureMessage("[BREVO] Email: {$event}", $severity);
+                return new Response('OK', Response::HTTP_OK);
             }
 
-            return new Response('OK', Response::HTTP_OK);
-        }
+            if (!$this->emailExistsInSystem($email)) {
+                \Sentry\configureScope(static function (Scope $scope) use ($email, $payload): void {
+                    $scope->setTag('email_recipient', $email);
+                    $scope->setExtra('brevo_payload', $payload);
+                });
 
-        if ($isDeliveryFailure) {
+                $severity = match ($event) {
+                    BrevoEvent::BLOCKED->value => new Severity(Severity::FATAL),
+                    BrevoEvent::HARD_BOUNCE, BrevoEvent::SOFT_BOUNCE, BrevoEvent::SPAM, BrevoEvent::INVALID_EMAIL, BrevoEvent::ERROR, BrevoEvent::UNSUBSCRIBED => new Severity(Severity::ERROR),
+                    default => null,
+                };
+
+                if ($severity) {
+                    \Sentry\captureMessage("[BREVO] Email: {$event}", $severity);
+                }
+
+                return new Response('OK', Response::HTTP_OK);
+            }
+
             $emailDeliveryIssue = $emailDeliveryIssueRepository->findOneBy(['email' => $email]) ?? new EmailDeliveryIssue();
             $emailDeliveryIssue
                 ->setEmail($email)

--- a/src/Entity/Enum/BrevoEvent.php
+++ b/src/Entity/Enum/BrevoEvent.php
@@ -10,17 +10,21 @@ enum BrevoEvent: string
 {
     use EnumTrait;
 
-    case BLOCKED = 'blocked';
-    case HARD_BOUNCE = 'hard_bounce';
+    case SENT = 'sent';
+    case CLICKED = 'clicked';
+    case DEFERRED = 'deferred';
+    case DELIVERED = 'delivered';
     case SOFT_BOUNCE = 'soft_bounce';
     case SPAM = 'spam';
-    case INVALID_EMAIL = 'invalid_email';
-    case ERROR = 'error';
-    case DELIVERED = 'delivered';
-    case OPENED = 'opened';
-    case CLICKED = 'clicked';
     case FIRST_OPENED = 'unique_opened';
-    case SENT = 'sent';
+    case HARD_BOUNCE = 'hard_bounce';
+    case OPENED = 'opened';
+    case INVALID_EMAIL = 'invalid_email';
+    case BLOCKED = 'blocked';
+    case ERROR = 'error';
+    case UNSUBSCRIBED = 'unsubscribed';
+    case PROXY_OPEN = 'proxy_open';
+    case UNIQUE_PROXY_OPEN = 'unique_proxy_open';
 
     /**
      * @return string[]
@@ -32,6 +36,8 @@ enum BrevoEvent: string
             self::OPENED->value,
             self::CLICKED->value,
             self::FIRST_OPENED->value,
+            self::PROXY_OPEN->value,
+            self::UNIQUE_PROXY_OPEN->value,
         ];
     }
 
@@ -47,6 +53,7 @@ enum BrevoEvent: string
             self::SPAM->value,
             self::INVALID_EMAIL->value,
             self::ERROR->value,
+            self::UNSUBSCRIBED->value,
         ];
     }
 

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -8,7 +8,6 @@ use App\Manager\FailedEmailManager;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
 use Psr\Log\LoggerInterface;
-use Sentry\Severity;
 use Sentry\State\Scope;
 use Symfony\Bridge\Twig\Mime\NotificationEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -139,26 +138,10 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
 
             return true;
         } catch (\Throwable $exception) {
-            if ($this->isBrevoTemplateDisabledError($exception)) {
-                \Sentry\withScope(function (Scope $scope) use ($exception): void {
-                    $scope->setLevel(Severity::fatal());
-                    $scope->setTag('brevo_error', 'template_disabled');
-                    $scope->setTag('brevo_template_id', (string) $this->brevoTemplateId);
-                    $scope->setTag('mailer_type', $this->mailerType->name);
-                    \Sentry\captureException($exception);
-                });
-            }
             $this->logAndSaveFailedEmail($message, $notificationMail, $exception, $params);
         }
 
         return false;
-    }
-
-    private function isBrevoTemplateDisabledError(\Throwable $exception): bool
-    {
-        $message = strtolower($exception->getMessage());
-
-        return str_contains($message, 'template') && str_contains($message, 'disabled');
     }
 
     /**

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -8,6 +8,7 @@ use App\Manager\FailedEmailManager;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
 use Psr\Log\LoggerInterface;
+use Sentry\Severity;
 use Sentry\State\Scope;
 use Symfony\Bridge\Twig\Mime\NotificationEmail;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -138,10 +139,26 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
 
             return true;
         } catch (\Throwable $exception) {
+            if ($this->isBrevoTemplateDisabledError($exception)) {
+                \Sentry\withScope(function (Scope $scope) use ($exception): void {
+                    $scope->setLevel(Severity::fatal());
+                    $scope->setTag('brevo_error', 'template_disabled');
+                    $scope->setTag('brevo_template_id', (string) $this->brevoTemplateId);
+                    $scope->setTag('mailer_type', $this->mailerType->name);
+                    \Sentry\captureException($exception);
+                });
+            }
             $this->logAndSaveFailedEmail($message, $notificationMail, $exception, $params);
         }
 
         return false;
+    }
+
+    private function isBrevoTemplateDisabledError(\Throwable $exception): bool
+    {
+        $message = strtolower($exception->getMessage());
+
+        return str_contains($message, 'template') && str_contains($message, 'disabled');
     }
 
     /**

--- a/tests/Functional/Controller/Webhook/BrevoWebhookControllerTest.php
+++ b/tests/Functional/Controller/Webhook/BrevoWebhookControllerTest.php
@@ -7,12 +7,16 @@ use App\Entity\User;
 use App\Repository\EmailDeliveryIssueRepository;
 use App\Utils\Sanitizer;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Sentry\SentrySdk;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 class BrevoWebhookControllerTest extends WebTestCase
 {
     private ?string $originalBrevoAllowedIps = null;
+    private ?HubInterface $originalSentryHub = null;
 
     protected function setUp(): void
     {
@@ -27,6 +31,11 @@ class BrevoWebhookControllerTest extends WebTestCase
 
     protected function tearDown(): void
     {
+        if (null !== $this->originalSentryHub) {
+            SentrySdk::setCurrentHub($this->originalSentryHub);
+            $this->originalSentryHub = null;
+        }
+
         if (null !== $this->originalBrevoAllowedIps) {
             putenv('BREVO_ALLOWED_IPS='.$this->originalBrevoAllowedIps);
             $_ENV['BREVO_ALLOWED_IPS'] = $this->originalBrevoAllowedIps;
@@ -183,6 +192,69 @@ class BrevoWebhookControllerTest extends WebTestCase
             'expectDeliveryIssue' => false,
             'expectedPayload' => null,
         ];
+    }
+
+    public function testHandleWebhookTemplateDisabledCapturesSentryFatal(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+        $container = static::getContainer();
+
+        $this->originalSentryHub = SentrySdk::getCurrentHub();
+        $mockHub = $this->createMock(HubInterface::class);
+        $mockHub->method('withScope')->willReturnCallback(static function (callable $callback): void {
+            $callback(new Scope());
+        });
+        $mockHub->expects($this->once())->method('captureMessage');
+        SentrySdk::setCurrentHub($mockHub);
+
+        $payload = [
+            'event' => 'error',
+            'email' => 'baptiste@yopmail.com',
+            'reason' => 'template is disabled',
+            'template_id' => 287,
+        ];
+
+        $client->request(
+            'POST',
+            '/webhook/brevo',
+            [],
+            [],
+            ['REMOTE_ADDR' => '127.0.0.1', 'CONTENT_TYPE' => 'application/json'],
+            (string) json_encode($payload)
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $issue = $container->get(EmailDeliveryIssueRepository::class)->findOneBy(['email' => 'baptiste@yopmail.com']);
+        $this->assertNull($issue);
+    }
+
+    public function testHandleWebhookOtherErrorDoesNotCaptureSentry(): void
+    {
+        self::ensureKernelShutdown();
+        $client = static::createClient();
+
+        $this->originalSentryHub = SentrySdk::getCurrentHub();
+        $mockHub = $this->createMock(HubInterface::class);
+        $mockHub->expects($this->never())->method('captureMessage');
+        SentrySdk::setCurrentHub($mockHub);
+
+        $client->request(
+            'POST',
+            '/webhook/brevo',
+            [],
+            [],
+            ['REMOTE_ADDR' => '127.0.0.1', 'CONTENT_TYPE' => 'application/json'],
+            (string) json_encode([
+                'event' => 'error',
+                'email' => 'baptiste@yopmail.com',
+                'reason' => 'smtp error',
+                'template_id' => 287,
+            ])
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
     }
 
     public function testArchivedUsersWithSameEmailPrefixCreatesDeliveryIssue(): void

--- a/tests/Unit/Service/Mailer/AbstractNotificationMailerTest.php
+++ b/tests/Unit/Service/Mailer/AbstractNotificationMailerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Tests\Unit\Service\Mailer;
+
+use App\Manager\FailedEmailManager;
+use App\Service\Mailer\Mail\AbstractNotificationMailer;
+use App\Service\Mailer\NotificationMail;
+use App\Service\Mailer\NotificationMailerType;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sentry\SentrySdk;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class AbstractNotificationMailerTest extends TestCase
+{
+    private MailerInterface&MockObject $mailerInterface;
+    private ParameterBagInterface&MockObject $parameterBag;
+    private FailedEmailManager&MockObject $failedEmailManager;
+    private HubInterface $originalSentryHub;
+
+    protected function setUp(): void
+    {
+        $this->originalSentryHub = SentrySdk::getCurrentHub();
+        $this->mailerInterface = $this->createMock(MailerInterface::class);
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
+        $this->failedEmailManager = $this->createMock(FailedEmailManager::class);
+
+        $this->parameterBag->method('get')->willReturnMap([
+            ['mail_enable', true],
+            ['host_url', 'https://example.com'],
+            ['notifications_email', 'no-reply@example.com'],
+            ['platform_name', 'TestPlatform'],
+            ['reply_to_email', 'reply@example.com'],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        SentrySdk::setCurrentHub($this->originalSentryHub);
+        parent::tearDown();
+    }
+
+    public function testSendReturnsTrueOnSuccess(): void
+    {
+        $this->mailerInterface->expects($this->once())->method('send');
+        $this->failedEmailManager->expects($this->never())->method('create');
+
+        $result = $this->buildMailer()->send($this->buildNotificationMail());
+
+        $this->assertTrue($result);
+    }
+
+    #[DataProvider('provideTemplateDisabledMessages')]
+    public function testSendCapturesFatalSentryEventOnTemplateDisabledError(string $exceptionMessage): void
+    {
+        $mockHub = $this->buildSentryHubMock();
+        $mockHub->expects($this->once())->method('captureException');
+        SentrySdk::setCurrentHub($mockHub);
+
+        $this->mailerInterface->expects($this->once())->method('send')->willThrowException(new \RuntimeException($exceptionMessage));
+        $this->failedEmailManager->expects($this->once())->method('create');
+
+        $result = $this->buildMailer()->send($this->buildNotificationMail());
+
+        $this->assertFalse($result);
+    }
+
+    #[DataProvider('provideOtherErrorMessages')]
+    public function testSendCapturesOnError(string $exceptionMessage): void
+    {
+        $mockHub = $this->buildSentryHubMock();
+        $mockHub->expects($this->never())->method('captureException');
+        SentrySdk::setCurrentHub($mockHub);
+
+        $this->mailerInterface->expects($this->once())->method('send')->willThrowException(new \RuntimeException($exceptionMessage));
+        $this->failedEmailManager->expects($this->once())->method('create');
+
+        $result = $this->buildMailer()->send($this->buildNotificationMail());
+
+        $this->assertFalse($result);
+    }
+
+    public function testSendDoesNotSaveFailedEmailForErrorSignalementType(): void
+    {
+        $this->mailerInterface->expects($this->once())->method('send')->willThrowException(new \RuntimeException('Some error'));
+        $this->failedEmailManager->expects($this->never())->method('create');
+
+        $result = $this->buildMailer(NotificationMailerType::TYPE_ERROR_SIGNALEMENT)
+            ->send($this->buildNotificationMail(NotificationMailerType::TYPE_ERROR_SIGNALEMENT));
+
+        $this->assertFalse($result);
+    }
+
+    public static function provideTemplateDisabledMessages(): \Generator
+    {
+        yield 'Brevo API format' => ['Unable to send an email: This template is disabled (code 400).'];
+        yield 'Uppercase' => ['TEMPLATE IS DISABLED'];
+        yield 'Lowercase' => ['template is disabled'];
+        yield 'Words in different order' => ['Error: template 42 is disabled'];
+    }
+
+    public static function provideOtherErrorMessages(): \Generator
+    {
+        yield 'Invalid Request' => ['Unable to send an email: Invalid Request (code 500).'];
+        yield 'email is not valid' => ['Unable to send an email: email is not valid in to (code 400).'];
+        yield 'upstream connect error or disconnect/reset before headers' => ['Unable to send an email: upstream connect error or disconnect/reset before headers. reset reason: connection timeout (code 503).'];
+        yield 'An email must have a "To", "Cc", or "Bcc" header' => ['An email must have a "To", "Cc", or "Bcc" header.'];
+    }
+
+    private function buildMailer(NotificationMailerType $mailerType = NotificationMailerType::TYPE_CRON): AbstractNotificationMailer
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+        $mailer = new class($this->mailerInterface, $this->parameterBag, $logger, $urlGenerator, $mailerType) extends AbstractNotificationMailer {
+            protected ?string $mailerSubject = 'Test subject';
+            protected ?string $brevoTemplateId = '42';
+
+            public function __construct(
+                MailerInterface $mailer,
+                ParameterBagInterface $parameterBag,
+                LoggerInterface $logger,
+                UrlGeneratorInterface $urlGenerator,
+                NotificationMailerType $type,
+            ) {
+                parent::__construct($mailer, $parameterBag, $logger, $urlGenerator);
+                $this->mailerType = $type;
+            }
+
+            public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
+            {
+                return [];
+            }
+        };
+
+        $mailer->setFailedEmailManager($this->failedEmailManager);
+
+        return $mailer;
+    }
+
+    private function buildNotificationMail(NotificationMailerType $type = NotificationMailerType::TYPE_CRON): NotificationMail
+    {
+        return new NotificationMail(type: $type, to: 'test@example.com');
+    }
+
+    private function buildSentryHubMock(): HubInterface&MockObject
+    {
+        $mockHub = $this->createMock(HubInterface::class);
+        // withScope executes the callback so captureException inside it reaches the mock
+        $mockHub->method('withScope')->willReturnCallback(static function (callable $callback): void {
+            $callback(new Scope());
+        });
+        // configureScope is called in logAndSaveFailedEmail, execute silently
+        $mockHub->method('configureScope')->willReturnCallback(static function (callable $callback): void {
+            $callback(new Scope());
+        });
+
+        return $mockHub;
+    }
+}

--- a/tests/Unit/Service/Mailer/AbstractNotificationMailerTest.php
+++ b/tests/Unit/Service/Mailer/AbstractNotificationMailerTest.php
@@ -11,9 +11,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Sentry\SentrySdk;
-use Sentry\State\HubInterface;
-use Sentry\State\Scope;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -24,11 +21,9 @@ class AbstractNotificationMailerTest extends TestCase
     private MailerInterface&MockObject $mailerInterface;
     private ParameterBagInterface&MockObject $parameterBag;
     private FailedEmailManager&MockObject $failedEmailManager;
-    private HubInterface $originalSentryHub;
 
     protected function setUp(): void
     {
-        $this->originalSentryHub = SentrySdk::getCurrentHub();
         $this->mailerInterface = $this->createMock(MailerInterface::class);
         $this->parameterBag = $this->createMock(ParameterBagInterface::class);
         $this->failedEmailManager = $this->createMock(FailedEmailManager::class);
@@ -42,12 +37,6 @@ class AbstractNotificationMailerTest extends TestCase
         ]);
     }
 
-    protected function tearDown(): void
-    {
-        SentrySdk::setCurrentHub($this->originalSentryHub);
-        parent::tearDown();
-    }
-
     public function testSendReturnsTrueOnSuccess(): void
     {
         $this->mailerInterface->expects($this->once())->method('send');
@@ -58,28 +47,9 @@ class AbstractNotificationMailerTest extends TestCase
         $this->assertTrue($result);
     }
 
-    #[DataProvider('provideTemplateDisabledMessages')]
-    public function testSendCapturesFatalSentryEventOnTemplateDisabledError(string $exceptionMessage): void
+    #[DataProvider('provideErrorMessages')]
+    public function testSendReturnsFalseAndSavesFailedEmailOnError(string $exceptionMessage): void
     {
-        $mockHub = $this->buildSentryHubMock();
-        $mockHub->expects($this->once())->method('captureException');
-        SentrySdk::setCurrentHub($mockHub);
-
-        $this->mailerInterface->expects($this->once())->method('send')->willThrowException(new \RuntimeException($exceptionMessage));
-        $this->failedEmailManager->expects($this->once())->method('create');
-
-        $result = $this->buildMailer()->send($this->buildNotificationMail());
-
-        $this->assertFalse($result);
-    }
-
-    #[DataProvider('provideOtherErrorMessages')]
-    public function testSendCapturesOnError(string $exceptionMessage): void
-    {
-        $mockHub = $this->buildSentryHubMock();
-        $mockHub->expects($this->never())->method('captureException');
-        SentrySdk::setCurrentHub($mockHub);
-
         $this->mailerInterface->expects($this->once())->method('send')->willThrowException(new \RuntimeException($exceptionMessage));
         $this->failedEmailManager->expects($this->once())->method('create');
 
@@ -99,16 +69,9 @@ class AbstractNotificationMailerTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public static function provideTemplateDisabledMessages(): \Generator
+    public static function provideErrorMessages(): \Generator
     {
-        yield 'Brevo API format' => ['Unable to send an email: This template is disabled (code 400).'];
-        yield 'Uppercase' => ['TEMPLATE IS DISABLED'];
-        yield 'Lowercase' => ['template is disabled'];
-        yield 'Words in different order' => ['Error: template 42 is disabled'];
-    }
-
-    public static function provideOtherErrorMessages(): \Generator
-    {
+        yield 'template is disabled' => ['Unable to send an email: This template is disabled (code 400).'];
         yield 'Invalid Request' => ['Unable to send an email: Invalid Request (code 500).'];
         yield 'email is not valid' => ['Unable to send an email: email is not valid in to (code 400).'];
         yield 'upstream connect error or disconnect/reset before headers' => ['Unable to send an email: upstream connect error or disconnect/reset before headers. reset reason: connection timeout (code 503).'];
@@ -149,20 +112,5 @@ class AbstractNotificationMailerTest extends TestCase
     private function buildNotificationMail(NotificationMailerType $type = NotificationMailerType::TYPE_CRON): NotificationMail
     {
         return new NotificationMail(type: $type, to: 'test@example.com');
-    }
-
-    private function buildSentryHubMock(): HubInterface&MockObject
-    {
-        $mockHub = $this->createMock(HubInterface::class);
-        // withScope executes the callback so captureException inside it reaches the mock
-        $mockHub->method('withScope')->willReturnCallback(static function (callable $callback): void {
-            $callback(new Scope());
-        });
-        // configureScope is called in logAndSaveFailedEmail, execute silently
-        $mockHub->method('configureScope')->willReturnCallback(static function (callable $callback): void {
-            $callback(new Scope());
-        });
-
-        return $mockHub;
     }
 }


### PR DESCRIPTION
## Ticket

#5941   

## Description
Ajout d'une erreur fatale sur sentry si on reçoit une erreur "Template is disabled"
Ajout des cas manquants dans l'enum BrevoEvent

## Changements apportés
* Ajout des cas manquants dans l'enum BrevoEvent
* Ajout d'un envoi d'erreur sentry dans `AbstractNotificationMailer`
* Ajout d'une classe de test pour `AbstractNotificationMailer`

## Pré-requis
Si sur fixtures, insérer une ligne

```
INSERT INTO `email_delivery_issue` (`id`, `email`, `event`, `reason`, `payload`, `created_at`, `updated_at`) VALUES (NULL, 'test@yopmail.fr', 'error', 'template is disabled', '{\r\n \"id\": 1444470,\r\n \"ts\": 1778836570,\r\n \"tag\": \"\",\r\n \"date\": \"2026-05-15 11:16:10\",\r\n \"uuid\": \"9c25007b-0762-4bcf-8597-a1f1e090d1bc\",\r\n \"email\": \"test@yopmail.fr\",\r\n \"event\": \"error\",\r\n \"reason\": \"template is disabled\",\r\n \"subject\": \"SIGNAL-LOGEMENT BOUCHES-DU-RHÔNE - ​Mettez à jour la situation concernant votre logement\",\r\n \"ts_epoch\": 1778836570493,\r\n \"ts_event\": 1778836570,\r\n \"message-id\": \"<202605150916.45672651987@smtp-relay.mailin.fr>\",\r\n \"template_id\": 287,\r\n \"sender_email\": \"\\\"signal-logement - bouches-du-rhone\\\" <notifications@signal-logement.beta.gouv.fr>\"\r\n}', '2026-05-15 11:16:10', NULL);
```
## Tests
- [ ] C/I ok
- [ ] `make execute-migration name=Version20260609120000 direction=up` vérifier la suppression des lignes
