### PR TITLE
[BO - Formulaire Pro] Amélioration de la navigation au clavier

### DIFF
--- a/assets/scripts/vanilla/services/component/component_search_and_select_badges.js
+++ b/assets/scripts/vanilla/services/component/component_search_and_select_badges.js
@@ -4,7 +4,8 @@ export function initSearchAndSelectBadges() {
       element.addEventListener('click', () => {
         element.classList?.add('fr-hidden', 'disabled');
 
-        const badge = document.createElement('span');
+        const badge = document.createElement('button');
+        badge.type = 'button';
         badge.classList.add(
           'fr-badge',
           'fr-badge--blue-ecume',

--- a/assets/scripts/vanilla/services/component/component_search_checkbox.js
+++ b/assets/scripts/vanilla/services/component/component_search_checkbox.js
@@ -5,7 +5,16 @@ document.addEventListener('DOMContentLoaded', initSearchCheckboxWidgets);
 export function initSearchCheckboxWidgets() {
   const all = document.querySelectorAll('.search-checkbox-container');
   Array.from(all).forEach((element, idx) => {
+    // Vérifier si l'élément a déjà été initialisé
+    if (element.dataset.searchCheckboxInitialized === 'true') {
+      searchCheckboxCompleteInputValue(element);
+      return;
+    }
+
     try {
+      // Marquer comme initialisé
+      element.dataset.searchCheckboxInitialized = 'true';
+
       searchCheckboxCompleteInputValue(element);
       const input = element.querySelector('input[type="text"]');
       const badgesContainer = element.querySelector('.search-checkbox-badges');
@@ -38,6 +47,8 @@ export function initSearchCheckboxWidgets() {
           badgesContainer.innerHTML = '';
         }
         closeBtn.classList.remove('fr-hidden');
+        // Rendre les checkboxes accessibles au clavier
+        enableCheckboxesKeyboardAccess(checkboxesContainer);
       });
       // filter choices on input keyup
       input.addEventListener('keyup', function () {
@@ -111,6 +122,62 @@ export function initSearchCheckboxWidgets() {
       });
       closeBtn.addEventListener('click', function () {
         searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
+      });
+      // Gérer la navigation au clavier dans l'input
+      input.addEventListener('keydown', function (event) {
+        if (
+          event.key === 'Tab' &&
+          !event.shiftKey &&
+          checkboxesContainer.style.display === 'block'
+        ) {
+          // Tab depuis l'input : aller à la première checkbox visible
+          event.preventDefault();
+          const firstVisibleCheckbox = getFirstVisibleCheckbox(checkboxesContainer);
+          if (firstVisibleCheckbox) {
+            firstVisibleCheckbox.focus();
+          }
+        } else if (
+          event.key === 'Tab' &&
+          event.shiftKey &&
+          checkboxesContainer.style.display === 'block'
+        ) {
+          // Shift+Tab depuis l'input quand dropdown ouvert : laisser le comportement natif pour sortir du composant
+          searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
+        } else if (event.key === 'Escape' && checkboxesContainer.style.display === 'block') {
+          // Escape : fermer le dropdown
+          event.preventDefault();
+          searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
+          input.focus();
+        }
+      });
+
+      // Gérer la navigation au clavier sur le bouton Fermer
+      closeBtn.addEventListener('keydown', function (event) {
+        if (event.key === 'Tab' && !event.shiftKey) {
+          event.preventDefault();
+          const nextFocusable = getNextFocusableElement(closeBtn);
+          if (nextFocusable) {
+            nextFocusable.focus();
+            setTimeout(() => {
+              if (document.activeElement !== nextFocusable) {
+                nextFocusable.focus();
+              }
+              searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
+            }, 10);
+          } else {
+            searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
+          }
+        } else if (event.key === 'Tab' && event.shiftKey) {
+          event.preventDefault();
+          const visibleCheckboxes = getVisibleCheckboxes(checkboxesContainer);
+          if (visibleCheckboxes.length > 0) {
+            visibleCheckboxes[visibleCheckboxes.length - 1].focus();
+          }
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
+          input.focus();
+        }
       });
       // reorder on uncheck
       checkboxesContainer.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
@@ -209,4 +276,161 @@ function searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initi
   searchCheckboxCompleteInputValue(element);
   searchCheckboxTriggerChange(element, initialValues);
   closeBtn.classList.add('fr-hidden');
+  // Retirer l'accessibilité au clavier des checkboxes
+  disableCheckboxesKeyboardAccess(checkboxesContainer);
+}
+
+function enableCheckboxesKeyboardAccess(checkboxesContainer) {
+  const checkboxes = checkboxesContainer.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach((checkbox) => {
+    checkbox.setAttribute('tabindex', '0');
+
+    // Gérer la navigation au clavier sur chaque checkbox
+    checkbox.addEventListener('keydown', handleCheckboxKeydown);
+  });
+
+  // Rendre le bouton Fermer accessible au clavier
+  const container = checkboxesContainer.closest('.search-checkbox-container');
+  const closeBtn = container.querySelector('.fr-btn--close');
+  if (closeBtn) {
+    closeBtn.setAttribute('tabindex', '0');
+  }
+}
+
+function disableCheckboxesKeyboardAccess(checkboxesContainer) {
+  const checkboxes = checkboxesContainer.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach((checkbox) => {
+    checkbox.setAttribute('tabindex', '-1');
+    checkbox.removeEventListener('keydown', handleCheckboxKeydown);
+  });
+
+  // Retirer l'accessibilité du bouton Fermer
+  const container = checkboxesContainer.closest('.search-checkbox-container');
+  const closeBtn = container.querySelector('.fr-btn--close');
+  if (closeBtn) {
+    closeBtn.setAttribute('tabindex', '-1');
+  }
+}
+
+function handleCheckboxKeydown(event) {
+  const checkbox = event.target;
+  const checkboxesContainer = checkbox.closest('.search-checkbox');
+  const visibleCheckboxes = getVisibleCheckboxes(checkboxesContainer);
+  const currentIndex = visibleCheckboxes.indexOf(checkbox);
+
+  if (event.key === 'ArrowDown') {
+    // Aller à la checkbox suivante
+    event.preventDefault();
+    if (currentIndex < visibleCheckboxes.length - 1) {
+      visibleCheckboxes[currentIndex + 1].focus();
+    }
+  } else if (event.key === 'ArrowUp') {
+    // Aller à la checkbox précédente
+    event.preventDefault();
+    if (currentIndex > 0) {
+      visibleCheckboxes[currentIndex - 1].focus();
+    } else {
+      // Si on est sur la première checkbox, revenir à l'input
+      const container = checkboxesContainer.closest('.search-checkbox-container');
+      const input = container.querySelector('input[type="text"]');
+      if (input) {
+        input.focus();
+      }
+    }
+  } else if (event.key === 'Escape') {
+    // Fermer le dropdown et revenir à l'input
+    event.preventDefault();
+    const container = checkboxesContainer.closest('.search-checkbox-container');
+    const input = container.querySelector('input[type="text"]');
+    const closeBtn = container.querySelector('.fr-btn--close');
+    const initialValues = [];
+    checkboxesContainer.querySelectorAll('input[type="checkbox"]:checked').forEach((cb) => {
+      initialValues.push(cb.value);
+    });
+    searchCheckboxHideChoices(container, checkboxesContainer, closeBtn, initialValues);
+    if (input) {
+      input.focus();
+    }
+  } else if (event.key === 'Tab' && !event.shiftKey) {
+    // Tab depuis la dernière checkbox : aller au bouton Fermer
+    if (currentIndex === visibleCheckboxes.length - 1) {
+      event.preventDefault();
+      const container = checkboxesContainer.closest('.search-checkbox-container');
+      const closeBtn = container.querySelector('.fr-btn--close');
+      if (closeBtn) {
+        closeBtn.focus();
+      }
+    }
+  } else if (event.key === 'Tab' && event.shiftKey) {
+    // Shift+Tab depuis la première checkbox : revenir à l'input
+    if (currentIndex === 0) {
+      event.preventDefault();
+      const container = checkboxesContainer.closest('.search-checkbox-container');
+      const input = container.querySelector('input[type="text"]');
+      if (input) {
+        input.focus();
+      }
+    }
+  }
+}
+
+function getVisibleCheckboxes(checkboxesContainer) {
+  const checkboxes = Array.from(checkboxesContainer.querySelectorAll('input[type="checkbox"]'));
+  return checkboxes.filter((checkbox) => {
+    const parent = checkbox.closest('.fr-fieldset__element');
+    return parent && parent.style.display !== 'none';
+  });
+}
+
+function getFirstVisibleCheckbox(checkboxesContainer) {
+  const visibleCheckboxes = getVisibleCheckboxes(checkboxesContainer);
+  return visibleCheckboxes.length > 0 ? visibleCheckboxes[0] : null;
+}
+
+function getNextFocusableElement(currentElement) {
+  const modal = currentElement.closest('dialog.fr-modal');
+  const searchContext = modal || document;
+  const focusableSelectors =
+    'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href]';
+
+  const allFocusable = Array.from(searchContext.querySelectorAll(focusableSelectors));
+
+  const visibleFocusable = allFocusable.filter((elem) => {
+    if (elem.getAttribute('tabindex') === '-1' || elem.classList.contains('fr-hidden')) {
+      return false;
+    }
+    if (elem.type === 'checkbox' && elem.closest('.search-checkbox')) {
+      return false;
+    }
+    const searchCheckboxContainer = elem.closest('.search-checkbox');
+    if (searchCheckboxContainer && searchCheckboxContainer.style.display === 'none') {
+      return false;
+    }
+    return true;
+  });
+
+  const currentIndex = visibleFocusable.indexOf(currentElement);
+
+  if (currentIndex === -1) {
+    const container = currentElement.closest('.search-checkbox-container');
+    if (container) {
+      for (let i = 0; i < visibleFocusable.length; i++) {
+        if (
+          !container.contains(visibleFocusable[i]) &&
+          isAfterInDOM(container, visibleFocusable[i])
+        ) {
+          return visibleFocusable[i];
+        }
+      }
+    }
+  } else if (currentIndex + 1 < visibleFocusable.length) {
+    return visibleFocusable[currentIndex + 1];
+  }
+
+  return null;
+}
+
+function isAfterInDOM(elementA, elementB) {
+  const position = elementA.compareDocumentPosition(elementB);
+  return (position & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
 }

--- a/templates/back/signalement_create/tabs/tab-validation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-validation.html.twig
@@ -129,10 +129,10 @@
                 </div>
                 <div class="fr-my-3v">
                     {% for item in partners %}
-                        <span
+                        <button type="button"
                             class="fr-badge fr-m-1v search-and-select-badge-add search-and-select-badge-add-{{ item.id }}"
                             data-badge-id="{{ item.id }}" data-badge-label="{{ item.name }}"
-                            >{{ item.name }} <span class="fr-icon-add-line" aria-hidden="true"></span></span>
+                            >{{ item.name }} <span class="fr-icon-add-line" aria-hidden="true"></span></button>
                     {% endfor %}
                 </div>
             </div>

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -185,7 +185,7 @@
 {% endblock choice_enum_widget_expanded %}
 
 {% block search_checkbox_row %}
-    <div class="search-checkbox-container fr-input-group {% if errors|length > 0 %}fr-select-group--error{% endif %}" id="{{ id }}_container">   
+    <div class="search-checkbox-container fr-input-group {% if errors|length > 0 %}fr-select-group--error{% endif %}" id="{{ id }}_container">
         <div class="fr-input-group fr-mb-0">
             {% if label is not same as(false) %}
                 <label for="{{ id }}_input" class="fr-label">{{ label }} {{form_help(form)}}</label>
@@ -194,13 +194,15 @@
         </div>
         <div class="search-checkbox-badges" {% if not showSelectionAsBadges %}style="display:none"{% endif %}></div>
         <button type="button" class="fr-btn--close fr-btn fr-hidden">Fermer</button>
-        {{ block('choice_enum_widget_expanded') }}
+        <div class="search-checkbox">
+            {{ block('choice_enum_widget_expanded') }}
+        </div>
         {{ block('form_errors') }}
     </div>
 {% endblock %}
 
 {% block search_checkbox_enum_row %}
-    <div class="search-checkbox-container fr-input-group {% if errors|length > 0 %}fr-select-group--error{% endif %}" id="{{ id }}_container">   
+    <div class="search-checkbox-container fr-input-group {% if errors|length > 0 %}fr-select-group--error{% endif %}" id="{{ id }}_container">
         <div class="fr-input-group fr-mb-0">
             {% if label is not same as(false) %}
                 <label for="{{ id }}_input" class="fr-label">{{ label }} {{form_help(form)}}</label>
@@ -209,7 +211,9 @@
         </div>
         <div class="search-checkbox-badges" {% if not showSelectionAsBadges %}style="display:none"{% endif %}></div>
         <button type="button" class="fr-btn--close fr-btn fr-hidden">Fermer</button>
-        {{ block('choice_enum_widget_expanded') }}
+        <div class="search-checkbox">
+            {{ block('choice_enum_widget_expanded') }}
+        </div>
         {{ block('form_errors') }}
     </div>
 {% endblock %}


### PR DESCRIPTION
## Ticket

#5973
#5974

## Description
Amélioration de la navigation au clavier dans le formulaire pro

## Changements apportés
* Amélioration de la gestion du clavier dans les composants search-checkbox, notamment pour la gestion dans les modales
* Transformation des `span` en `button` pour les partenaires à affecter dans l'onglet Validation

## Pré-requis
`make npm-watch`

## Tests
- [ ] TNR : Vérifier les composants search-checkbox hors modale (ex : édition de document)
- [ ] Utiliser le form pro au clavier (au cas où d'autres soucis sont repérés que j'ai pu louper)
- [ ] Onglet Désordres : en utilisant uniquement le clavier : Ajouter et retirer des désordres
- [ ] Onglet Validation : en utilisant uniquement le clavier : Ajouter et retirer des partenaires à affecter au signalement
