### PR TITLE
[Matomo] Erreur CSP toujours pas de carte de chaleur sur matomo

### DIFF
--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -8,7 +8,7 @@ parameters:
       - "'self'"
       - "'unsafe-inline'"
       - "'unsafe-eval'"
-      - "https://stats.beta.gouv.fr/matomo.js"
+      - "https://stats.beta.gouv.fr"
       - "https://cdn.jsdelivr.net/gh/nelmio/NelmioApiDocBundle/public/swagger-ui/"
       - "https://cdn.jsdelivr.net/gh/nelmio/NelmioApiDocBundle/public/"
     style-src:


### PR DESCRIPTION
## Ticket

#5938   

## Description

```
{
"csp-report": {
"blocked-uri": "https://stats.beta.gouv.fr/plugins/HeatmapSessionRecording/configs.php?idsite=241&trackerid=y0t94q&url=https%3A%2F%2Fbo.signal-logement.beta.gouv.fr%2Fbo%2Fnotifications",
"column-number": 453,
"disposition": "enforce",
"document-uri": "https://bo.signal-logement.beta.gouv.fr/bo/notifications",
"effective-directive": "script-src-elem",
"line-number": 196,
"original-policy": "[Filtered]",
"referrer": "",
"source-file": "https://stats.beta.gouv.fr/matomo.js",
"status-code": 200,
"violated-directive": "script-src-elem"
}
}
```

Alerte CSP remonté sur la directive `script-src-elem `
Cette directive est absente de notre configuration, la modification est donc appliqué sur la directive` script-src` qui est sa directive de fallback

https://developer.mozilla.org/fr/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src-elem#:~:text=Oui%2C%20si%20cette%20directive%20est%20absente%2C%20l%27agent%20utilisateur%20consultera%20la%20directive%20script%2Dsrc

`stats.beta.gouv.fr` est un domaine de confiance, on peut donc autoriser tous le domaine et pas seulement le script `matomo.js `pour la directive `script-src`. Le domaine est deja autorisé pour la directive `connect-src`

## Changements apportés
* Mise à jour csp

## Pré-requis

## Tests
- [ ] CI OK
