### PR TITLE
[FO - Suivi Usager] Accessibilité - Champs de formulaire

### DIFF
--- a/src/Form/MessageUsagerType.php
+++ b/src/Form/MessageUsagerType.php
@@ -16,8 +16,9 @@ class MessageUsagerType extends AbstractType
     {
         $builder
             ->add('description', TextareaType::class, [
-                'label' => 'Votre message',
+                'label' => 'Votre message <span class="text-required">*</span>',
                 'help' => 'Dix (10) caractères minimum.',
+                'label_html' => true,
                 'attr' => [
                     'rows' => 5,
                 ],

--- a/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
@@ -54,7 +54,7 @@ class CoordonneesBailleurType extends AbstractType
                     'required' => false,
                 ])
                 ->add('prenomProprio', TextType::class, [
-                    'label' => 'Prénom',
+                    'label' => 'Prénom (facultatif)',
                     'required' => false,
                 ])
                 ->add('adresseCompleteProprio', null, [
@@ -93,15 +93,17 @@ class CoordonneesBailleurType extends AbstractType
                     ],
                 ])
                 ->add('telProprio', TextType::class, [
-                    'label' => 'Téléphone principal',
+                    'label' => 'Téléphone principal (facultatif)',
+                    'help' => 'Format attendu : 0639987654',
                     'required' => false,
                 ])
                 ->add('telProprioSecondaire', TextType::class, [
-                    'label' => 'Téléphone secondaire',
+                    'label' => 'Téléphone secondaire (facultatif)',
+                    'help' => 'Format attendu : 0639987654',
                     'required' => false,
                 ])
                 ->add('mailProprio', TextType::class, [
-                    'label' => 'Adresse e-mail',
+                    'label' => 'Adresse e-mail (facultatif)',
                     'required' => false,
                     'help' => 'Format attendu : nom@domaine.fr',
                 ])
@@ -122,7 +124,7 @@ class CoordonneesBailleurType extends AbstractType
                     ],
                 ])
                 ->add('infoProcedureBailMoyen', EnumType::class, [
-                    'label' => 'Moyen de contact utilisé pour avertir le propriétaire',
+                    'label' => 'Moyen de contact utilisé pour avertir le propriétaire (facultatif)',
                     'class' => MoyenContact::class,
                     'choice_label' => static function ($choice) {
                         return $choice->label();
@@ -133,7 +135,7 @@ class CoordonneesBailleurType extends AbstractType
                     'data' => MoyenContact::tryFromString($signalement->getInformationProcedure()?->getInfoProcedureBailMoyen()),
                 ])
                 ->add('proprioAvertiAt', DateType::class, [
-                    'label' => 'Date d\'avertissement du propriétaire',
+                    'label' => 'Date d\'avertissement du propriétaire (facultatif)',
                     'help' => 'Format attendu : MM/AAAA',
                     'required' => false,
                     'html5' => false,
@@ -141,7 +143,7 @@ class CoordonneesBailleurType extends AbstractType
                     'format' => 'MM/yyyy',
                 ])
                 ->add('infoProcedureBailReponse', TextareaType::class, [
-                    'label' => 'Réponse du propriétaire',
+                    'label' => 'Réponse du propriétaire (facultatif)',
                     'help' => 'Format attendu : 255 caractères maximum',
                     'required' => false,
                     'mapped' => false,
@@ -158,7 +160,7 @@ class CoordonneesBailleurType extends AbstractType
             if ($signalement->getIsLogementSocial()) {
                 $builder
                     ->add('infoProcedureBailNumero', TextType::class, [
-                        'label' => 'Numéro de réclamation fourni par le bailleur',
+                        'label' => 'Numéro de réclamation fourni par le bailleur (facultatif)',
                         'help' => 'Format attendu : 30 caractères maximum',
                         'required' => false,
                         'mapped' => false,
@@ -174,7 +176,9 @@ class CoordonneesBailleurType extends AbstractType
         } else {
             $builder
                 ->add('mailProprio', TextType::class, [
-                    'label' => 'Afin de fluidifier les échanges, merci de renseigner votre adresse e-mail.',
+                    'label' => 'Afin de fluidifier les échanges, merci de renseigner votre adresse e-mail. <span class="text-required">*</span>',
+                    'label_html' => true,
+                    'help' => 'Format attendu : nom@domaine.fr',
                     'constraints' => [
                         new Assert\NotBlank(),
                     ],

--- a/src/Form/SignalementeEditFO/CoordonneesOccupantType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesOccupantType.php
@@ -26,7 +26,7 @@ class CoordonneesOccupantType extends AbstractType
         $mailOccupant = $signalement->getMailOccupant();
         $builder
             ->add('civiliteOccupant', ChoiceType::class, [
-                'label' => 'Civilité',
+                'label' => 'Civilité (facultatif)',
                 'choices' => [
                     'M' => 'mr',
                     'Mme' => 'mme',
@@ -62,17 +62,20 @@ class CoordonneesOccupantType extends AbstractType
         $builder->add('mailOccupantTemp', TextType::class, [
             'label' => $labelMailOccupant,
             'label_html' => true,
+            'help' => 'Format attendu : nom@domaine.fr',
             'required' => false,
             'mapped' => false,
             'data' => $mailOccupant,
             'constraints' => $constraintsMailOccupant,
         ])
         ->add('telOccupant', null, [
-            'label' => 'Numéro de téléphone',
+            'label' => 'Numéro de téléphone (facultatif)',
+            'help' => 'Format attendu : 0639987654',
             'required' => false,
         ])
         ->add('telOccupantBis', null, [
-            'label' => 'Numéro de téléphone secondaire',
+            'label' => 'Numéro de téléphone secondaire (facultatif)',
+            'help' => 'Format attendu : 0639987654',
             'required' => false,
         ])
         ->add('save', SubmitType::class, [

--- a/src/Form/UsagerCancelProcedureType.php
+++ b/src/Form/UsagerCancelProcedureType.php
@@ -19,7 +19,8 @@ class UsagerCancelProcedureType extends AbstractType
         $builder
             ->add('reason', EnumType::class, [
                 'class' => MotifClotureUsager::class,
-                'label' => 'Pour quelle raison voulez-vous arrêter la procédure ?',
+                'label' => 'Pour quelle raison voulez-vous arrêter la procédure ? <span class="text-required">*</span>',
+                'label_html' => true,
                 'expanded' => true,
                 'multiple' => false,
                 'required' => false,
@@ -32,7 +33,8 @@ class UsagerCancelProcedureType extends AbstractType
                 ],
             ])
             ->add('details', TextareaType::class, [
-                'label' => 'Veuillez détailler la raison pour laquelle vous souhaitez arrêter la procédure',
+                'label' => 'Veuillez détailler la raison pour laquelle vous souhaitez arrêter la procédure. <span class="text-required">*</span>',
+                'label_html' => true,
                 'help' => 'Dix (10) caractères minimum',
                 'required' => false,
                 'constraints' => [

--- a/src/Form/UsagerCoordonneesTiersType.php
+++ b/src/Form/UsagerCoordonneesTiersType.php
@@ -20,17 +20,20 @@ class UsagerCoordonneesTiersType extends AbstractType
     {
         $builder
             ->add('lastname', TextType::class, [
-                'label' => 'Nom de famille',
+                'label' => 'Nom de famille <span class="text-required">*</span>',
+                'label_html' => true,
                 'required' => false,
                 'attr' => ['maxlength' => 50],
             ])
             ->add('firstname', TextType::class, [
-                'label' => 'Prénom',
+                'label' => 'Prénom <span class="text-required">*</span>',
+                'label_html' => true,
                 'required' => false,
                 'attr' => ['maxlength' => 50],
             ])
             ->add('email', TextType::class, [
-                'label' => 'Adresse e-mail',
+                'label' => 'Adresse e-mail <span class="text-required">*</span>',
+                'label_html' => true,
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
             ])

--- a/templates/front/edit-signalement/coordonnees-bailleur.html.twig
+++ b/templates/front/edit-signalement/coordonnees-bailleur.html.twig
@@ -49,7 +49,7 @@
 			</fieldset>
 			<fieldset class="fr-fieldset">
 				<legend class="fr-fieldset__legend">
-					<h4 class="fr-h6">Adresse postale</h4>
+					<h4 class="fr-h6">Adresse postale (facultatif)</h4>
 				</legend>
 				<div class="fr-fieldset__element">
 					{{ form_row(formCoordonneesBailleur.adresseCompleteProprio) }}

--- a/templates/front/edit-signalement/procedure-assurance.html.twig
+++ b/templates/front/edit-signalement/procedure-assurance.html.twig
@@ -21,6 +21,8 @@
 			<h1 class="title-blue-france">Compléter les informations sur l'assurance</h1>
 			<div class="fr-mb-3w">
 				Complétez votre dossier en remplissant les champs ci-dessous. Un signalement complet permet une meilleure prise en charge du dossier !
+				<br>
+				Aucun champ n'est obligatoire.
 			</div>
 			<div class="fr-mb-3w">
 				{{ form_errors(form) }}				

--- a/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
+++ b/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
@@ -20,7 +20,10 @@
 			{{ form_errors(form) }}
 				<h1 class="title-blue-france">Demander l'arrêt de la procédure</h1>
 				<div class="fr-my-3w">
-					Expliquez pourquoi vous souhaitez arrêter la procédure puis envoyez votre demande à l'administration.<br>
+					<div class="fr-mb-2w">
+						Expliquez pourquoi vous souhaitez arrêter la procédure puis envoyez votre demande à l'administration.<br>
+						Tous les champs sont obligatoires.
+					</div>
 					<fieldset class="fr-fieldset {% if form.reason.vars.errors|length > 0 %}fr-fieldset--error{% endif %}" aria-labelledby="reason-legend">
 						<legend class="fr-fieldset__legend fr-fieldset__legend--regular" id="reason-legend">
 							{{ form_label(form.reason) }}

--- a/templates/front/suivi_signalement_coordonnees_tiers.html.twig
+++ b/templates/front/suivi_signalement_coordonnees_tiers.html.twig
@@ -18,7 +18,9 @@
 		<h1 class="title-blue-france">Inviter un tiers</h1>
 		<div class="fr-mb-3w">
 			Saisissez les coordonnées de la personne que vous souhaitez inviter à suivre l'avancement de votre dossier.<br>
-			Tous les champs sont obligatoires, sauf mention contraire.
+			Les champs marqués d’un astérisque (<span class="text-required">*</span>) sont obligatoires.
+			<br>
+			Les autres champs sont facultatifs, mais peuvent aider à une meilleure prise en charge du dossier.
 		</div>
 		{{ form_start(form, {'attr': {'id': 'form-usager-coordonnees-tiers'}}) }}
 		{{ form_errors(form) }}				

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -28,7 +28,9 @@
 			{% if (is_granted('SIGN_USAGER_ADD_SUIVI', signalement)) %}
 				{{ form_start(formMessage, {'attr': {'id': 'form-message-usager'}}) }}
 				{{ form_errors(formMessage) }}
-				<p>Nous vous rappelons que les échanges entre les agents en charge de votre dossier et vous doivent se faire dans le respect mutuel. Nous invitons chaque partie à adopter une attitude courtoise et bienveillante.</p>
+				<p>Nous vous rappelons que les échanges entre les agents en charge de votre dossier et vous doivent se faire dans le respect mutuel. Nous invitons chaque partie à adopter une attitude courtoise et bienveillante.
+				<br>
+				Le champ "Votre message <span class="text-required">*</span>" est obligatoire.</p>
 				<div class="fr-notice fr-notice--info fr-mb-3w">
 					<div class="fr-container">
 						<div class="fr-notice__body">


### PR DESCRIPTION
## Ticket

#5991   

## Description
Ajouter le format attendu manquants sur quelques champs mails et téléphones
Harmoniser la façon d'indiquer les champs obligatoires et facultatifs

## Changements apportés
* Changement formType
* Changement twig

## Pré-requis

## Tests
- [ ] Vérifier les différents formulaires de l'espace suivi usager
