### PR TITLE
[BO - Formulaire Pro - Accessibilité] Modification des champs radio buttons en fieldset

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -214,7 +214,9 @@ pre {
 .fr-rounded {
     border-radius: .25rem;
 }
-
+.fr-select-group--error legend {
+    color: var(--text-default-error);
+}
 legend.required::after, label.required::after {
     color: var(--text-default-error);
     content: '*';

--- a/templates/back/zone/index.html.twig
+++ b/templates/back/zone/index.html.twig
@@ -120,7 +120,7 @@
                                 <p>Vous êtes sur le point de supprimer une zone.</p>
                                 <p>Une fois la zone supprimée :</p>
                                 <ul>
-                                    <li>Elle sera retirée de tous les partenaires sur lesquels elle est positionnées</li>
+                                    <li>Elle sera retirée de tous les partenaires sur lesquels elle est positionnée</li>
                                 </ul>
                                 <form action="#" id="zone_delete_form" method="POST" data-submit-type="formData">
                                     <input type="hidden" name="search_params" value="{{ app.request.query.all|url_encode }}">

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -25,16 +25,21 @@
             {% set row_attr = row_attr|merge({'class': (row_attr.class ~ ' fr-input-group--error')|trim}) %}
         {% endif %}
     {% endif %}
-    <div{% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
-        {% if 'checkbox' in block_prefixes %}
-            {{form_widget(form, widget_attr)}}
-            {{form_label(form)}}
-        {% else %}
-            {{form_label(form)}}
-            {{form_widget(form, widget_attr)}}
-        {% endif %}
-        {{form_errors(form)}}
-    </div>
+
+    {% if 'choice' in block_prefixes and expanded %}
+        {{form_widget(form, widget_attr)}}
+    {% else %}
+        <div{% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
+            {% if 'checkbox' in block_prefixes %}
+                {{form_widget(form, widget_attr)}}
+                {{form_label(form)}}
+            {% else %}
+                {{form_label(form)}}
+                {{form_widget(form, widget_attr)}}
+            {% endif %}
+            {{form_errors(form)}}
+        </div>
+    {% endif %}
 {% endblock form_row %}
 
 {% block form_errors %}
@@ -114,7 +119,10 @@
 
 {% block choice_widget_expanded %}
     {% set display_mode = display_mode|default('inline') %}
-    <div {{ block('widget_container_attributes') }} class="fr-fieldset fr-mt-1w fr-mb-0">
+    <fieldset {{ block('widget_container_attributes') }} class="fr-fieldset fr-mt-1w fr-mb-0" aria-labelledby="{{ id }}_legend">
+    {% if label is not same as(false) %}
+        <legend id="{{ id }}_legend" class="fr-fieldset__legend fr-fieldset__legend--regular">{{ block('form_label_content') }}</legend>
+    {% endif %}
     {% for child in form %}
         {% set rich_label = child.vars.attr['data-dsfr-label'] ?? null %}
         {% set rich_hint  = child.vars.attr['data-dsfr-hint'] ?? null %}
@@ -133,7 +141,7 @@
             </div>
         </div>
     {% endfor %}
-    </div>
+    </fieldset>
 {% endblock choice_widget_expanded %}
 
 {% block choice_enum_widget_expanded %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -26,20 +26,18 @@
         {% endif %}
     {% endif %}
 
-    {% if 'choice' in block_prefixes and expanded %}
-        {{form_widget(form, widget_attr)}}
-    {% else %}
-        <div{% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
-            {% if 'checkbox' in block_prefixes %}
-                {{form_widget(form, widget_attr)}}
-                {{form_label(form)}}
-            {% else %}
-                {{form_label(form)}}
-                {{form_widget(form, widget_attr)}}
-            {% endif %}
-            {{form_errors(form)}}
-        </div>
-    {% endif %}
+    <div{% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
+        {% if 'choice' in block_prefixes and expanded %}
+            {{ form_widget(form, widget_attr) }}
+        {% elseif 'checkbox' in block_prefixes %}
+            {{form_widget(form, widget_attr)}}
+            {{form_label(form)}}
+        {% else %}
+            {{form_label(form)}}
+            {{form_widget(form, widget_attr)}}
+        {% endif %}
+        {{form_errors(form)}}
+    </div>
 {% endblock form_row %}
 
 {% block form_errors %}

--- a/templates/front/edit-signalement/coordonnees-bailleur.html.twig
+++ b/templates/front/edit-signalement/coordonnees-bailleur.html.twig
@@ -77,7 +77,7 @@
 				<legend class="fr-fieldset__legend">
 					<h4 class="fr-h6">Procédures</h4>
 				</legend>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(formCoordonneesBailleur.isProprioAverti) }}
 				</div>
 				<div class="fr-fieldset__element">

--- a/templates/front/edit-signalement/informations-generales.html.twig
+++ b/templates/front/edit-signalement/informations-generales.html.twig
@@ -47,13 +47,13 @@
 				<div class="fr-fieldset__element">
 					{{ form_row(form.autreSituationVulnerabilite) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.bail) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.etatDesLieux) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.dpe) }}
 				</div>
 				<div class="fr-fieldset__element">
@@ -67,14 +67,14 @@
 				</div>
 				{% set isBailleurOccupant = ( signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT) or (signalement.profileOccupant and signalement.profileOccupant is same as enum('App\\Entity\\Enum\\ProfileOccupant').BAILLEUR_OCCUPANT) %}
 
-				<div class="fr-fieldset__element {% if isBailleurOccupant %}fr-hidden{% endif %}">
+				<div class="fr-fieldset__element fr-mb-0 {% if isBailleurOccupant %}fr-hidden{% endif %}">
 					{{ form_row(form.payementLoyersAJour) }}
 				</div>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.anneeConstruction) }}
 				</div>
     			{% if signalement.natureLogement is same as 'appartement' %}					
-					<div class="fr-fieldset__element">
+					<div class="fr-fieldset__element fr-mb-0">
 						{{ form_row(form.autresOccupantsDesordre) }}
 					</div>
 				{% endif %}

--- a/templates/front/edit-signalement/situation-foyer.html.twig
+++ b/templates/front/edit-signalement/situation-foyer.html.twig
@@ -32,13 +32,13 @@
 				<legend class="fr-fieldset__legend">
 					<h3>Allocations</h3>
 				</legend>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.isLogementSocial) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.allocataire) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.caisseAllocation) }}
 				</div>
 				<div class="fr-fieldset__element">
@@ -53,10 +53,10 @@
 				<div class="fr-fieldset__element">
 					{{ form_row(form.montantAllocation) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.beneficiaireRSA) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.beneficiaireFSL) }}
 				</div>
 				<div class="fr-fieldset__element">
@@ -67,16 +67,16 @@
 				<legend class="fr-fieldset__legend">
 					<h3>Accompagnement</h3>
 				</legend>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.isRelogement) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.souhaiteQuitterLogement) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.preavisDepartDepose) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.accompagnementTravailleurSocial) }}
 				</div>
 				<div class="fr-fieldset__element">
@@ -88,7 +88,7 @@
 				<div class="fr-fieldset__element">
 					{{ form_row(form.accompagnementTravailleurSocialPrenomReferent) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.departApresTravaux) }}
 				</div>
 			</fieldset>

--- a/templates/front/edit-signalement/type-composition.html.twig
+++ b/templates/front/edit-signalement/type-composition.html.twig
@@ -35,43 +35,43 @@
 				<div class="fr-fieldset__element">
 					{{ form_row(form.natureAutrePrecision) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.appartementEtage) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.appartementAvecFenetres) }}
 				</div>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.superficie) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.pieceUnique) }}
 				</div>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.nbPieces) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.pieceAVivre9m) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.cuisine) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.cuisineCollective) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.salleDeBain) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.salleDeBainCollective) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.wc) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.wcCollective) }}
 				</div>
-				<div class="fr-fieldset__element">
+				<div class="fr-fieldset__element fr-mb-0">
 					{{ form_row(form.wcCuisine) }}
 				</div>
 			</fieldset>

--- a/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
+++ b/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
@@ -20,16 +20,9 @@
 			{{ form_errors(form) }}
 				<h1 class="title-blue-france">Demander l'arrêt de la procédure</h1>
 				<div class="fr-my-3w">
-					Expliquez pourquoi vous souhaitez arrêter la procédure puis envoyez votre demande à l'administration.<br>
-					<fieldset class="fr-fieldset {% if form.reason.vars.errors|length > 0 %}fr-fieldset--error{% endif %}" aria-labelledby="reason-legend">
-						<legend class="fr-fieldset__legend fr-fieldset__legend--regular" id="reason-legend">
-							{{ form_label(form.reason) }}
-						</legend>
-
-						{{ form_widget(form.reason, {display_mode: 'block-borders'}) }}
-
-						{{ form_errors(form.reason) }}
-					</fieldset>
+					Expliquez pourquoi vous souhaitez arrêter la procédure puis envoyez votre demande à l'administration.
+					
+					{{ form_widget(form.reason, {display_mode: 'block-borders'}) }}
 					
 					{{ form_row(form.details,{}) }}
 				</div>	

--- a/tests/Functional/Controller/ServiceSecoursControllerTest.php
+++ b/tests/Functional/Controller/ServiceSecoursControllerTest.php
@@ -100,7 +100,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $this->submitStep2($client, $crawler, 'oui', EtageType::RDC->value);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('label', 'Profil de l\'occupant');
+        $this->assertSelectorTextContains('legend', 'Profil de l\'occupant');
     }
 
     public function testSubmitToStep4(): void
@@ -113,7 +113,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $this->submitStep3($client, $crawler);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('label', 'Bailleur averti');
+        $this->assertSelectorTextContains('legend', 'Bailleur averti');
     }
 
     public function testSubmitToStep5(): void
@@ -128,7 +128,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $this->submitStep4($client, $crawler);
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('label', 'Désordres');
+        $this->assertSelectorTextContains('legend', 'Désordres');
         $this->assertSelectorTextContains('button[data-upload-photos-trigger]', 'Ajouter des photos');
     }
 


### PR DESCRIPTION
## Ticket

#5967 
#5976   

## Description
Les champs de formulaire avec des radio buttons étaient englobés dans une div, et la légende était un label rattaché à rien

## Changements apportés
* Utilisation de balise de type `fieldset` pour pouvoir utiliser une balise `legend` plutôt qu'un label rattaché à rien
* Correction d'une coquille sur la modale de suppression de zone 

## Tests
- [ ] Vérifier affichage (normal + avec erreur)
