### PR TITLE
[Tech] Mise à jour tinymce 8.6.0 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "leaflet.markercluster": "1.5.3",
         "leaflet.vectorgrid": "1.3.0",
         "libphonenumber-js": "1.12.26",
-        "tinymce": "7.9.1",
+        "tinymce": "8.6.0",
         "vue": "3.5.24",
         "vue-chartjs": "4.1.2",
         "vue-loader": "17.4.2",
@@ -14728,10 +14728,9 @@
       }
     },
     "node_modules/tinymce": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.9.1.tgz",
-      "integrity": "sha512-zaOHwmiP1EqTeLRXAvVriDb00JYnfEjWGPdKEuac7MiZJ5aiDMZ4Unc98Gmajn+PBljOmO1GKV6G0KwWn3+k8A==",
-      "license": "GPL-2.0-or-later"
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.6.0.tgz",
+      "integrity": "sha512-qODYoNL4cPIzNFpkEEQDm3DWI78I/nQXIPwUMHRN+q/LyT9Wzt7xis2Nfhk88kV6sibp6MJXPSaUDVNe02ZB/w=="
     },
     "node_modules/tldts-core": {
       "version": "6.1.86",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "leaflet.markercluster": "1.5.3",
     "leaflet.vectorgrid": "1.3.0",
     "libphonenumber-js": "1.12.26",
-    "tinymce": "7.9.1",
+    "tinymce": "8.6.0",
     "vue": "3.5.24",
     "vue-chartjs": "4.1.2",
     "vue-loader": "17.4.2",


### PR DESCRIPTION
## Ticket

#5955   

## Description
Suite à alerte de sécurité, passage à la version supérieure de tinyMCE
Remplace et supprime https://github.com/MTES-MCT/histologe/pull/5951

## Pré-requis
`make npm-ci`
`make npm-watch`

## Tests
- [ ] Vérifier le fonctionnement des champs textes riches
