### PR TITLE
[BUG - Form FO] numéro de tel réunionais

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -67,11 +67,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -158,11 +158,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -67,11 +67,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -158,11 +158,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -87,11 +87,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -87,11 +87,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -71,11 +71,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -192,11 +192,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -585,11 +585,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -71,11 +71,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -192,11 +192,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -585,11 +585,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -67,11 +67,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -159,11 +159,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -285,11 +285,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -67,11 +67,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -159,11 +159,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -285,11 +285,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -294,11 +294,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -75,11 +75,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -166,11 +166,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -294,11 +294,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -75,11 +75,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -166,11 +166,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -63,11 +63,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -154,11 +154,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -279,11 +279,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -63,11 +63,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
           "slug": "vos_coordonnees_tiers_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "message": "Veuillez renseigner votre numéro de téléphone.",
             "expression": "!formStore.data.vos_coordonnees_tiers_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.vos_coordonnees_tiers_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -154,11 +154,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_occupant_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_occupant_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",
@@ -279,11 +279,11 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false,
             "expression": "!formStore.data.coordonnees_bailleur_tel || !/[\\s\\+\\-\\.]/.test(formStore.data.coordonnees_bailleur_tel)",
-            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 702030405"
+            "expressionMessage": "Le numéro de téléphone ne doit pas contenir d'espaces, de tirets, de points ou d'indicatif international. Format attendu : 0702030405 ou 702030405"
           },
           "accessibility": {
             "name": "telephone",

--- a/assets/scripts/vue/components/signalement-form/requests.ts
+++ b/assets/scripts/vue/components/signalement-form/requests.ts
@@ -32,7 +32,7 @@ export const requests = {
       .catch(error => {
         console.error(error)
         Sentry.captureException(new Error(error))
-        functionReturn(error)
+        functionReturn(error.response?.data ?? error)
       })
   },
   doRequestPostUpload (ajaxUrl: string, data: any, functionReturn: Function, config: any) {
@@ -48,7 +48,7 @@ export const requests = {
       .catch(error => {
         console.error(error)
         Sentry.captureException(new Error('Something wrong happened with the upload.'))
-        functionReturn(error)
+        functionReturn(error.response?.data ?? error)
       })
   },
   doRequestPut (ajaxUrl: string, data: any, functionReturn: Function) {

--- a/src/Form/Type/PhoneType.php
+++ b/src/Form/Type/PhoneType.php
@@ -31,7 +31,7 @@ class PhoneType extends AbstractType
             'multiple' => true,
             'attr' => ['class' => 'phone-input'],
             'label' => 'Téléphone',
-            'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+            'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 702030405.',
             'countryCodes' => $countryCallingCodes,
         ]);
     }

--- a/src/Form/Type/PhoneType.php
+++ b/src/Form/Type/PhoneType.php
@@ -31,7 +31,7 @@ class PhoneType extends AbstractType
             'multiple' => true,
             'attr' => ['class' => 'phone-input'],
             'label' => 'Téléphone',
-            'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 702030405.',
+            'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
             'countryCodes' => $countryCallingCodes,
         ]);
     }

--- a/src/Validator/TelephoneFormatValidator.php
+++ b/src/Validator/TelephoneFormatValidator.php
@@ -34,19 +34,16 @@ class TelephoneFormatValidator extends ConstraintValidator
             // la valeur saisie correspond exactement au numéro parsé (contrôle pour éviter que des caractères indésirables soient ignorés)
             $normalizedInput = preg_replace('/[\s\-\(\)\.]+/', '', $value);
             $formattedE164 = $phoneNumberUtil->format($phoneNumberParsed, \libphonenumber\PhoneNumberFormat::E164);
+            $formattedNational = str_replace(' ', '', $phoneNumberUtil->format($phoneNumberParsed, \libphonenumber\PhoneNumberFormat::NATIONAL));
 
             // Accepter les formats: +33808080808, +330808080808, 33808080808, 0808080808
             // Rejeter: 0808080808D ou tout format avec caractères invalides
             $validFormats = [
-                $formattedE164,                           // +33808080808
-                ltrim($formattedE164, '+'),              // 33808080808
-                '0'.substr(ltrim($formattedE164, '+'), 2), // 0808080808
+                '+'.$phoneNumberParsed->getCountryCode().$formattedNational, // +330808080808
+                $formattedE164,                                              // +33808080808
+                ltrim($formattedE164, '+'),                                  // 33808080808
+                $formattedNational,                                          // 0808080808
             ];
-
-            // Ajouter le format +330808080808 si numéro français (formulaire front)
-            if (str_starts_with($formattedE164, '+33')) {
-                $validFormats[] = '+330'.substr(ltrim($formattedE164, '+'), 2);
-            }
 
             if (!in_array($normalizedInput, $validFormats, true)) {
                 $this->context->buildViolation($constraint->message)

--- a/tests/Unit/Validator/TelephoneFormatValidatorTest.php
+++ b/tests/Unit/Validator/TelephoneFormatValidatorTest.php
@@ -49,6 +49,11 @@ class TelephoneFormatValidatorTest extends ConstraintValidatorTestCase
         yield 'french format with +330 (formulaire front)' => ['+330808080808'];
         yield 'french format with + and spaces' => ['+33 8 08 08 08 08'];
 
+        // Format Ile de la Réunion
+        yield 'La Réunion with national format' => ['0692345678'];
+        yield 'La Réunion with international format' => ['+262692345678'];
+        yield 'La Réunion with country code and national format' => ['+2620692345678'];
+
         // Formats étrangers
         yield 'italian phone number' => ['+39 6 8888 1111'];
         yield 'italian phone number without spaces' => ['+3968888111'];


### PR DESCRIPTION
## Ticket

#5953

## Description
On recevait pas mal d'erreur sur les soumissions de formulaire concernant les numéro de téléphone réunionnais. En effet le format que l'on demandait était incohérent, fonctionnel uniquement pour les numéro avec l'indicatif français et quand l'erreur survenait rien n'était précisé : 
<img width="676" height="81" alt="Screenshot 2026-06-08 at 13-17-48 Signaler un problème de logement - Signal-Logement" src="https://github.com/user-attachments/assets/c06d58b8-353c-421a-bcae-e4186255d15b" />
<img width="769" height="403" alt="Capture d’écran 2026-06-08 131935" src="https://github.com/user-attachments/assets/c6235416-d6d5-4e24-9b50-f2b593387137" />

- Modification du format demandé (pour correspondre au format international et non pas "indicatif regional + format national")
- Modification du validateur (afin de généraliser l'acceptation du format "indicatif regional + format national")
- Ajout de tests unitaire sur les numéro de type île de la réunion.
- Amélioration de la gestion d'erreur dans `requests.ts ` afin que les erreur de contrainte de validation soit retourné à l'utilisateur plutot que le message d'erreur par défaut.

## Pré-requis
`make npm-watch`

## Tests
- [ ] Tester de form FO de signalement en renseignant un numéro de téléphone au format réunionnais y compris avec le zéro initial et voir qu'il n'y à pas d'erreur 
