### PR TITLE
[QA] Cannot assign null to property App\Entity\SignalementQualification::$signalement

### DIFF
--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2367,12 +2367,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function removeSignalementQualification(SignalementQualification $signalementQualification): static
     {
-        if ($this->signalementQualifications->removeElement($signalementQualification)) {
-            // set the owning side to null (unless already changed)
-            if ($signalementQualification->getSignalement() === $this) {
-                $signalementQualification->setSignalement(null);
-            }
-        }
+        $this->signalementQualifications->removeElement($signalementQualification);
 
         return $this;
     }

--- a/tests/Unit/Entity/SignalementTest.php
+++ b/tests/Unit/Entity/SignalementTest.php
@@ -102,4 +102,17 @@ class SignalementTest extends KernelTestCase
         $signalement = $signalementRepository->findOneBy(['reference' => '2022-2']);
         $this->assertTrue($signalement->hasSuiviUsagerPostCloture());
     }
+
+    public function testRemoveSignalementQualificationDoesNotThrowTypeError(): void
+    {
+        $signalement = $this->getSignalement($this->getTerritory('Pas-de-calais', '62'));
+        $qualification = (new SignalementQualification())->setQualification(Qualification::SUROCCUPATION);
+        $signalement->addSignalementQualification($qualification);
+
+        $this->assertCount(1, $signalement->getSignalementQualifications());
+
+        $signalement->removeSignalementQualification($qualification);
+
+        $this->assertCount(0, $signalement->getSignalementQualifications());
+    }
 }


### PR DESCRIPTION
## Ticket

#5999   

## Description
Lors de l'édition d'un signalement, si cela mettait à jour les qualifications (par exemple, suroccupation), cela jetait une erreur car on essayait de mettre null pour la propriété non-nullable `signalement` de la qualification

## Changements apportés
* Fix de la fonction removeSignalementQualification sur l'entité Signalement
* Ajout d'un test

## Pré-requis

## Tests
- [ ] C/I ok
