### PR TITLE
[FO - Suivi Usager] Accessibilité - Préciser les liens + Titres et hiérarchie

### DIFF
--- a/templates/front/dossier_bailleur/dossier_bailleur_cloture.html.twig
+++ b/templates/front/dossier_bailleur/dossier_bailleur_cloture.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Détails du dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Demander l'arrêt de la procédure (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/edit-signalement/adresse-logement.html.twig
+++ b/templates/front/edit-signalement/adresse-logement.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(formAdresseLogement, {'attr': {'id': 'form-usager-complete-adresse-logement'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter l'adresse du logement</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous. Un signalement complet permet une meilleure prise en charge du dossier !
 				<br>
@@ -27,7 +27,7 @@
 			{{ form_errors(formAdresseLogement) }}				
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3 class="fr-h5">Adresse du logement</h3>
+					<h2 class="fr-h5">Adresse du logement</h2>
 				</legend>
 
 				<div class="fr-fieldset__element">

--- a/templates/front/edit-signalement/adresse-logement.html.twig
+++ b/templates/front/edit-signalement/adresse-logement.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter l'adresse du logement #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter l'adresse du logement (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/edit-signalement/coordonnees-agence.html.twig
+++ b/templates/front/edit-signalement/coordonnees-agence.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter les informations de l'agence</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous. Un signalement complet permet une meilleure prise en charge du dossier !
 				<br>
@@ -27,7 +27,7 @@
 			{{ form_errors(form) }}				
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3 class="fr-h5">Coordonnées de l'agence</h3>
+					<h2 class="fr-h5">Coordonnées de l'agence</h2>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.denominationAgence) }}
@@ -50,7 +50,7 @@
 			</fieldset>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h4 class="fr-h6">Adresse postale</h4>
+					<h3 class="fr-h6">Adresse postale</h3>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.adresseCompleteAgence) }}

--- a/templates/front/edit-signalement/coordonnees-agence.html.twig
+++ b/templates/front/edit-signalement/coordonnees-agence.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter les informations de l'agence #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter les informations de l'agence (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/edit-signalement/coordonnees-bailleur.html.twig
+++ b/templates/front/edit-signalement/coordonnees-bailleur.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter les informations bailleur #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter les informations bailleur (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 
@@ -75,7 +75,7 @@
 			</fieldset>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3 class="fr-h6">Procédures</h3>
+					<h2 class="fr-h5">Procédures</h2>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(formCoordonneesBailleur.isProprioAverti) }}

--- a/templates/front/edit-signalement/coordonnees-bailleur.html.twig
+++ b/templates/front/edit-signalement/coordonnees-bailleur.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(formCoordonneesBailleur, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter les informations du bailleur</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous.
 				<br>
@@ -29,7 +29,7 @@
 			{{ form_errors(formCoordonneesBailleur) }}				
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3 class="fr-h5">Coordonnées du bailleur</h3>
+					<h2 class="fr-h5">Coordonnées du bailleur</h2>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(formCoordonneesBailleur.nomProprio) }}
@@ -49,7 +49,7 @@
 			</fieldset>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h4 class="fr-h6">Adresse postale</h4>
+					<h3 class="fr-h6">Adresse postale</h3>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(formCoordonneesBailleur.adresseCompleteProprio) }}
@@ -75,7 +75,7 @@
 			</fieldset>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h4 class="fr-h6">Procédures</h4>
+					<h3 class="fr-h6">Procédures</h3>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(formCoordonneesBailleur.isProprioAverti) }}

--- a/templates/front/edit-signalement/coordonnees-occupant.html.twig
+++ b/templates/front/edit-signalement/coordonnees-occupant.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Modifier les coordonnées de l'occupant #{{ signalement.reference }}{% endblock %}
+{% block title %}Modifier les coordonnées de l'occupant (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/edit-signalement/coordonnees-syndic.html.twig
+++ b/templates/front/edit-signalement/coordonnees-syndic.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter les informations du syndic #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter les informations du syndic (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations du syndic</h1>
+			<h1 class="title-blue-france">Compléter les coordonnées du syndic</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous. Un signalement complet permet une meilleure prise en charge du dossier !
 				<br>
@@ -26,9 +26,6 @@
 			</div>
 			{{ form_errors(form) }}
 			<fieldset class="fr-fieldset">
-				<legend class="fr-fieldset__legend">
-					<h2 class="fr-h5">Coordonnées du syndic</h2>
-				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.denominationSyndic) }}
 				</div>

--- a/templates/front/edit-signalement/coordonnees-syndic.html.twig
+++ b/templates/front/edit-signalement/coordonnees-syndic.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter les informations du syndic</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous. Un signalement complet permet une meilleure prise en charge du dossier !
 				<br>
@@ -27,7 +27,7 @@
 			{{ form_errors(form) }}
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3 class="fr-h5">Coordonnées du syndic</h3>
+					<h2 class="fr-h5">Coordonnées du syndic</h2>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.denominationSyndic) }}

--- a/templates/front/edit-signalement/informations-generales.html.twig
+++ b/templates/front/edit-signalement/informations-generales.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter les informations générales sur le logement #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter les informations générales sur le logement (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations générales</h1>
+			<h1 class="title-blue-france">Compléter les informations générales sur le logement</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous.
 				<br>
@@ -27,7 +27,6 @@
 				Les autres champs sont facultatifs, mais peuvent aider à une meilleure prise en charge du dossier.
 			</div>
 			{{ form_errors(form) }}
-			<h2>Informations générales sur le logement</h2>
 			<fieldset class="fr-fieldset">
 				<div class="fr-fieldset__element">
 					{{ form_row(form.dateEntree) }}

--- a/templates/front/edit-signalement/informations-generales.html.twig
+++ b/templates/front/edit-signalement/informations-generales.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter les informations générales</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous.
 				<br>

--- a/templates/front/edit-signalement/procedure-assurance.html.twig
+++ b/templates/front/edit-signalement/procedure-assurance.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter les informations sur l'assurance #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter les informations sur l'assurance (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/edit-signalement/situation-foyer.html.twig
+++ b/templates/front/edit-signalement/situation-foyer.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-dossier'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter la situation du foyer</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous.
 				<br>

--- a/templates/front/edit-signalement/situation-foyer.html.twig
+++ b/templates/front/edit-signalement/situation-foyer.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter la situation du foyer #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter la situation du foyer (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 
@@ -27,10 +27,9 @@
 				Les autres champs sont facultatifs, mais peuvent aider à une meilleure prise en charge du dossier.
 			</div>
 			{{ form_errors(form) }}
-			<h2>Situation du foyer</h2>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3>Allocations</h3>
+					<h2>Allocations</h2>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.isLogementSocial) }}
@@ -65,7 +64,7 @@
 			</fieldset>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h3>Accompagnement</h3>
+					<h2>Accompagnement</h2>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(form.isRelogement) }}

--- a/templates/front/edit-signalement/type-composition.html.twig
+++ b/templates/front/edit-signalement/type-composition.html.twig
@@ -18,7 +18,7 @@
 	{{ form_start(form, {'attr': {'id': 'form-usager-complete-type-composition'}}) }}
 	<div class="fr-grid-row fr-mt-3w">
 		<div class="fr-col-12">
-			<h1 class="title-blue-france">Compléter les informations</h1>
+			<h1 class="title-blue-france">Compléter le type et la composition du logement</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous.
 				<br>

--- a/templates/front/edit-signalement/type-composition.html.twig
+++ b/templates/front/edit-signalement/type-composition.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Compléter le type et la composition du logement #{{ signalement.reference }}{% endblock %}
+{% block title %}Compléter le type et la composition du logement (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 
@@ -27,7 +27,6 @@
 				Les autres champs sont facultatifs, mais peuvent aider à une meilleure prise en charge du dossier.
 			</div>
 			{{ form_errors(form) }}
-			<h2>Type et composition du logement</h2>
 			<fieldset class="fr-fieldset">
 				<div class="fr-fieldset__element">
 					{{ form_row(form.natureLogement) }}

--- a/templates/front/suivi_signalement_bailleur_cloture_procedure.html.twig
+++ b/templates/front/suivi_signalement_bailleur_cloture_procedure.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Votre dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Valider la fermeture de la démarche (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/suivi_signalement_cancel_procedure_intro.html.twig
+++ b/templates/front/suivi_signalement_cancel_procedure_intro.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Votre dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Demander l'arrêt de la procédure (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
+++ b/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Votre dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Expliquer la demande d'arrêt de la procédure (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/suivi_signalement_coordonnees_tiers.html.twig
+++ b/templates/front/suivi_signalement_coordonnees_tiers.html.twig
@@ -24,7 +24,7 @@
 		{{ form_errors(form) }}				
 		<fieldset class="fr-fieldset">
 			<legend class="fr-fieldset__legend">
-				<h3 class="fr-h5">Coordonnées du tiers</h3>
+				<h2 class="fr-h5">Coordonnées du tiers</h2>
 			</legend>
 			<div class="fr-fieldset__element">
 				{{ form_row(form.lastname) }}

--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -240,28 +240,48 @@
 
 			<ul class="fr-list fr-list--none">
 				<li>
-					<a href="{{ sites_faciles_url }}une-question/" class="fr-link" target="_blank" rel="noopener"
+					<a 
+						href="{{ sites_faciles_url }}une-question/"
+						class="fr-link"
+						target="_blank" 
+						rel="noopener external"
+						title="Signal Logement : questions fréquentes - Ouvre une nouvelle fenêtre"
 						data-matomo-clickable-event-category="Suivre mon signalement"
 						data-matomo-clickable-event-action="clickLink"
 						data-matomo-clickable-event-name="Questions fréquentes"
 						>Questions fréquentes</a>
 				</li>
 				<li>
-					<a href="{{ sites_faciles_url }}blog/entretien-logement-qui-paye-quoi/" class="fr-link" target="_blank" rel="noopener"
+					<a 
+						href="{{ sites_faciles_url }}blog/entretien-logement-qui-paye-quoi/"
+						class="fr-link"
+						target="_blank" 
+						rel="noopener external"
+						title="Signal Logement : qui paye quoi - Ouvre une nouvelle fenêtre"
 						data-matomo-clickable-event-category="Suivre mon signalement"
 						data-matomo-clickable-event-action="clickLink"
 						data-matomo-clickable-event-name="Entretien du logement, qui paye quoi ?"
 						>Entretien du logement, qui paye quoi ?</a>
 				</li>
 				<li>
-					<a href="{{ sites_faciles_url }}blog/habitat-indigne-quelles-procedures/" class="fr-link" target="_blank" rel="noopener"
+					<a
+						href="{{ sites_faciles_url }}blog/habitat-indigne-quelles-procedures/"
+						class="fr-link"
+						target="_blank" 
+						rel="noopener external"
+						title="Signal Logement : procédures de l'habitat indigne - Ouvre une nouvelle fenêtre"
 						data-matomo-clickable-event-category="Suivre mon signalement"
 						data-matomo-clickable-event-action="clickLink"
 						data-matomo-clickable-event-name="Habitat indigne : quelles procédures ?"
 						>Habitat indigne : quelles procédures ?</a>
 				</li>
 				<li>
-					<a href="{{ sites_faciles_url }}politique-de-confidentialite/" class="fr-link" target="_blank" rel="noopener"
+					<a
+						href="{{ sites_faciles_url }}politique-de-confidentialite/"
+						class="fr-link"
+						target="_blank" 
+						rel="noopener external"
+						title="Signal Logement : politique de confidentialité - Ouvre une nouvelle fenêtre"
 						data-matomo-clickable-event-category="Suivre mon signalement"
 						data-matomo-clickable-event-action="clickLink"
 						data-matomo-clickable-event-name="Politique de confidentialité"

--- a/templates/front/suivi_signalement_poursuivre_procedure_bascule.html.twig
+++ b/templates/front/suivi_signalement_poursuivre_procedure_bascule.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Votre dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Basculer en procédure administrative (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/suivi_signalement_poursuivre_procedure_validation.html.twig
+++ b/templates/front/suivi_signalement_poursuivre_procedure_validation.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Votre dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Poursuivre la procédure (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 

--- a/templates/front/suivi_signalement_tiers_cgu.html.twig
+++ b/templates/front/suivi_signalement_tiers_cgu.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Conditions générales d'utilisation (dossier #{{ signalement.reference }}){% endblock %}
+{% block title %}Conditions générales d'utilisation{% endblock %}
 
 {% block body %}
 <main class="fr-container fr-pb-5w" id="content">

--- a/templates/front/suivi_signalement_tiers_cgu.html.twig
+++ b/templates/front/suivi_signalement_tiers_cgu.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Votre dossier #{{ signalement.reference }}{% endblock %}
+{% block title %}Conditions générales d'utilisation (dossier #{{ signalement.reference }}){% endblock %}
 
 {% block body %}
 <main class="fr-container fr-pb-5w" id="content">


### PR DESCRIPTION
## Ticket

#5989
#5990

## Description
- Sur l'accueil, mettre une info sur les 4 liens des "Infos utiles" pour dire que ça ouvre une nouvelle fenêtre
- Modification des titres sur certaines pages pour avoir un titre unique (page /procedure,  page /procedure/abandon,  dossier_bailleur_cloture, basculer en procédure administrative, poursuivre la procédure, cgu)
- Sur les pages d'édition, on précise le h1 quand c'était "Compléter les informations"
- Inviter un tiers, passer le h3 en h2
- Syndic, passer le h3 en h2
- Agence, passer le h3 en h2, les h4 en h3 
- Bailleur, passer le h3 en h2, les h4 en h3 
- Adresse du logement, passer le h3 en h2 

## Changements apportés
* Changements dans les twigs

## Pré-requis

## Tests
- [ ] Tester les pages concernées
