### PR TITLE
[FO - Suivi Usager] Accessibilité - Harmoniser les boutons d'annulation et d'enregistrement + Déplacer l'encart sur le dossier

### DIFF
--- a/src/Form/CoordonneesAgenceType.php
+++ b/src/Form/CoordonneesAgenceType.php
@@ -90,7 +90,7 @@ class CoordonneesAgenceType extends AbstractType
                 'empty_data' => '',
             ])
             ->add('save', SubmitType::class, [
-                'label' => 'Envoyer',
+                'label' => 'Enregistrer',
                 'attr' => [
                     'class' => 'fr-btn--primary',
                 ],

--- a/src/Form/SignalementeEditFO/AdresseLogementType.php
+++ b/src/Form/SignalementeEditFO/AdresseLogementType.php
@@ -67,7 +67,7 @@ class AdresseLogementType extends AbstractType
             ]);
 
         $builder->add('save', SubmitType::class, [
-            'label' => 'Envoyer',
+            'label' => 'Enregistrer',
             'attr' => [
                 'class' => 'fr-btn--primary',
             ],

--- a/src/Form/SignalementeEditFO/CoordonneesAgenceType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesAgenceType.php
@@ -88,7 +88,7 @@ class CoordonneesAgenceType extends AbstractType
                 ],
             ])
             ->add('save', SubmitType::class, [
-                'label' => 'Envoyer',
+                'label' => 'Enregistrer',
                 'attr' => [
                     'class' => 'fr-btn--primary',
                 ],

--- a/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
@@ -182,7 +182,7 @@ class CoordonneesBailleurType extends AbstractType
         }
 
         $builder->add('save', SubmitType::class, [
-            'label' => 'Envoyer',
+            'label' => 'Enregistrer',
             'attr' => [
                 'class' => 'fr-btn--primary',
             ],

--- a/src/Form/SignalementeEditFO/CoordonneesOccupantType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesOccupantType.php
@@ -76,7 +76,7 @@ class CoordonneesOccupantType extends AbstractType
             'required' => false,
         ])
         ->add('save', SubmitType::class, [
-            'label' => 'Envoyer',
+            'label' => 'Enregistrer',
             'attr' => [
                 'class' => 'fr-btn--primary',
             ],

--- a/src/Form/SignalementeEditFO/CoordonneesSyndicType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesSyndicType.php
@@ -45,7 +45,7 @@ class CoordonneesSyndicType extends AbstractType
                 'required' => false,
             ])
             ->add('save', SubmitType::class, [
-                'label' => 'Envoyer',
+                'label' => 'Enregistrer',
                 'attr' => [
                     'class' => 'fr-btn--primary',
                 ],

--- a/src/Form/SignalementeEditFO/InformationsGeneralesType.php
+++ b/src/Form/SignalementeEditFO/InformationsGeneralesType.php
@@ -218,7 +218,7 @@ class InformationsGeneralesType extends AbstractType
             ]);
         }
         $builder->add('save', SubmitType::class, [
-            'label' => 'Envoyer',
+            'label' => 'Enregistrer',
             'attr' => [
                 'class' => 'fr-btn--primary',
             ],

--- a/src/Form/SignalementeEditFO/ProcedureAssuranceType.php
+++ b/src/Form/SignalementeEditFO/ProcedureAssuranceType.php
@@ -40,7 +40,7 @@ class ProcedureAssuranceType extends AbstractType
             ],
         ]);
         $builder->add('save', SubmitType::class, [
-            'label' => 'Envoyer',
+            'label' => 'Enregistrer',
             'attr' => [
                 'class' => 'fr-btn--primary',
             ],

--- a/src/Form/SignalementeEditFO/TypeCompositionType.php
+++ b/src/Form/SignalementeEditFO/TypeCompositionType.php
@@ -315,7 +315,7 @@ class TypeCompositionType extends AbstractType
             ]);
 
         $builder->add('save', SubmitType::class, [
-            'label' => 'Envoyer',
+            'label' => 'Enregistrer',
             'attr' => [
                 'class' => 'fr-btn--primary',
             ],

--- a/src/Form/SignalementeEditFO/UsagerSituationFoyerType.php
+++ b/src/Form/SignalementeEditFO/UsagerSituationFoyerType.php
@@ -302,7 +302,7 @@ class UsagerSituationFoyerType extends AbstractType
                 'data' => $departApresTravaux,
             ])
             ->add('save', SubmitType::class, [
-                'label' => 'Envoyer',
+                'label' => 'Enregistrer',
                 'attr' => [
                     'class' => 'fr-btn--primary',
                 ],

--- a/templates/front/_partials/_suivi_signalement_card_right.html.twig
+++ b/templates/front/_partials/_suivi_signalement_card_right.html.twig
@@ -1,4 +1,4 @@
-<div class="fr-hidden-sm fr-unhidden-md fr-col-md-4">
+<div class="fr-hidden fr-unhidden-md fr-col-md-4">
 	<div class="fr-mb-3w">
 		<div class="signalement-card fr-grid-row fr-grid-row--gutters">
 			<div class="fr-col-12">

--- a/templates/front/edit-signalement/adresse-logement.html.twig
+++ b/templates/front/edit-signalement/adresse-logement.html.twig
@@ -45,7 +45,7 @@
 			</fieldset>
 		</div>
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(formAdresseLogement.save) }}
 				</li>

--- a/templates/front/edit-signalement/coordonnees-agence.html.twig
+++ b/templates/front/edit-signalement/coordonnees-agence.html.twig
@@ -76,7 +76,7 @@
 			</fieldset>
 		</div>
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(form.save) }}
 				</li>

--- a/templates/front/edit-signalement/coordonnees-bailleur.html.twig
+++ b/templates/front/edit-signalement/coordonnees-bailleur.html.twig
@@ -97,7 +97,7 @@
 			</fieldset>
 		</div>		
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(formCoordonneesBailleur.save) }}
 				</li>

--- a/templates/front/edit-signalement/coordonnees-occupant.html.twig
+++ b/templates/front/edit-signalement/coordonnees-occupant.html.twig
@@ -65,7 +65,7 @@
 			</div>
 		</div>
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(form.save) }}
 				</li>

--- a/templates/front/edit-signalement/coordonnees-syndic.html.twig
+++ b/templates/front/edit-signalement/coordonnees-syndic.html.twig
@@ -46,11 +46,15 @@
 				</div>
 			</fieldset>
 		</div>
-		<div class="fr-col-6">
-			<a href="{{ path('front_suivi_signalement_dossier', {code: signalement.codeSuivi}) }}" class="fr-btn fr-btn--secondary">Annuler</a>
-		</div>
-		<div class="fr-col-6 fr-text--right">
-			{{ form_row(form.save) }}
+		<div class="fr-col-12">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+				<li>
+					{{ form_row(form.save) }}
+				</li>
+				<li>
+					<a href="{{ path('front_suivi_signalement_dossier', {code: signalement.codeSuivi}) }}" class="fr-btn fr-btn--secondary">Annuler</a>
+				</li>
+			</ul>
 		</div>
 	</div>
 	{{ form_end(form) }}

--- a/templates/front/edit-signalement/informations-generales.html.twig
+++ b/templates/front/edit-signalement/informations-generales.html.twig
@@ -81,7 +81,7 @@
 			</fieldset>
 		</div>
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(form.save) }}
 				</li>

--- a/templates/front/edit-signalement/procedure-assurance.html.twig
+++ b/templates/front/edit-signalement/procedure-assurance.html.twig
@@ -29,7 +29,7 @@
 			</div>
 		</div>
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(form.save) }}
 				</li>

--- a/templates/front/edit-signalement/situation-foyer.html.twig
+++ b/templates/front/edit-signalement/situation-foyer.html.twig
@@ -94,7 +94,7 @@
 			</fieldset>
 		</div>		
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(form.save) }}
 				</li>

--- a/templates/front/edit-signalement/type-composition.html.twig
+++ b/templates/front/edit-signalement/type-composition.html.twig
@@ -77,7 +77,7 @@
 			</fieldset>
 		</div>
 		<div class="fr-col-12">
-			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline fr-btns-group--icon-left">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
 				<li>
 					{{ form_row(form.save) }}
 				</li>

--- a/templates/front/suivi_signalement_coordonnees_tiers.html.twig
+++ b/templates/front/suivi_signalement_coordonnees_tiers.html.twig
@@ -39,6 +39,16 @@
 				{{ form_row(form.telephone) }}
 			</div>
 		</fieldset>
+		<div class="fr-col-12">
+			<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+				<li>
+					{{ form_row(form.save) }}
+				</li>
+				<li>
+					<a href="{{ path('front_suivi_signalement_dossier', {code: signalement.codeSuivi}) }}" class="fr-btn fr-btn--secondary">Annuler</a>
+				</li>
+			</ul>
+		</div>
 		{{ form_end(form) }}
 	</div>
 </main>


### PR DESCRIPTION
## Ticket

#5986
#5987

## Description
- pages d'abandon, poursuite ou bascule de procédure, faire en sorte que l'encart violet de droite reste caché sous le breakpoint sm
- harmonisation des noms et positions des boutons d'annulation et d'enregistrement (pages d'édition du dossier + page inviter un tiers)

## Changements apportés
* Changement des formTypes
* Changement des twigs

## Pré-requis

## Tests
- [ ] Tester les différentes pages
